### PR TITLE
feat: stream compilation output to browser via SSE (#49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "zip",
  "zstd",
@@ -4680,6 +4681,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ crossterm = "0.28"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "fs", "signal"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["fs", "cors", "set-header"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 
 [profile.release]
 debug = "line-tables-only"

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -28,6 +28,7 @@ crossterm = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
+tokio-stream = { workspace = true }
 tempfile = "3"
 
 [package.metadata.binstall]

--- a/crates/fastled-cli/src/main.rs
+++ b/crates/fastled-cli/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitCode};
+use std::process::{Command, ExitCode, Stdio};
 
 mod archive;
 mod build;
@@ -25,14 +26,32 @@ fn write_build_status(output_dir: &Path, status: &str, message: &str) {
 }
 
 // ---------------------------------------------------------------------------
-// Python compile subprocess (inherits stdio for live output)
+// Streaming compile (captures output line-by-line, sends via broadcast)
 // ---------------------------------------------------------------------------
 
-/// Run `python -m fastled.app --just-compile <dir> [flags]`.
+/// Escape a string for JSON embedding.
+fn json_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+/// Send an SSE event through the broadcast channel.
+fn send_sse(tx: &tokio::sync::broadcast::Sender<String>, json: &str) {
+    let _ = tx.send(json.to_string());
+}
+
+/// Run `python -m fastled.app --just-compile` with piped stdout/stderr.
 ///
-/// Returns `true` when the compilation succeeds.  The subprocess inherits
-/// stdin/stdout/stderr so the user sees live output.
-fn run_python_compile(cli: &Cli, extra_args: &[&str]) -> bool {
+/// Each line is printed to the terminal AND sent through the broadcast
+/// channel so the loading page receives it via SSE.
+fn run_python_compile_streaming(
+    cli: &Cli,
+    extra_args: &[&str],
+    tx: &tokio::sync::broadcast::Sender<String>,
+) -> bool {
     let python = find_python();
     let mut args = vec![
         "-m".to_string(),
@@ -43,14 +62,11 @@ fn run_python_compile(cli: &Cli, extra_args: &[&str]) -> bool {
     if let Some(dir) = &cli.directory {
         args.push(dir.clone());
     }
-
-    // Build mode
     if cli.debug {
         args.push("--debug".to_string());
     } else if cli.release {
         args.push("--release".to_string());
     }
-
     if cli.profile {
         args.push("--profile".to_string());
     }
@@ -58,15 +74,63 @@ fn run_python_compile(cli: &Cli, extra_args: &[&str]) -> bool {
         args.push("--fastled-path".to_string());
         args.push(fp.clone());
     }
-
     for arg in extra_args {
         args.push(arg.to_string());
     }
 
-    match Command::new(&python).args(&args).status() {
-        Ok(s) => s.success(),
+    let mut child = match Command::new(&python)
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
         Err(e) => {
             eprintln!("fastled: failed to launch `{python} -m fastled.app`: {e}");
+            return false;
+        }
+    };
+
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+
+    let tx_out = tx.clone();
+    let stdout_thread = std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            println!("{line}");
+            send_sse(
+                &tx_out,
+                &format!(
+                    r#"{{"type":"log","line":"{}","stream":"stdout"}}"#,
+                    json_escape(&line)
+                ),
+            );
+        }
+    });
+
+    let tx_err = tx.clone();
+    let stderr_thread = std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            eprintln!("{line}");
+            send_sse(
+                &tx_err,
+                &format!(
+                    r#"{{"type":"log","line":"{}","stream":"stderr"}}"#,
+                    json_escape(&line)
+                ),
+            );
+        }
+    });
+
+    stdout_thread.join().ok();
+    stderr_thread.join().ok();
+
+    match child.wait() {
+        Ok(s) => s.success(),
+        Err(e) => {
+            eprintln!("fastled: error waiting for subprocess: {e}");
             false
         }
     }
@@ -79,8 +143,7 @@ fn run_python_compile(cli: &Cli, extra_args: &[&str]) -> bool {
 /// Compile a sketch, serve the output via the built-in HTTP server, and
 /// watch for file changes to trigger recompilation.
 ///
-/// This replaces the Python Flask server + file watcher loop with a native
-/// Rust implementation.
+/// Build output is streamed to the browser in real time via SSE.
 fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
     let sketch_dir = PathBuf::from(dir);
     if !sketch_dir.is_dir() {
@@ -97,13 +160,16 @@ fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    // Write initial compiling status for the loading page.
+    // Broadcast channel for SSE streaming to browser.
+    let (tx, _rx) = tokio::sync::broadcast::channel::<String>(256);
+
+    // Write initial compiling status for polling fallback.
     write_build_status(&output_dir, "compiling", "Compiling...");
 
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
         // Start the Rust HTTP server (background tokio task).
-        let addr = match server::start_server(output_dir.clone(), 0).await {
+        let addr = match server::start_server(output_dir.clone(), 0, Some(tx.clone())).await {
             Ok(a) => a,
             Err(e) => {
                 eprintln!("fastled: failed to start server: {e}");
@@ -116,16 +182,29 @@ fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
         open_browser(&url);
 
         // --- Initial compilation ------------------------------------------------
+        send_sse(
+            &tx,
+            r#"{"type":"status","status":"compiling","message":"Compiling..."}"#,
+        );
+
         let mut extra: Vec<&str> = Vec::new();
         if cli.purge {
             extra.push("--purge");
         }
-        let success = run_python_compile(cli, &extra);
+        let success = run_python_compile_streaming(cli, &extra, &tx);
 
         if success {
             write_build_status(&output_dir, "success", "Done");
+            send_sse(
+                &tx,
+                r#"{"type":"status","status":"success","message":"Done"}"#,
+            );
         } else {
             write_build_status(&output_dir, "error", "Compilation failed");
+            send_sse(
+                &tx,
+                r#"{"type":"status","status":"error","message":"Compilation failed"}"#,
+            );
         }
 
         // --- Watch mode ---------------------------------------------------------
@@ -157,14 +236,26 @@ fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
             if should_rebuild {
                 println!("Compiling...");
                 write_build_status(&output_dir, "compiling", "Recompiling...");
+                send_sse(
+                    &tx,
+                    r#"{"type":"status","status":"compiling","message":"Recompiling..."}"#,
+                );
 
-                let success = run_python_compile(cli, &[]);
+                let success = run_python_compile_streaming(cli, &[], &tx);
                 if success {
                     println!("Recompilation successful!");
                     write_build_status(&output_dir, "success", "Done");
+                    send_sse(
+                        &tx,
+                        r#"{"type":"status","status":"success","message":"Done"}"#,
+                    );
                 } else {
                     eprintln!("Recompilation failed.");
                     write_build_status(&output_dir, "error", "Compilation failed");
+                    send_sse(
+                        &tx,
+                        r#"{"type":"status","status":"error","message":"Compilation failed"}"#,
+                    );
                 }
             }
         }
@@ -410,7 +501,7 @@ fn serve_directory(dir: &str, cli: &Cli) -> ExitCode {
 
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
-        let addr = match server::start_server(path.clone(), 0).await {
+        let addr = match server::start_server(path.clone(), 0, None).await {
             Ok(a) => a,
             Err(e) => {
                 eprintln!("fastled: failed to start server: {e}");

--- a/crates/fastled-cli/src/server.rs
+++ b/crates/fastled-cli/src/server.rs
@@ -5,15 +5,20 @@
 //! does not exist yet (compilation in progress) a built-in loading page
 //! is returned that polls `/build-status.json` for live updates.
 
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::State;
 use axum::http::{header, HeaderValue, Method, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 
@@ -34,24 +39,52 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
              animation: spin 1s linear infinite; margin-bottom: 20px; }
   @keyframes spin { to { transform: rotate(360deg); } }
   #status { font-size: 1.2em; }
-  #log { margin-top: 20px; max-width: 80%; max-height: 40vh;
-         overflow-y: auto; font-size: 0.85em; color: #888;
-         white-space: pre-wrap; text-align: left; }
+  #log { margin-top: 20px; width: 80%; max-height: 50vh;
+         overflow-y: auto; font-size: 0.85em; color: #aaa;
+         white-space: pre-wrap; text-align: left; line-height: 1.4;
+         padding: 8px; background: #1a1a1a; border-radius: 4px; }
 </style>
 <script>
+  const logEl = document.addEventListener('DOMContentLoaded', () => {
+    const log = document.getElementById('log');
+    const status = document.getElementById('status');
+
+    function appendLog(line) {
+      log.textContent += line + '\n';
+      log.scrollTop = log.scrollHeight;
+    }
+
+    // Try SSE first, fall back to polling.
+    if (typeof EventSource !== 'undefined') {
+      const es = new EventSource('/build-stream');
+      es.onmessage = (e) => {
+        try {
+          const d = JSON.parse(e.data);
+          if (d.type === 'log') {
+            appendLog(d.line);
+          } else if (d.type === 'status') {
+            status.textContent = d.message || d.status;
+            if (d.status === 'success') { es.close(); location.reload(); }
+          }
+        } catch(err) {}
+      };
+      es.onerror = () => { es.close(); poll(); };
+    } else {
+      poll();
+    }
+  });
+
   async function poll() {
     try {
       const r = await fetch('/build-status.json');
       if (r.ok) {
         const s = await r.json();
         document.getElementById('status').textContent = s.message || 'Compiling...';
-        if (s.log) document.getElementById('log').textContent = s.log;
         if (s.status === 'success') { location.reload(); return; }
       }
     } catch(e) {}
     setTimeout(poll, 500);
   }
-  poll();
 </script>
 </head><body>
 <div class="spinner"></div>
@@ -66,6 +99,9 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
 #[derive(Clone)]
 struct AppState {
     serve_dir: Arc<PathBuf>,
+    /// Broadcast channel for SSE build streaming.  `None` when serving a
+    /// static directory (no compilation happening).
+    build_tx: Option<broadcast::Sender<String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +155,25 @@ async fn serve_file(
     }
 }
 
+/// SSE endpoint that streams build log lines and status events.
+async fn build_stream(State(state): State<AppState>) -> Response {
+    let tx = match &state.build_tx {
+        Some(tx) => tx,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let rx = tx.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|result| {
+        result
+            .ok()
+            .map(|data| Ok::<_, Infallible>(Event::default().data(data)))
+    });
+
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
 fn mime_for_path(path: &str) -> &'static str {
     match path.rsplit('.').next().unwrap_or("") {
         "html" => "text/html; charset=utf-8",
@@ -146,13 +201,19 @@ fn mime_for_path(path: &str) -> &'static str {
 ///
 /// Returns the actual address the server bound to (useful when port 0 is
 /// requested for automatic assignment).
-pub async fn start_server(serve_dir: PathBuf, port: u16) -> anyhow::Result<SocketAddr> {
+pub async fn start_server(
+    serve_dir: PathBuf,
+    port: u16,
+    build_tx: Option<broadcast::Sender<String>>,
+) -> anyhow::Result<SocketAddr> {
     let state = AppState {
         serve_dir: Arc::new(serve_dir),
+        build_tx,
     };
 
     let app = Router::new()
         .route("/", get(serve_index))
+        .route("/build-stream", get(build_stream))
         .route("/{*path}", get(serve_file))
         .layer(SetResponseHeaderLayer::overriding(
             axum::http::HeaderName::from_static("cross-origin-embedder-policy"),
@@ -202,7 +263,9 @@ mod tests {
     /// Helper: create a temp dir, start the server, return (addr, dir).
     async fn setup_server() -> (SocketAddr, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
-        let addr = start_server(dir.path().to_path_buf(), 0).await.unwrap();
+        let addr = start_server(dir.path().to_path_buf(), 0, None)
+            .await
+            .unwrap();
         // Give the server a moment to bind.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         (addr, dir)
@@ -328,5 +391,90 @@ mod tests {
             .unwrap();
         // Should not serve files outside the serve dir
         assert_ne!(resp.status(), 200);
+    }
+
+    // ------------------------------------------------------------------
+    // SSE build-stream tests
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_sse_returns_404_without_broadcast() {
+        // Server started without broadcast channel → /build-stream returns 404.
+        let (addr, _dir) = setup_server().await;
+        let resp = reqwest::get(format!("http://{addr}/build-stream"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_sse_endpoint_streams_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = broadcast::channel::<String>(16);
+        let addr = start_server(dir.path().to_path_buf(), 0, Some(tx.clone()))
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let url = format!("http://{addr}/build-stream");
+
+        // Connect to SSE endpoint.
+        let client = reqwest::Client::new();
+        let mut resp = client.get(&url).send().await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            ct.contains("text/event-stream"),
+            "expected event-stream content-type, got: {ct}"
+        );
+
+        // Give the server handler a moment to subscribe to the broadcast.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Send test events.
+        tx.send(r#"{"type":"log","line":"Building sketch...","stream":"stdout"}"#.to_string())
+            .unwrap();
+        tx.send(r#"{"type":"status","status":"success","message":"Done"}"#.to_string())
+            .unwrap();
+
+        // Read SSE chunks until we see both events (or timeout).
+        let mut collected = String::new();
+        let deadline = std::time::Duration::from_secs(3);
+        while let Ok(Ok(Some(chunk))) = tokio::time::timeout(deadline, resp.chunk()).await {
+            collected.push_str(&String::from_utf8_lossy(&chunk));
+            if collected.contains("Building sketch...") && collected.contains("success") {
+                break;
+            }
+        }
+
+        assert!(
+            collected.contains("Building sketch..."),
+            "expected log line in SSE body, got: {collected}"
+        );
+        assert!(
+            collected.contains("success"),
+            "expected status event in SSE body, got: {collected}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_loading_page_contains_eventsource() {
+        let (addr, _dir) = setup_server().await;
+        let resp = reqwest::get(format!("http://{addr}/")).await.unwrap();
+        let body = resp.text().await.unwrap();
+        assert!(
+            body.contains("EventSource"),
+            "loading page should use EventSource for SSE"
+        );
+        assert!(
+            body.contains("/build-stream"),
+            "loading page should connect to /build-stream"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Browser loading page now shows **live compilation output** in real time via Server-Sent Events (SSE)
- Each line of Python subprocess stdout/stderr is teed to both the terminal and the browser
- Loading page uses `EventSource` to subscribe to `/build-stream`, with polling fallback

## What changed

### Rust server (`server.rs`)
- New `/build-stream` SSE endpoint backed by `tokio::sync::broadcast`
- `AppState` gains optional `broadcast::Sender<String>` for SSE fan-out
- `start_server()` accepts optional broadcast sender (`None` for `--serve-dir` mode)
- Loading page rewritten: uses `EventSource` for real-time log streaming, falls back to polling

### CLI (`main.rs`)
- `compile_and_serve()` creates a broadcast channel and passes it to the server
- New `run_python_compile_streaming()` captures subprocess output via `Stdio::piped()`, reads line-by-line with `BufReader`, tees to terminal + SSE broadcast
- Status events (compiling/success/error) sent through both `build-status.json` and SSE

### Dependencies
- Added `tokio-stream` (with `sync` feature) for `BroadcastStream`

## Test plan
- [x] `cargo test -p fastled-cli` — 58 tests pass (3 new SSE tests)
- [x] `bash lint` — all checks pass
- [x] `bash test` — 119 Python tests pass
- [ ] CI passes