### PR TITLE
fix(ci): build the Rust fastled CLI from source when binstall fails

### DIFF
--- a/install
+++ b/install
@@ -79,8 +79,31 @@ if ! command -v cargo-binstall &> /dev/null; then
     | bash 2>/dev/null || echo "  cargo-binstall install failed (non-fatal)"
 fi
 
+FASTLED_CLI_BINSTALLED=0
+FASTLED_TAURI_BINSTALLED=0
 if command -v cargo-binstall &> /dev/null; then
   echo "Fetching pre-built binaries via cargo-binstall..."
-  cargo binstall fastled-cli --no-confirm 2>/dev/null || echo "  fastled-cli: no pre-built binary available (will compile from source when needed)"
-  cargo binstall fastled-tauri --no-confirm 2>/dev/null || echo "  fastled-tauri: no pre-built binary available (will compile from source when needed)"
+  if cargo binstall fastled-cli --no-confirm 2>/dev/null; then
+    FASTLED_CLI_BINSTALLED=1
+  else
+    echo "  fastled-cli: no pre-built binary available (will compile from source)"
+  fi
+  if cargo binstall fastled-tauri --no-confirm 2>/dev/null; then
+    FASTLED_TAURI_BINSTALLED=1
+  else
+    echo "  fastled-tauri: no pre-built binary available (will compile from source)"
+  fi
+fi
+
+# Ensure the Rust `fastled` CLI binary is materialised somewhere our Python
+# helpers (src/fastled/_rust_cli.py) can find it. The Python `[project.scripts]`
+# entry-point shim collides with the Rust binary's name on PATH, so the helper
+# explicitly looks in target/{release,debug}/ and $CARGO_HOME/bin. If
+# cargo-binstall didn't supply a pre-built copy, build from source so unit
+# tests and the deploy workflow can subprocess the binary for the internal
+# auto-install plumbing flags (--internal-ensure-fastled-repo, etc.).
+if [[ "$FASTLED_CLI_BINSTALLED" -eq 0 ]]; then
+  echo "Building fastled CLI from source..."
+  "$(dirname "$0")/_cargo" build --release --bin fastled \
+    || { echo "Error: cargo build --bin fastled failed"; exit 1; }
 fi


### PR DESCRIPTION
## Summary

Follow-up to PR #65, which merged the Python `_find_rust_fastled_cli` helper. The helper now correctly *avoids* the Python entry-point shim — but in CI the lookup returns `None` because the Rust binary is missing entirely:

* `cargo binstall fastled-cli` fails (no published release yet).
* `cargo test --workspace` (in `./test`) compiles the test binary into `target/<arch>/debug/deps/` but does not always produce the main bin output at `target/<arch>/debug/fastled[.exe]`.
* The Build Webpage / `deploy` job never runs `cargo test` at all.

Result: `Api.project_init` and `download_cpp_devtools_extension` fail across every runner with `RuntimeError: Could not locate the fastled CLI binary` (visible in the current red unit-test + deploy jobs on `main`).

## Fix

When `cargo binstall fastled-cli` does not supply a pre-built copy, `./install` now falls back to building the binary from source:

```bash
"$(dirname "$0")/_cargo" build --release --bin fastled
```

* Uses the existing `_cargo` trampoline so the MSVC target gets forced on Windows (matching the directories `_rust_cli.py` searches).
* Same single-source-of-truth applies to both unit-test and deploy jobs — they all go through `./install`.
* No-op for the case where `cargo binstall` succeeds (release published) — that path still wins.

## Test plan

- [x] `bash -n install` clean
- [x] `bash lint` clean
- [x] `bash test` — 119 unit tests pass locally with the binary populated in `target/debug/`
- [ ] CI green — `call / unit-test` and `deploy` jobs both turn green

Refs #63, #64, #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)