### PR TITLE
fix(ci): pick the Rust fastled binary, not the Python entry-point shim

### DIFF
--- a/src/fastled/_rust_cli.py
+++ b/src/fastled/_rust_cli.py
@@ -1,0 +1,87 @@
+"""Locate the Rust ``fastled`` binary, NOT the Python entry-point shim.
+
+The Python package registers ``fastled`` as a console-script in
+``[project.scripts]``, which lands at ``.venv/Scripts/fastled.exe`` (or
+``.venv/bin/fastled``) and shadows the Rust binary on ``PATH``. The Rust
+binary needs to be invoked for the internal plumbing flags
+(``--internal-ensure-fastled-repo`` etc.); the shim's argparse rejects them.
+
+Search order:
+    1. Workspace ``target/{release,debug}/fastled[.exe]`` (dev builds).
+    2. ``$CARGO_HOME/bin/fastled[.exe]`` (where ``cargo binstall`` installs).
+    3. PATH walk that skips Python venv / system-Python directories.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _exe_name() -> str:
+    return "fastled.exe" if sys.platform == "win32" else "fastled"
+
+
+def _looks_like_python_dir(dir_path: Path) -> bool:
+    """Return True if ``dir_path`` hosts a Python interpreter.
+
+    Used to filter out Python venv/install dirs from the PATH walk so that a
+    ``fastled`` console-script entry-point in the same directory does not
+    shadow the actual Rust binary.
+    """
+    if sys.platform == "win32":
+        return (dir_path / "python.exe").is_file()
+    return (dir_path / "python").is_file() or (dir_path / "python3").is_file()
+
+
+def find_rust_fastled_cli() -> Path | None:
+    """Return the path to the Rust ``fastled`` binary, or ``None``."""
+    exe = _exe_name()
+
+    # 1. Workspace target/ tree (dev builds).
+    current = Path(__file__).resolve().parent
+    for _ in range(10):
+        if (current / "Cargo.toml").is_file():
+            for profile in ("release", "debug"):
+                candidate = current / "target" / profile / exe
+                if candidate.is_file():
+                    return candidate
+            target_dir = current / "target"
+            if target_dir.is_dir():
+                for arch_dir in target_dir.iterdir():
+                    if arch_dir.is_dir() and not arch_dir.name.startswith("."):
+                        for profile in ("release", "debug"):
+                            candidate = arch_dir / profile / exe
+                            if candidate.is_file():
+                                return candidate
+            break
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    # 2. cargo-binstall install location.
+    cargo_home = os.environ.get("CARGO_HOME")
+    if cargo_home:
+        candidate = Path(cargo_home) / "bin" / exe
+        if candidate.is_file():
+            return candidate
+    candidate = Path.home() / ".cargo" / "bin" / exe
+    if candidate.is_file():
+        return candidate
+
+    # 3. PATH walk, skipping Python interpreter dirs (which contain the
+    # Python entry-point shim that shadows the Rust binary).
+    for path_entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not path_entry:
+            continue
+        path_dir = Path(path_entry)
+        candidate = path_dir / exe
+        if not candidate.is_file():
+            continue
+        if _looks_like_python_dir(path_dir):
+            continue
+        return candidate
+
+    return None

--- a/src/fastled/playwright/chrome_extension_downloader.py
+++ b/src/fastled/playwright/chrome_extension_downloader.py
@@ -11,43 +11,11 @@ import sys
 import warnings
 from pathlib import Path
 
+from fastled._rust_cli import find_rust_fastled_cli as _find_rust_fastled_cli
 from fastled.interrupts import handle_keyboard_interrupt
 
 CPP_DEVTOOLS_EXTENSION_ID = "pdcpmagijalfljmkmjngeonclgbbannb"
 CPP_DEVTOOLS_EXTENSION_NAME = "cpp-devtools-support"
-
-
-def _find_rust_fastled_cli() -> Path | None:
-    """Locate the Rust fastled binary, preferring target/ over the venv shim."""
-    import shutil
-
-    exe_name = "fastled.exe" if sys.platform == "win32" else "fastled"
-
-    current = Path(__file__).resolve().parent
-    for _ in range(10):
-        if (current / "Cargo.toml").is_file():
-            for profile in ("release", "debug"):
-                candidate = current / "target" / profile / exe_name
-                if candidate.is_file():
-                    return candidate
-            target_dir = current / "target"
-            if target_dir.is_dir():
-                for arch_dir in target_dir.iterdir():
-                    if arch_dir.is_dir() and not arch_dir.name.startswith("."):
-                        for profile in ("release", "debug"):
-                            candidate = arch_dir / profile / exe_name
-                            if candidate.is_file():
-                                return candidate
-            break
-        parent = current.parent
-        if parent == current:
-            break
-        current = parent
-
-    found = shutil.which(exe_name)
-    if found:
-        return Path(found)
-    return None
 
 
 def download_cpp_devtools_extension() -> Path | None:

--- a/src/fastled/project_init.py
+++ b/src/fastled/project_init.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from fastled._rust_cli import find_rust_fastled_cli as _find_rust_fastled_cli
 from fastled.interrupts import handle_keyboard_interrupt
 
 DEFAULT_EXAMPLE = "wasm"
@@ -15,47 +16,6 @@ DEFAULT_EXAMPLE = "wasm"
 class _CachedRepo:
     root: Path
     ref_name: str
-
-
-def _find_rust_fastled_cli() -> Path | None:
-    """Locate the **Rust** fastled CLI binary, not the Python entry-point shim.
-
-    The Python `[project.scripts] fastled = ...` console-script sits in the
-    same directory as the interpreter and shadows the Rust binary in step 1
-    of the open_browser lookup. We need the Rust one, so search the workspace
-    target/ tree first, then PATH.
-    """
-    import shutil
-    import sys
-
-    exe_name = "fastled.exe" if sys.platform == "win32" else "fastled"
-
-    # Walk up to find a Cargo.toml workspace root and check target dirs.
-    current = Path(__file__).resolve().parent
-    for _ in range(10):
-        if (current / "Cargo.toml").is_file():
-            for profile in ("release", "debug"):
-                candidate = current / "target" / profile / exe_name
-                if candidate.is_file():
-                    return candidate
-            target_dir = current / "target"
-            if target_dir.is_dir():
-                for arch_dir in target_dir.iterdir():
-                    if arch_dir.is_dir() and not arch_dir.name.startswith("."):
-                        for profile in ("release", "debug"):
-                            candidate = arch_dir / profile / exe_name
-                            if candidate.is_file():
-                                return candidate
-            break
-        parent = current.parent
-        if parent == current:
-            break
-        current = parent
-
-    found = shutil.which(exe_name)
-    if found:
-        return Path(found)
-    return None
 
 
 def _ensure_repo_via_rust(ref: str | None) -> Path:


### PR DESCRIPTION
## Summary

PR #64 merged with a latent bug that surfaced as red CI on `main`. The Python-side helpers (`project_init.py`, `playwright/chrome_extension_downloader.py`) used `shutil.which(\"fastled\")` to locate the Rust binary for the new hidden plumbing flags (`--internal-ensure-fastled-repo`, `--internal-ensure-chrome-extension`).

In CI (and in any normal editable install), `shutil.which(\"fastled\")` returns the **Python entry-point shim** at `.venv/Scripts/fastled.exe` declared in `[project.scripts]`, NOT the Rust binary at `target/debug/fastled.exe`. The shim runs `fastled.cli:main` and rejects the hidden flag with `fastled: error: unrecognized arguments: --internal-ensure-fastled-repo`. Every unit-test job + the `deploy` job failed with this exit-2 RuntimeError.

## Fix

New `src/fastled/_rust_cli.py` module with a search order specifically designed to find the Rust binary, not the shim:

1. Workspace `target/{release,debug}/fastled[.exe]` (dev builds + CI after `cargo test`).
2. `$CARGO_HOME/bin/fastled[.exe]` and `~/.cargo/bin/fastled[.exe]` (the `cargo binstall` install path).
3. PATH walk that **skips directories hosting a Python interpreter** (so the venv `Scripts`/`bin` dir with the entry-point shim is filtered out).

Both `project_init.py` and `chrome_extension_downloader.py` now import this single helper; their inline finders are deleted.

## Test plan

- [x] `bash lint` clean (cargo check + clippy + rustfmt + ruff + black + isort + pyright)
- [x] `bash test` — 119 passed, 1 skipped (including `test_api.py::test_project_init` which exercises the subprocess-to-Rust path end-to-end)
- [ ] CI green — both `unit-test` and `deploy` jobs that failed on `main` should now pass

Refs #63, #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)