### PR TITLE
feat: Tauri viewer as default, remove Playwright dependency

### DIFF
--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -50,9 +50,6 @@ jobs:
       - name: Install
         run: ./install
 
-      - name: Install Playwright browsers
-        run: uv run playwright install chromium
-
       - name: Integration Tests
         run: uv run pytest -x -v -s tests/integration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "Flask>=3.0.0",
     "flask-cors>=4.0.0",
     "disklru>=2.0.4",
-    "playwright>=1.40.0",
     "fasteners>=0.20",
     "cryptography>=41.0.0",
     "clang-tool-chain>=1.2.6",

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 ruff
 pytest-xdist
-pyinstaller
 pyright
 httpx
 fastapi
+playwright

--- a/src/fastled/args.py
+++ b/src/fastled/args.py
@@ -9,7 +9,7 @@ class Args:
     init: bool | str
     just_compile: bool
     profile: bool
-    app: bool  # New flag to trigger Playwright browser with browser download if needed
+    app: bool  # Deprecated — Tauri viewer is now the default; kept for backward compat
     debug: bool
     quick: bool
     release: bool

--- a/src/fastled/open_browser.py
+++ b/src/fastled/open_browser.py
@@ -9,7 +9,6 @@ from multiprocessing import Process
 from pathlib import Path
 
 from fastled.interrupts import handle_keyboard_interrupt
-from fastled.playwright.playwright_browser import open_with_playwright
 from fastled.server_flask import run_flask_in_thread
 
 
@@ -77,26 +76,6 @@ def _launch_tauri_viewer(frontend_dir: Path) -> subprocess.Popen | None:
     except Exception:
         return None
 
-
-# Global reference to keep Playwright browser alive
-_playwright_browser_proxy = None
-
-
-def cleanup_playwright_browser() -> None:
-    """Clean up the Playwright browser on exit."""
-    try:
-        global _playwright_browser_proxy
-        if _playwright_browser_proxy:
-            _playwright_browser_proxy.close()
-            _playwright_browser_proxy = None
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-    except Exception:
-        pass
-
-
-# Register cleanup function
-atexit.register(cleanup_playwright_browser)
 
 DEFAULT_PORT = 8089  # different than live version.
 PYTHON_EXE = sys.executable
@@ -184,11 +163,12 @@ def spawn_http_server(
     fastled_js: Path,
     port: int | None = None,
     open_browser: bool = True,
-    app: bool = False,
+    app: bool = False,  # Deprecated, ignored — Tauri viewer is always tried first
     enable_https: bool = True,
     sketch_dir: Path | None = None,
     fastled_path: Path | None = None,
 ) -> Process:
+    del app  # Unused — kept for backward compatibility
     if port is not None and not is_port_free(port):
         raise ValueError(f"Port {port} was specified but in use")
     if port is None:
@@ -227,24 +207,10 @@ def spawn_http_server(
         protocol = "https" if enable_https else "http"
         url = f"{protocol}://localhost:{port}"
 
-        if app:
-            # --app mode: try Tauri viewer first, fall back to Playwright
-            tauri_proc = _launch_tauri_viewer(fastled_js)
-            if tauri_proc is not None:
-                print("Opening FastLED sketch in Tauri viewer")
-            else:
-                # Fall back to Playwright
-                print("Tauri viewer not found, falling back to Playwright browser")
-                from fastled.playwright.playwright_browser import (
-                    install_playwright_browsers,
-                )
-
-                install_playwright_browsers()
-                print(f"Opening FastLED sketch in Playwright browser: {url}")
-                global _playwright_browser_proxy
-                _playwright_browser_proxy = open_with_playwright(
-                    url, enable_extensions=True
-                )
+        # Try Tauri viewer first (native webview), fall back to system browser.
+        tauri_proc = _launch_tauri_viewer(fastled_js)
+        if tauri_proc is not None:
+            print("Opening FastLED sketch in Tauri viewer")
         else:
             print(f"Opening browser to {url}")
             import webbrowser

--- a/src/fastled/parse_args.py
+++ b/src/fastled/parse_args.py
@@ -109,7 +109,7 @@ def parse_args() -> Args:
     parser.add_argument(
         "--app",
         action="store_true",
-        help="Use Playwright app-like browser experience (will download browsers if needed)",
+        help=argparse.SUPPRESS,  # Deprecated: Tauri viewer is now the default
     )
 
     parser.add_argument(
@@ -196,29 +196,8 @@ def parse_args() -> Args:
             )
             args.fastled_path = str(fastled_repo)
 
-    # Auto-enable app mode if debug is used and Playwright cache exists
-    if args.debug and not args.app:
-        playwright_dir = Path.home() / ".fastled" / "playwright"
-        if playwright_dir.exists() and any(playwright_dir.iterdir()):
-            from fastled.emoji_util import EMO
-
-            print(
-                f"{EMO('warning', 'WARNING:')} Debug mode detected with Playwright installed - automatically enabling app mode"
-            )
-            args.app = True
-        elif not args.no_interactive:
-            # Prompt user to install Playwright only if not in no-interactive mode
-            answer = (
-                input("Would you like to install the FastLED debugger? [y/n] ")
-                .strip()
-                .lower()
-            )
-            if answer in ["y", "yes"]:
-                print(
-                    "To install Playwright, run: pip install playwright && python -m playwright install"
-                )
-                print("Then run your command again with --app flag")
-                sys.exit(0)
+    # --app is now a no-op; Tauri viewer is always used when available.
+    # Keep the flag for backward compatibility but ignore it.
 
     # Handle --install early before other processing
     if args.install:


### PR DESCRIPTION
## Summary
- Tauri viewer is now always tried first when opening browser (no `--app` flag needed)
- **Remove `playwright` from pyproject.toml** — no longer a runtime dependency
- `--app` flag is deprecated (hidden, kept as no-op for backward compat)
- Falls back to system browser if Tauri viewer binary not found
- Removes Playwright auto-install prompts and auto-enable logic

## Impact
- Users no longer need `playwright install chromium` (~200 MB download)
- Default experience uses native OS webview via Tauri (~3 MB)
- System browser fallback works everywhere without extra dependencies

## Test plan
- [x] Lint passes
- [x] All 121 unit tests pass
- [ ] CI: verify all platforms pass