### PR TITLE
chore: release 2.0.7 — adopt setup-soldr@v0, fix native-playwright test

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,10 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          cache-key-suffix: build-${{ inputs.runs-on }}
+          # Include github.workflow because some callers (e.g. Windows
+          # x86/ARM) currently share the same runs-on. Without this they
+          # collide on the same cache key and one job fails to save.
+          cache-key-suffix: build-${{ inputs.runs-on }}-${{ github.workflow }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -34,15 +34,10 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain
-        run: |
-          CHANNEL=$(grep 'channel' rust-toolchain.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: zackees/setup-soldr@v0
         with:
-          shared-key: fastled-${{ inputs.runs-on }}
-          cache-targets: false
+          cache: true
+          cache-key-suffix: build-${{ inputs.runs-on }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -34,7 +34,10 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          cache-key-suffix: integration-test-${{ inputs.runs-on }}
+          # Include github.workflow because some callers (e.g. Windows
+          # x86/ARM) currently share the same runs-on. Without this they
+          # collide on the same cache key and one job fails to save.
+          cache-key-suffix: integration-test-${{ inputs.runs-on }}-${{ github.workflow }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -31,15 +31,10 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain
-        run: |
-          CHANNEL=$(grep 'channel' rust-toolchain.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: zackees/setup-soldr@v0
         with:
-          shared-key: fastled-${{ inputs.runs-on }}
-          cache-targets: false
+          cache: true
+          cache-key-suffix: integration-test-${{ inputs.runs-on }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -33,7 +33,10 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          cache-key-suffix: lint-${{ inputs.runs-on }}
+          # Include github.workflow because some callers (e.g. Windows
+          # x86/ARM) currently share the same runs-on. Without this they
+          # collide on the same cache key and one job fails to save.
+          cache-key-suffix: lint-${{ inputs.runs-on }}-${{ github.workflow }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -30,15 +30,10 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain
-        run: |
-          CHANNEL=$(grep 'channel' rust-toolchain.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: zackees/setup-soldr@v0
         with:
-          shared-key: fastled-${{ inputs.runs-on }}
-          cache-targets: false
+          cache: true
+          cache-key-suffix: lint-${{ inputs.runs-on }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -34,7 +34,10 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          cache-key-suffix: unit-test-${{ inputs.runs-on }}
+          # Include github.workflow because some callers (e.g. Windows
+          # x86/ARM) currently share the same runs-on. Without this they
+          # collide on the same cache key and one job fails to save.
+          cache-key-suffix: unit-test-${{ inputs.runs-on }}-${{ github.workflow }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -31,15 +31,10 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain
-        run: |
-          CHANNEL=$(grep 'channel' rust-toolchain.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: zackees/setup-soldr@v0
         with:
-          shared-key: fastled-${{ inputs.runs-on }}
-          cache-targets: false
+          cache: true
+          cache-key-suffix: unit-test-${{ inputs.runs-on }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -1031,14 +1031,14 @@ dependencies = [
 
 [[package]]
 name = "fastled-py"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "fastled-tauri"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/install
+++ b/install
@@ -24,15 +24,27 @@ uv pip install -r requirements.testing.txt
 
 
 # If activate exists, delete it
-if [[ -f activate ]]; then
-  rm activate
+if [[ -f activate || -L activate ]]; then
+  rm -f activate
 fi
 
-# If Windows, then symlink .venv/Scripts/activate to .venv/bin/activate
+# Create a top-level ./activate pointer for developer convenience. On
+# Windows, ln -s requires create-symlink privilege which CI runners (and
+# many dev machines) lack — current windows-2025 images fail here even for
+# git-bash. Fall back to plain copy, then to a no-op with a warning. Not
+# fatal: ./activate is only used interactively.
 if [[ "$OSTYPE" == "msys" ]]; then
-  ln -s .venv/Scripts/activate ./activate
+  ACTIVATE_SRC=".venv/Scripts/activate"
 else
-  ln -s .venv/bin/activate ./activate
+  ACTIVATE_SRC=".venv/bin/activate"
+fi
+
+if [[ -f "$ACTIVATE_SRC" ]]; then
+  ln -s "$ACTIVATE_SRC" ./activate 2>/dev/null \
+    || cp "$ACTIVATE_SRC" ./activate 2>/dev/null \
+    || echo "Warning: could not create ./activate (activate manually with: source $ACTIVATE_SRC)"
+else
+  echo "Warning: $ACTIVATE_SRC not found; skipping ./activate symlink"
 fi
 
 # ── Rust toolchain bootstrap ────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fastled"
-version = "2.0.6"
+version = "2.0.7"
 readme = "README.md"
 description = "FastLED Wasm Compiler"
 requires-python = ">=3.10"

--- a/src/fastled/__version__.py
+++ b/src/fastled/__version__.py
@@ -1,2 +1,2 @@
 # Version is read directly from this file by the GitHub Actions release workflow.
-__version__ = "2.0.6"
+__version__ = "2.0.7"

--- a/test_native_playwright.py
+++ b/test_native_playwright.py
@@ -11,6 +11,12 @@ import sys
 import time
 from pathlib import Path
 
+# Windows console defaults to cp1252, which can't encode emoji that FastLED
+# prints to console (🔧, ✅, etc.). Reconfigure stdout/stderr to UTF-8 so the
+# relevant-message dump near the end of main() doesn't UnicodeEncodeError.
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+
 FASTLED_JS = Path.home() / "dev" / "fastled7" / "examples" / "Blink" / "fastled_js"
 
 # Inline server script - runs in its own subprocess
@@ -59,8 +65,11 @@ from pathlib import Path
 port = int(sys.argv[1])
 url = f"http://localhost:{port}/"
 
+# Only redirect PLAYWRIGHT_BROWSERS_PATH if the dir actually contains a
+# Chromium install. The dir can exist with only user-data/ in it, in which
+# case Playwright searches an empty location and fails to launch.
 browsers_path = Path.home() / ".fastled" / "playwright"
-if browsers_path.exists():
+if browsers_path.exists() and any(browsers_path.glob("chromium*")):
     os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_path)
 
 from playwright.sync_api import sync_playwright


### PR DESCRIPTION
## Summary

- Bump version 2.0.6 → 2.0.7
- Adopt `zackees/setup-soldr@v0` across all four reusable workflows for Rust toolchain provisioning + artifact caching
- Fix latent Unicode crash and Playwright browsers-path bug in `test_native_playwright.py`

## Changes

### Version bump
- `Cargo.toml` workspace, `pyproject.toml`, `src/fastled/__version__.py`
- `Cargo.lock` regenerated via `cargo update --workspace`

### CI workflows (`_build`, `_unit-test`, `_lint`, `_integration-test`)
- Replace manual `rust-toolchain.toml` parsing + `Swatinem/rust-cache@v2` with a single `zackees/setup-soldr@v0` step
- `setup-soldr` reads `rust-toolchain.toml` by default and handles Rust artifact caching via zccache
- `mozilla-actions/sccache-action@v0.0.9` retained as a separate compile-cache layer

### `test_native_playwright.py`
- Reconfigure `sys.stdout`/`sys.stderr` to UTF-8 so console messages containing emoji (FastLED uses 🔧, ✅, etc.) don't crash on Windows cp1252
- Only redirect `PLAYWRIGHT_BROWSERS_PATH` when `~/.fastled/playwright` actually contains a `chromium*` install — the dir can exist with only `user-data/` inside, which made Playwright search an empty location and fail to launch

## Test plan
- [ ] CI green across all six platform matrices (Linux x86/ARM, Windows x86/ARM, macOS x86/ARM) for build, lint, unit-test, integration-test
- [ ] `setup-soldr@v0` resolves the toolchain from `rust-toolchain.toml` (1.85) on first run
- [ ] zccache cache hit rate observable on second run
- [ ] `python test_native_playwright.py` passes locally on Windows without UnicodeEncodeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)