### PR TITLE
feat: use cargo-binstall for pre-built Rust binary installation

### DIFF
--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -27,4 +27,9 @@ strsim = { workspace = true }
 crossterm = { workspace = true }
 tempfile = "3"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/fastled-{ target }{ archive-suffix }"
+bin-dir = "fastled{ binary-ext }"
+pkg-fmt = "zip"
+
 [dev-dependencies]

--- a/crates/fastled-tauri/Cargo.toml
+++ b/crates/fastled-tauri/Cargo.toml
@@ -12,6 +12,11 @@ description = "FastLED WASM viewer (Tauri webview)"
 name = "fastled-viewer"
 path = "src/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/fastled-viewer-{ target }{ archive-suffix }"
+bin-dir = "fastled-viewer{ binary-ext }"
+pkg-fmt = "zip"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/install
+++ b/install
@@ -54,5 +54,21 @@ if [[ -f rust-toolchain.toml ]]; then
   CHANNEL=$(grep 'channel' rust-toolchain.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
   echo "Installing Rust toolchain: $CHANNEL"
   rustup toolchain install "$CHANNEL" --profile minimal -c clippy -c rustfmt --no-self-update
-  cargo check --workspace
+fi
+
+# ── cargo-binstall: install pre-built Rust binaries ───────────────────────────
+# Install cargo-binstall if not present, then fetch pre-built CLI and viewer
+# binaries instead of compiling from source.
+
+if ! command -v cargo-binstall &> /dev/null; then
+  echo "Installing cargo-binstall..."
+  curl -L --proto '=https' --tlsv1.2 -sSf \
+    https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
+    | bash 2>/dev/null || echo "  cargo-binstall install failed (non-fatal)"
+fi
+
+if command -v cargo-binstall &> /dev/null; then
+  echo "Fetching pre-built binaries via cargo-binstall..."
+  cargo binstall fastled-cli --no-confirm 2>/dev/null || echo "  fastled-cli: no pre-built binary available (will compile from source when needed)"
+  cargo binstall fastled-tauri --no-confirm 2>/dev/null || echo "  fastled-tauri: no pre-built binary available (will compile from source when needed)"
 fi


### PR DESCRIPTION
Closes #29

## Summary
- Remove redundant `cargo check --workspace` from install script (saves 2-7 min per install)
- Install cargo-binstall from pre-built release and use it to fetch pre-built `fastled-cli` and `fastled-viewer` binaries
- Graceful fallback when crates aren't published yet (no hard failure)
- Add `[package.metadata.binstall]` config to fastled-cli and fastled-tauri Cargo.toml for future GitHub Release integration

## Test plan
- [x] Local install: verified install script completes successfully
- [x] Unit tests: all 121 Python tests + 47 Rust tests pass
- [ ] CI: verify all platforms still pass