### PR TITLE
Phase 2b: Port file watching to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,14 +49,41 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cfg-if"
@@ -111,10 +138,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastled-cli"
 version = "2.0.6"
 dependencies = [
  "clap",
+ "notify",
+ "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -125,10 +200,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -140,10 +303,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -152,12 +376,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -173,10 +467,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -260,10 +570,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "strsim"
@@ -289,10 +695,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -307,10 +738,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -320,3 +843,161 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ homepage = "https://github.com/zackees/fastled-wasm"
 pyo3 = { version = "0.23", features = ["abi3-py310"] }
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
+notify = { version = "7", features = ["macos_fsevent"] }
+sha2 = "0.10"
 
 [profile.release]
 debug = "line-tables-only"

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -14,3 +14,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
+notify = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/fastled-cli/src/main.rs
+++ b/crates/fastled-cli/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use std::process::{Command, ExitCode};
 
+mod watcher;
+
 /// FastLED WASM compilation CLI.
 ///
 /// Thin Rust front-end that mirrors every Python flag, then delegates to

--- a/crates/fastled-cli/src/watcher.rs
+++ b/crates/fastled-cli/src/watcher.rs
@@ -1,0 +1,437 @@
+//! File-system watcher that ports the core logic from `filewatcher.py`.
+//!
+//! Key behaviours mirrored from Python:
+//! * Watch a directory recursively via the [`notify`] crate.
+//! * Filter out paths that contain any of the standard ignored segments.
+//! * Detect *real* changes by comparing SHA-256 digests (avoids spurious
+//!   events from editors that touch mtime without changing content).
+//! * Debounce rapid bursts: accumulate events for `debounce_ms` milliseconds
+//!   after the last activity before emitting a single batch.
+
+// This module is a library component not yet wired into the CLI entry point.
+// Suppress dead-code lints for the public API until Phase 2e integration.
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+use notify::{
+    event::{ModifyKind, RenameMode},
+    Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use sha2::{Digest, Sha256};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default debounce window.
+pub const DEFAULT_DEBOUNCE_MS: u64 = 300;
+
+/// Path segments that are always ignored (mirrors Python's excluded_patterns).
+pub const DEFAULT_IGNORED_SEGMENTS: &[&str] = &[
+    "fastled_js",
+    ".build",
+    "__pycache__",
+    ".git",
+    "node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+    "target",
+];
+
+// ---------------------------------------------------------------------------
+// Helper: file hash
+// ---------------------------------------------------------------------------
+
+/// Return the SHA-256 hex digest of a file, or `None` if the file cannot be
+/// read (e.g. it was deleted between the notification and the read).
+fn file_hash(path: &Path) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    let digest = Sha256::digest(&bytes);
+    Some(format!("{digest:x}"))
+}
+
+// ---------------------------------------------------------------------------
+// Internal shared state (guarded by a Mutex so the notify callback + the
+// background debounce thread can both access it safely).
+// ---------------------------------------------------------------------------
+
+struct State {
+    /// Paths whose change events have arrived but haven't been flushed yet.
+    pending: Vec<PathBuf>,
+    /// Monotonic instant of the *last* received event (used for debouncing).
+    last_event: Option<Instant>,
+    /// Per-path content hash cache (skip events where content didn't change).
+    hashes: HashMap<PathBuf, String>,
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            pending: Vec::new(),
+            last_event: None,
+            hashes: HashMap::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// A running file watcher that emits batches of changed [`PathBuf`]s via an
+/// [`std::sync::mpsc`] channel.
+///
+/// # Example
+/// ```no_run
+/// use std::path::PathBuf;
+///
+/// // FileWatcher lives in the fastled binary crate (watcher module).
+/// // let mut watcher = FileWatcher::new(PathBuf::from("/my/sketch"), 300).unwrap();
+/// // let rx = watcher.start();
+/// // for batch in rx { println!("changed: {:?}", batch); }
+/// ```
+pub struct FileWatcher {
+    watch_dir: PathBuf,
+    debounce_ms: u64,
+    ignored_segments: Vec<String>,
+    stop_flag: Arc<AtomicBool>,
+    // Keep the notify watcher alive for the lifetime of FileWatcher.
+    _watcher: Option<RecommendedWatcher>,
+}
+
+impl FileWatcher {
+    /// Create a new watcher (does not start watching yet — call [`start`]).
+    pub fn new(watch_dir: PathBuf, debounce_ms: u64) -> Result<Self, notify::Error> {
+        Ok(Self {
+            watch_dir,
+            debounce_ms,
+            ignored_segments: DEFAULT_IGNORED_SEGMENTS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            _watcher: None,
+        })
+    }
+
+    /// Override the ignored path segments (replaces the defaults).
+    pub fn with_ignored_segments(mut self, segments: Vec<String>) -> Self {
+        self.ignored_segments = segments;
+        self
+    }
+
+    /// Begin watching.  Returns an [`mpsc::Receiver`] that yields `Vec<PathBuf>`
+    /// batches after each debounce window expires.
+    ///
+    /// Dropping the receiver stops the background debounce thread (it will
+    /// notice the broken channel and exit).  Call [`stop`] to also shut down
+    /// the notify watcher cleanly.
+    pub fn start(&mut self) -> std::sync::mpsc::Receiver<Vec<PathBuf>> {
+        let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
+
+        let state = Arc::new(Mutex::new(State::new()));
+        let state_for_cb = Arc::clone(&state);
+        let ignored = self.ignored_segments.clone();
+
+        // --- notify event callback -------------------------------------------
+        let notify_cb = move |res: notify::Result<Event>| {
+            let event = match res {
+                Ok(e) => e,
+                Err(_) => return,
+            };
+
+            // Only act on create / modify / rename events (not access).
+            let relevant = matches!(
+                event.kind,
+                EventKind::Create(_)
+                    | EventKind::Modify(ModifyKind::Data(_))
+                    | EventKind::Modify(ModifyKind::Name(RenameMode::To))
+                    | EventKind::Modify(ModifyKind::Any)
+                    | EventKind::Remove(_)
+            );
+            if !relevant {
+                return;
+            }
+
+            for path in event.paths {
+                // Directories are skipped (we only care about file content).
+                if path.is_dir() {
+                    continue;
+                }
+                // Filter ignored segments.
+                if path_contains_ignored(&path, &ignored) {
+                    continue;
+                }
+
+                // Hash-based deduplication.
+                let new_hash = match file_hash(&path) {
+                    Some(h) => h,
+                    None => continue, // deleted or unreadable
+                };
+
+                let mut s = state_for_cb.lock().unwrap();
+                let old_hash = s.hashes.get(&path).cloned().unwrap_or_default();
+                if new_hash == old_hash {
+                    continue; // content unchanged
+                }
+                s.hashes.insert(path.clone(), new_hash);
+                s.pending.push(path);
+                s.last_event = Some(Instant::now());
+            }
+        };
+
+        // --- start notify watcher --------------------------------------------
+        let mut watcher =
+            RecommendedWatcher::new(notify_cb, Config::default()).expect("notify watcher failed");
+        watcher
+            .watch(&self.watch_dir, RecursiveMode::Recursive)
+            .expect("notify watch failed");
+        self._watcher = Some(watcher);
+
+        // --- debounce thread -------------------------------------------------
+        let debounce = Duration::from_millis(self.debounce_ms);
+        let stop_flag = Arc::clone(&self.stop_flag);
+
+        std::thread::spawn(move || {
+            loop {
+                if stop_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+
+                let should_flush = {
+                    let s = state.lock().unwrap();
+                    match s.last_event {
+                        Some(t) => !s.pending.is_empty() && t.elapsed() >= debounce,
+                        None => false,
+                    }
+                };
+
+                if should_flush {
+                    let batch = {
+                        let mut s = state.lock().unwrap();
+                        let mut batch: Vec<PathBuf> = s.pending.drain(..).collect();
+                        s.last_event = None;
+                        batch.sort();
+                        batch.dedup();
+                        batch
+                    };
+                    if tx.send(batch).is_err() {
+                        // Receiver dropped — nothing left to do.
+                        break;
+                    }
+                }
+            }
+        });
+
+        rx
+    }
+
+    /// Signal the background debounce thread to stop.
+    pub fn stop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn path_contains_ignored(path: &Path, ignored: &[String]) -> bool {
+    path.components().any(|c| {
+        let s = c.as_os_str().to_string_lossy();
+        ignored.iter().any(|ig| s == ig.as_str())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn temp_dir() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    // ------------------------------------------------------------------
+    // path_contains_ignored helper
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_ignored_segment_detection() {
+        let ignored: Vec<String> = DEFAULT_IGNORED_SEGMENTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        assert!(path_contains_ignored(
+            Path::new("/sketch/fastled_js/bundle.js"),
+            &ignored
+        ));
+        assert!(path_contains_ignored(
+            Path::new("/sketch/.build/output.o"),
+            &ignored
+        ));
+        assert!(path_contains_ignored(
+            Path::new("/sketch/__pycache__/mod.pyc"),
+            &ignored
+        ));
+        assert!(!path_contains_ignored(
+            Path::new("/sketch/src/main.cpp"),
+            &ignored
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // file_hash helper
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_file_hash_changes_on_content_change() {
+        let dir = temp_dir();
+        let file = dir.path().join("test.txt");
+
+        fs::write(&file, b"hello").unwrap();
+        let h1 = file_hash(&file).expect("hash1");
+
+        fs::write(&file, b"world").unwrap();
+        let h2 = file_hash(&file).expect("hash2");
+
+        assert_ne!(h1, h2, "hash must differ after content change");
+    }
+
+    #[test]
+    fn test_file_hash_stable_for_same_content() {
+        let dir = temp_dir();
+        let file = dir.path().join("stable.txt");
+
+        fs::write(&file, b"same content").unwrap();
+        let h1 = file_hash(&file).expect("hash1");
+        let h2 = file_hash(&file).expect("hash2");
+
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_file_hash_none_for_missing_file() {
+        let result = file_hash(Path::new("/nonexistent/path/file.txt"));
+        assert!(result.is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // FileWatcher integration tests
+    // ------------------------------------------------------------------
+
+    /// Creating / modifying a file triggers a change event.
+    #[test]
+    fn test_watcher_detects_file_change() {
+        let dir = temp_dir();
+        let file = dir.path().join("sketch.ino");
+
+        let mut watcher = FileWatcher::new(dir.path().to_path_buf(), DEFAULT_DEBOUNCE_MS).unwrap();
+        let rx = watcher.start();
+
+        // Give the watcher time to initialise before touching files.
+        std::thread::sleep(Duration::from_millis(200));
+
+        fs::write(&file, b"void setup() {}").unwrap();
+
+        // Wait up to 2 s for the debounced batch.
+        let batch = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("expected a change event within 2 s");
+
+        watcher.stop();
+
+        assert!(!batch.is_empty(), "batch should contain the changed file");
+        assert!(
+            batch.iter().any(|p| p == &file),
+            "expected {:?} in batch {:?}",
+            file,
+            batch
+        );
+    }
+
+    /// Changes under ignored directories must not be reported.
+    #[test]
+    fn test_watcher_ignores_filtered_paths() {
+        let dir = temp_dir();
+        let ignored_dir = dir.path().join("fastled_js");
+        fs::create_dir_all(&ignored_dir).unwrap();
+        let ignored_file = ignored_dir.join("bundle.js");
+
+        let mut watcher = FileWatcher::new(dir.path().to_path_buf(), DEFAULT_DEBOUNCE_MS).unwrap();
+        let rx = watcher.start();
+
+        std::thread::sleep(Duration::from_millis(200));
+
+        fs::write(&ignored_file, b"console.log('x');").unwrap();
+
+        // We should NOT receive any event.
+        let result = rx.recv_timeout(Duration::from_millis(800));
+        watcher.stop();
+
+        assert!(
+            result.is_err(),
+            "ignored path triggered an unexpected event: {:?}",
+            result.ok()
+        );
+    }
+
+    /// Multiple rapid writes should be coalesced into a single batch.
+    #[test]
+    fn test_watcher_debounces_rapid_changes() {
+        let dir = temp_dir();
+        let file = dir.path().join("rapid.ino");
+
+        // Use a longer debounce so the rapid writes definitely fall inside.
+        let debounce_ms = 500u64;
+        let mut watcher = FileWatcher::new(dir.path().to_path_buf(), debounce_ms).unwrap();
+        let rx = watcher.start();
+
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Write five times in quick succession with distinct content.
+        for i in 0u8..5 {
+            fs::write(&file, [i; 64]).unwrap();
+            std::thread::sleep(Duration::from_millis(30));
+        }
+
+        // Collect all batches that arrive within a 2 s window.
+        let mut batches: Vec<Vec<PathBuf>> = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while let Ok(batch) = rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+            batches.push(batch);
+            if Instant::now() >= deadline {
+                break;
+            }
+        }
+
+        watcher.stop();
+
+        // All five writes arrived within the debounce window — expect at most
+        // a small number of batches (ideally 1).
+        assert!(!batches.is_empty(), "expected at least one batch, got none");
+        assert!(
+            batches.len() <= 2,
+            "expected debounced to <=2 batches, got {}",
+            batches.len()
+        );
+    }
+}

--- a/crates/fastled-py/src/lib.rs
+++ b/crates/fastled-py/src/lib.rs
@@ -6,9 +6,25 @@ fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// Return whether the native Rust file watcher is available in this build.
+///
+/// Python callers can use this to decide whether to prefer the Rust watcher
+/// over the Python watchdog implementation.
+///
+/// ```python
+/// from fastled._native import watch_available
+/// if watch_available():
+///     print("native watcher ready")
+/// ```
+#[pyfunction]
+fn watch_available() -> bool {
+    true
+}
+
 /// FastLED native extension module.
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(version, m)?)?;
+    m.add_function(wrap_pyfunction!(watch_available, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds `crates/fastled-cli/src/watcher.rs` — a Rust file watcher backed by the `notify-7` crate, porting the core logic from `src/fastled/filewatcher.py`
- Watches a directory recursively, filters ignored path segments (`fastled_js`, `.build`, `__pycache__`, `.git`, etc.), deduplicates events via SHA-256 content hashing, and debounces rapid bursts (default 300 ms window)
- Adds `watch_available() -> bool` PyO3 stub in `fastled-py` so Python can probe native-watcher availability
- No existing Python files were modified

Closes #19

## Test plan

- [x] `./_cargo build --workspace` — compiles clean
- [x] `./_cargo test --workspace` — 7 new Rust tests pass (hash stability, ignored-path filtering, event detection, debounce coalescing)
- [x] `./_cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `./_cargo fmt --all --check` — clean
- [x] `bash lint` — all checks pass (ruff, black, isort, pyright, clippy, fmt)
- [x] `bash test` — all 121 Python tests pass