### PR TITLE
refactor: move app selection plumbing into Rust

### DIFF
--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -528,10 +528,18 @@ fn detect_local_fastled_path() -> Option<String> {
     project::find_fastled_repo_upwards(&cwd, 10).map(|path| canonical_display_path(&path))
 }
 
-enum PromptChoice {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PromptChoice {
     Selected(String),
     Narrowed(Vec<String>),
     Retry,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SketchSelection {
+    Selected(String),
+    Prompt(Vec<String>),
+    None,
 }
 
 fn option_basename(option: &str) -> &str {
@@ -561,7 +569,11 @@ fn fuzzy_match_options(input: &str, options: &[String]) -> Vec<String> {
     results
 }
 
-fn resolve_prompt_choice(input: &str, options: &[String], default_index: usize) -> PromptChoice {
+pub fn resolve_prompt_choice(
+    input: &str,
+    options: &[String],
+    default_index: usize,
+) -> PromptChoice {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return PromptChoice::Selected(options[default_index].clone());
@@ -597,6 +609,31 @@ fn resolve_prompt_choice(input: &str, options: &[String], default_index: usize) 
         1 => PromptChoice::Selected(fuzzy_matches[0].clone()),
         n if n > 1 => PromptChoice::Narrowed(fuzzy_matches),
         _ => PromptChoice::Retry,
+    }
+}
+
+pub fn prepare_sketch_selection(
+    mut sketch_directories: Vec<PathBuf>,
+    cwd_is_fastled: bool,
+    is_followup: bool,
+) -> SketchSelection {
+    if cwd_is_fastled {
+        sketch_directories.retain(|path| {
+            let text = path.to_string_lossy().replace('\\', "/");
+            !matches!(text.as_str(), "src" | "dev" | "tests")
+        });
+    }
+
+    match sketch_directories.len() {
+        0 => SketchSelection::None,
+        1 => SketchSelection::Selected(display_path(&sketch_directories[0])),
+        _ if !is_followup && sketch_directories.len() > 4 => SketchSelection::None,
+        _ => SketchSelection::Prompt(
+            sketch_directories
+                .iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect(),
+        ),
     }
 }
 
@@ -1268,5 +1305,48 @@ mod tests {
             }
             _ => panic!("expected fuzzy selection"),
         }
+    }
+
+    #[test]
+    fn prepare_sketch_selection_auto_selects_single_directory() {
+        let result = prepare_sketch_selection(vec![PathBuf::from("sketch1")], false, false);
+        assert_eq!(result, SketchSelection::Selected("sketch1".to_string()));
+    }
+
+    #[test]
+    fn prepare_sketch_selection_defers_large_first_scan() {
+        let sketches = (0..5)
+            .map(|index| PathBuf::from(format!("sketch{index}")))
+            .collect();
+        let result = prepare_sketch_selection(sketches, false, false);
+        assert_eq!(result, SketchSelection::None);
+    }
+
+    #[test]
+    fn prepare_sketch_selection_prompts_large_followup_scan() {
+        let sketches: Vec<PathBuf> = (0..5)
+            .map(|index| PathBuf::from(format!("sketch{index}")))
+            .collect();
+        let result = prepare_sketch_selection(sketches, false, true);
+        assert_eq!(
+            result,
+            SketchSelection::Prompt(
+                (0..5)
+                    .map(|index| format!("sketch{index}"))
+                    .collect::<Vec<_>>()
+            )
+        );
+    }
+
+    #[test]
+    fn prepare_sketch_selection_filters_fastled_repo_dirs() {
+        let sketches = vec![
+            PathBuf::from("src"),
+            PathBuf::from("dev"),
+            PathBuf::from("tests"),
+            PathBuf::from("examples"),
+        ];
+        let result = prepare_sketch_selection(sketches, true, false);
+        assert_eq!(result, SketchSelection::Selected("examples".to_string()));
     }
 }

--- a/crates/fastled-py/src/lib.rs
+++ b/crates/fastled-py/src/lib.rs
@@ -1,5 +1,6 @@
 use fastled_cli::install;
 use fastled_cli::project;
+use fastled_cli::{PromptChoice, SketchSelection};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyModule};
@@ -865,6 +866,55 @@ fn find_sketch_by_partial_name(partial_name: &str, search_dir: Option<&str>) -> 
         .map_err(|err| PyValueError::new_err(err.to_string()))
 }
 
+fn selection_payload(selection: SketchSelection) -> (String, Option<String>, Vec<String>) {
+    match selection {
+        SketchSelection::Selected(value) => ("selected".to_string(), Some(value), Vec::new()),
+        SketchSelection::Prompt(options) => ("prompt".to_string(), None, options),
+        SketchSelection::None => ("none".to_string(), None, Vec::new()),
+    }
+}
+
+fn prompt_choice_payload(choice: PromptChoice) -> (String, Option<String>, Vec<String>) {
+    match choice {
+        PromptChoice::Selected(value) => ("selected".to_string(), Some(value), Vec::new()),
+        PromptChoice::Narrowed(options) => ("narrowed".to_string(), None, options),
+        PromptChoice::Retry => ("retry".to_string(), None, Vec::new()),
+    }
+}
+
+#[pyfunction]
+fn prepare_sketch_selection(
+    sketch_directories: Vec<String>,
+    cwd_is_fastled: bool,
+    is_followup: bool,
+) -> (String, Option<String>, Vec<String>) {
+    let paths = sketch_directories.into_iter().map(PathBuf::from).collect();
+    selection_payload(fastled_cli::prepare_sketch_selection(
+        paths,
+        cwd_is_fastled,
+        is_followup,
+    ))
+}
+
+#[pyfunction(signature = (input, options, default_index=0))]
+fn resolve_prompt_choice(
+    input: &str,
+    options: Vec<String>,
+    default_index: usize,
+) -> PyResult<(String, Option<String>, Vec<String>)> {
+    if options.is_empty() {
+        return Err(PyValueError::new_err("options must not be empty"));
+    }
+    if default_index >= options.len() {
+        return Err(PyValueError::new_err("default_index out of range"));
+    }
+    Ok(prompt_choice_payload(fastled_cli::resolve_prompt_choice(
+        input,
+        &options,
+        default_index,
+    )))
+}
+
 #[pyfunction(signature = (path=None))]
 fn looks_like_fastled_repo(path: Option<&str>) -> PyResult<bool> {
     let directory = path.map(PathBuf::from).unwrap_or(std::env::current_dir()?);
@@ -974,6 +1024,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(project_available, m)?)?;
     m.add_function(wrap_pyfunction!(find_sketch_directories, m)?)?;
     m.add_function(wrap_pyfunction!(find_sketch_by_partial_name, m)?)?;
+    m.add_function(wrap_pyfunction!(prepare_sketch_selection, m)?)?;
+    m.add_function(wrap_pyfunction!(resolve_prompt_choice, m)?)?;
     m.add_function(wrap_pyfunction!(looks_like_fastled_repo, m)?)?;
     m.add_function(wrap_pyfunction!(looks_like_sketch_directory, m)?)?;
     m.add_function(wrap_pyfunction!(find_fastled_repo_upwards, m)?)?;

--- a/src/fastled/build_service.py
+++ b/src/fastled/build_service.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
-import io
-import json
-import shutil
-import time
-import zipfile
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 from fastled.build_types import BuildRequest, BuildResult, BuildStrategy
 from fastled.interrupts import handle_keyboard_interrupt
 from fastled.types import BuildMode, CompileResult
 
-try:
-    from fastled._native import NativeBuildService as _NativeBuildService
-except ImportError:
-    _NativeBuildService = None
+from fastled._native import NativeBuildService as _NativeBuildService
 
 
 def _toolchain_key(fastled_path: Path | None) -> str | None:
@@ -33,231 +24,19 @@ class _CompilerToolchain(Protocol):
     ) -> Path: ...
 
 
-@dataclass
-class _BuildState:
-    build_mode: str
-    profile: bool
-    fastled_path: str | None
-
-
-class _PythonBuildService:
-    def __init__(self) -> None:
-        self._toolchains: dict[str | None, _CompilerToolchain] = {}
-        self._states: dict[Path, _BuildState] = {}
-
-    def register_toolchain(
-        self, fastled_path: Path | None, toolchain: _CompilerToolchain
-    ) -> None:
-        self._toolchains[_toolchain_key(fastled_path)] = toolchain
-
-    def build(self, request: BuildRequest) -> BuildResult:
-        from fastled.toolchain.emscripten import EmscriptenToolchain
-
-        strategy = self.detect_strategy(request)
-        output_dir = request.output_dir
-
-        if request.force_clean and output_dir.exists():
-            shutil.rmtree(output_dir, ignore_errors=True)
-
-        toolchain_key = _toolchain_key(request.fastled_path)
-        toolchain = self._toolchains.get(toolchain_key)
-        if toolchain is None:
-            toolchain = EmscriptenToolchain(fastled_path=request.fastled_path)
-            self._toolchains[toolchain_key] = toolchain
-
-        start_time = time.time()
-        zip_time = 0.0
-        try:
-            output_dir.mkdir(parents=True, exist_ok=True)
-            js_file = toolchain.compile(
-                sketch_dir=request.sketch_dir,
-                output_dir=output_dir,
-                build_mode=request.build_mode,
-                profile=request.profile,
-            )
-            compile_time = time.time() - start_time
-            zip_start = time.time()
-            zip_bytes = self._zip_output(output_dir)
-            zip_time = time.time() - zip_start
-            compile_result = CompileResult(
-                success=True,
-                stdout=(
-                    "Native compilation successful!\n"
-                    f"Output: {js_file}\n"
-                    f"WASM: {js_file.with_suffix('.wasm')}"
-                ),
-                hash_value=None,
-                zip_bytes=zip_bytes,
-                zip_time=zip_time,
-                libfastled_time=0.0,
-                sketch_time=compile_time,
-                response_processing_time=0.0,
-            )
-        except KeyboardInterrupt as ki:
-            handle_keyboard_interrupt(ki)
-            raise
-        except Exception as exc:
-            compile_time = time.time() - start_time
-            compile_result = CompileResult(
-                success=False,
-                stdout=f"Native compilation failed: {exc}",
-                hash_value=None,
-                zip_bytes=b"",
-                zip_time=0.0,
-                libfastled_time=0.0,
-                sketch_time=compile_time,
-                response_processing_time=0.0,
-            )
-
-        if compile_result.success:
-            state = _BuildState(
-                build_mode=request.build_mode.value,
-                profile=request.profile,
-                fastled_path=toolchain_key,
-            )
-            self._states[request.sketch_dir.resolve()] = state
-            self._write_state(output_dir, state)
-
-        return BuildResult(
-            compile_result=compile_result,
-            strategy=strategy,
-            output_dir=output_dir,
-            artifacts=self._discover_artifacts(output_dir),
-        )
-
-    def detect_strategy(self, request: BuildRequest) -> BuildStrategy:
-        if request.force_clean:
-            return "cold"
-
-        output_dir = request.output_dir
-        if not output_dir.exists():
-            return "cold"
-
-        required_artifacts = [
-            output_dir / "fastled.js",
-            output_dir / "fastled.wasm",
-        ]
-        if not all(path.exists() for path in required_artifacts):
-            return "cold"
-
-        previous = self._states.get(request.sketch_dir.resolve())
-        if previous is None:
-            previous = self._read_state(output_dir)
-            if previous is not None:
-                self._states[request.sketch_dir.resolve()] = previous
-        if previous is None:
-            return "cold"
-
-        current_fastled_path = _toolchain_key(request.fastled_path)
-        if previous.fastled_path != current_fastled_path:
-            return "cold"
-        if previous.build_mode != request.build_mode.value:
-            return "cold"
-        if previous.profile != request.profile:
-            return "cold"
-        return "incremental"
-
-    def purge(self, sketch_dir: Path) -> None:
-        resolved = sketch_dir.resolve()
-        self._states.pop(resolved, None)
-        output_dir = resolved / "fastled_js"
-        if output_dir.exists():
-            shutil.rmtree(output_dir, ignore_errors=True)
-
-    @staticmethod
-    def _state_file(output_dir: Path) -> Path:
-        return output_dir / ".fastled_build_state.json"
-
-    @classmethod
-    def _write_state(cls, output_dir: Path, state: _BuildState) -> None:
-        try:
-            cls._state_file(output_dir).write_text(
-                json.dumps(
-                    {
-                        "build_mode": state.build_mode,
-                        "profile": state.profile,
-                        "fastled_path": state.fastled_path,
-                    }
-                ),
-                encoding="utf-8",
-            )
-        except OSError:
-            pass
-
-    @classmethod
-    def _read_state(cls, output_dir: Path) -> _BuildState | None:
-        state_file = cls._state_file(output_dir)
-        if not state_file.exists():
-            return None
-        try:
-            payload = json.loads(state_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return None
-        if not isinstance(payload, dict):
-            return None
-        build_mode = payload.get("build_mode")
-        profile = payload.get("profile")
-        fastled_path = payload.get("fastled_path")
-        if not isinstance(build_mode, str) or not isinstance(profile, bool):
-            return None
-        if fastled_path is not None and not isinstance(fastled_path, str):
-            return None
-        return _BuildState(
-            build_mode=build_mode,
-            profile=profile,
-            fastled_path=fastled_path,
-        )
-
-    @staticmethod
-    def _zip_output(output_dir: Path) -> bytes:
-        zip_buffer = io.BytesIO()
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-            for file_path in output_dir.rglob("*"):
-                if file_path.is_file():
-                    zf.write(file_path, file_path.relative_to(output_dir))
-        return zip_buffer.getvalue()
-
-    @staticmethod
-    def _discover_artifacts(output_dir: Path) -> dict[str, Path]:
-        artifacts: dict[str, Path] = {}
-        candidates = {
-            "js": output_dir / "fastled.js",
-            "wasm": output_dir / "fastled.wasm",
-            "dwarf": output_dir / "fastled.wasm.dwarf",
-            "symbol_map": output_dir / "fastled.js.symbols",
-            "frontend_assets": output_dir / "assets",
-        }
-        for name, path in candidates.items():
-            if path.exists():
-                artifacts[name] = path
-        if "frontend_assets" not in artifacts and output_dir.exists():
-            artifacts["frontend_assets"] = output_dir
-        return artifacts
-
-
 class BuildService:
     def __init__(self) -> None:
-        self._native = _NativeBuildService() if _NativeBuildService is not None else None
+        self._native = _NativeBuildService()
         self._toolchains: dict[str | None, _CompilerToolchain] = {}
-        self._fallback = None if self._native is not None else _PythonBuildService()
 
     def register_toolchain(
         self, fastled_path: Path | None, toolchain: _CompilerToolchain
     ) -> None:
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.register_toolchain(fastled_path, toolchain)
-            return
-
         key = _toolchain_key(fastled_path)
         self._toolchains[key] = toolchain
         self._native.register_toolchain(toolchain, key)
 
     def build(self, request: BuildRequest) -> BuildResult:
-        if self._native is None:
-            assert self._fallback is not None
-            return self._fallback.build(request)
-
         self._ensure_toolchain(request.fastled_path)
 
         try:
@@ -297,10 +76,6 @@ class BuildService:
         )
 
     def detect_strategy(self, request: BuildRequest) -> BuildStrategy:
-        if self._native is None:
-            assert self._fallback is not None
-            return self._fallback.detect_strategy(request)
-
         return cast(
             BuildStrategy,
             self._native.detect_strategy(
@@ -313,10 +88,6 @@ class BuildService:
         )
 
     def purge(self, sketch_dir: Path) -> None:
-        if self._native is None:
-            assert self._fallback is not None
-            self._fallback.purge(sketch_dir)
-            return
         self._native.purge(str(sketch_dir))
 
     def _ensure_toolchain(self, fastled_path: Path | None) -> None:

--- a/src/fastled/select_sketch_directory.py
+++ b/src/fastled/select_sketch_directory.py
@@ -1,9 +1,34 @@
 from pathlib import Path
 from typing import Callable, TypeVar, Union
 
-from fastled.string_diff import string_diff
+from fastled._native import prepare_sketch_selection as _native_prepare_sketch_selection
+from fastled._native import resolve_prompt_choice as _native_resolve_prompt_choice
 
 T = TypeVar("T")
+
+
+def _find_matching_option(
+    options: list[T], option_to_str: Callable[[T], str], selected: str
+) -> T | None:
+    selected_lower = selected.lower()
+    for option in options:
+        if option_to_str(option).lower() == selected_lower:
+            return option
+    return None
+
+
+def _filter_options_by_labels(
+    options: list[T], option_to_str: Callable[[T], str], labels: list[str]
+) -> list[T]:
+    remaining = list(options)
+    narrowed: list[T] = []
+    for label in labels:
+        match = _find_matching_option(remaining, option_to_str, label)
+        if match is None:
+            continue
+        narrowed.append(match)
+        remaining.remove(match)
+    return narrowed
 
 
 def _disambiguate_user_choice(
@@ -15,14 +40,8 @@ def _disambiguate_user_choice(
     """
     Present multiple options to the user with a default selection.
 
-    Args:
-        options: List of options to choose from
-        option_to_str: Function to convert option to display string
-        prompt: Prompt message to show user
-        default_index: Index of the default option (0-based)
-
-    Returns:
-        Selected option or None if cancelled
+    Matching and narrowing are delegated to the native Rust implementation;
+    Python only preserves the compatibility prompt surface for existing callers.
     """
     if not options:
         return None
@@ -30,131 +49,88 @@ def _disambiguate_user_choice(
     if len(options) == 1:
         return options[0]
 
-    # Ensure default_index is valid
-    if default_index < 0 or default_index >= len(options):
-        default_index = 0
+    current_options = list(options)
+    current_prompt = prompt
+    current_default = default_index
 
-    print(f"\n{prompt}")
-    for i, option in enumerate(options):
-        option_str = option_to_str(option)
-        if i == default_index:
-            print(f"  [{i+1}]: [{option_str}]")  # Default option shown in brackets
-        else:
-            print(f"  [{i+1}]: {option_str}")
+    while True:
+        if current_default < 0 or current_default >= len(current_options):
+            current_default = 0
 
-    default_option_str = option_to_str(options[default_index])
-    user_input = input(
-        f"\nEnter number or name (default: [{default_option_str}]): "
-    ).strip()
+        print(f"\n{current_prompt}")
+        for i, option in enumerate(current_options):
+            option_str = option_to_str(option)
+            if i == current_default:
+                print(f"  [{i + 1}]: [{option_str}]")
+            else:
+                print(f"  [{i + 1}]: {option_str}")
 
-    # Handle empty input - select default
-    if not user_input:
-        return options[default_index]
+        default_option_str = option_to_str(current_options[current_default])
+        user_input = input(
+            f"\nEnter number or name (default: [{default_option_str}]): "
+        ).strip()
 
-    # Try to parse as number
-    try:
-        index = int(user_input) - 1
-        if 0 <= index < len(options):
-            return options[index]
-    except ValueError:
-        pass
-
-    # Try to match by name (case insensitive)
-    user_input_lower = user_input.lower()
-    for option in options:
-        option_str = option_to_str(option).lower()
-        if option_str == user_input_lower:
-            return option
-
-    # Try partial match
-    matches = []
-    for option in options:
-        option_str = option_to_str(option)
-        if user_input_lower in option_str.lower():
-            matches.append(option)
-
-    if len(matches) == 1:
-        return matches[0]
-    elif len(matches) > 1:
-        # Recursive disambiguation with the filtered matches
-        return _disambiguate_user_choice(
-            matches,
-            option_to_str,
-            f"Multiple partial matches for '{user_input}':",
-            0,  # Reset default to first match
+        option_labels = [option_to_str(option) for option in current_options]
+        status, selected, narrowed = _native_resolve_prompt_choice(
+            user_input,
+            option_labels,
+            current_default,
         )
 
-    # Try fuzzy matching as fallback
-    # For better fuzzy matching on paths, extract just the last component (basename)
-    # to avoid the "examples/" prefix interfering with matching
-    from pathlib import Path as PathLib
+        if status == "selected" and selected is not None:
+            return _find_matching_option(current_options, option_to_str, selected)
 
-    option_basenames = []
-    for option in options:
-        option_str = option_to_str(option)
-        # Extract basename for fuzzy matching
-        basename = (
-            PathLib(option_str).name
-            if "/" in option_str or "\\" in option_str
-            else option_str
-        )
-        option_basenames.append(basename)
-
-    fuzzy_results = string_diff(user_input, option_basenames)
-
-    if fuzzy_results:
-        # Map fuzzy results back to original options
-        fuzzy_matches = []
-        for _, matched_basename in fuzzy_results:
-            for i, basename in enumerate(option_basenames):
-                if basename == matched_basename:
-                    fuzzy_matches.append(options[i])
-                    break
-
-        if len(fuzzy_matches) == 1:
-            return fuzzy_matches[0]
-        elif len(fuzzy_matches) > 1:
-            # Recursive disambiguation with fuzzy matches
-            return _disambiguate_user_choice(
-                fuzzy_matches,
+        if status == "narrowed":
+            narrowed_options = _filter_options_by_labels(
+                current_options,
                 option_to_str,
-                f"Multiple fuzzy matches for '{user_input}':",
-                0,
+                list(narrowed),
             )
+            if not narrowed_options:
+                print(f"No match found for '{user_input}'. Please try again.")
+                continue
 
-    # No match found
-    print(f"No match found for '{user_input}'. Please try again.")
-    return _disambiguate_user_choice(options, option_to_str, prompt, default_index)
+            user_input_lower = user_input.lower()
+            is_partial = (
+                sum(
+                    1
+                    for label in option_labels
+                    if user_input_lower in label.lower()
+                )
+                > 1
+            )
+            current_prompt = (
+                f"Multiple partial matches for '{user_input}':"
+                if is_partial
+                else f"Multiple fuzzy matches for '{user_input}':"
+            )
+            current_options = narrowed_options
+            current_default = 0
+            continue
+
+        print(f"No match found for '{user_input}'. Please try again.")
 
 
 def select_sketch_directory(
     sketch_directories: list[Path], cwd_is_fastled: bool, is_followup: bool = False
 ) -> str | None:
-    if cwd_is_fastled:
-        exclude = ["src", "dev", "tests"]
-        for ex in exclude:
-            p = Path(ex)
-            if p in sketch_directories:
-                sketch_directories.remove(p)
+    status, selected, options = _native_prepare_sketch_selection(
+        [str(path) for path in sketch_directories],
+        cwd_is_fastled,
+        is_followup,
+    )
 
-    if len(sketch_directories) == 1:
-        print(f"\nUsing sketch directory: {sketch_directories[0]}")
-        return str(sketch_directories[0])
-    elif len(sketch_directories) > 1:
-        # First scan with >4 directories: return None (too many to auto-select)
-        if not is_followup and len(sketch_directories) > 4:
-            return None
+    if status == "selected" and selected is not None:
+        print(f"\nUsing sketch directory: {selected}")
+        return str(selected)
 
-        # Prompt user to disambiguate
-        result = _disambiguate_user_choice(
-            sketch_directories,
-            option_to_str=lambda x: str(x),
-            prompt="Multiple Directories found, choose one:",
-            default_index=0,
-        )
+    if status != "prompt":
+        return None
 
-        if result is None:
-            return None
-
-        return str(result)
-    return None
+    result = _disambiguate_user_choice(
+        [Path(option) for option in options],
+        option_to_str=lambda path: str(path),
+        prompt="Multiple Directories found, choose one:",
+        default_index=0,
+    )
+    return str(result) if result is not None else None

--- a/src/fastled/types.py
+++ b/src/fastled/types.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Protocol
 
-from fastled.args import Args
 from fastled.print_filter import PrintFilterDefault
+
+
+class _BuildModeArgs(Protocol):
+    debug: bool
+    release: bool
 
 
 @dataclass
@@ -43,7 +47,7 @@ class BuildMode(Enum):
             raise ValueError(f"BUILD_MODE must be one of {valid_modes}, got {mode_str}")
 
     @staticmethod
-    def from_args(args: Args) -> "BuildMode":
+    def from_args(args: _BuildModeArgs) -> "BuildMode":
         if args.debug:
             return BuildMode.DEBUG
         elif args.release:

--- a/tests/unit/test_post_migration.py
+++ b/tests/unit/test_post_migration.py
@@ -19,6 +19,26 @@ class TestPythonEntrypointsDelegateToRust(unittest.TestCase):
         self.assertIn("invoke_rust_fastled_cli", source)
 
 
+class TestNativeAppOrchestration(unittest.TestCase):
+    """App-layer compatibility modules should prefer native Rust behavior."""
+
+    def test_select_sketch_directory_uses_native_resolver(self) -> None:
+        source = (SRC_DIR / "select_sketch_directory.py").read_text()
+        self.assertIn("_native_prepare_sketch_selection", source)
+        self.assertIn("_native_resolve_prompt_choice", source)
+        self.assertNotIn("from fastled.string_diff import string_diff", source)
+
+    def test_build_service_has_no_python_fallback_service(self) -> None:
+        source = (SRC_DIR / "build_service.py").read_text()
+        self.assertIn("from fastled._native import NativeBuildService", source)
+        self.assertNotIn("class _PythonBuildService", source)
+        self.assertNotIn("if self._native is None", source)
+
+    def test_types_do_not_import_legacy_args_at_runtime(self) -> None:
+        source = (SRC_DIR / "types.py").read_text()
+        self.assertNotIn("from fastled.args import Args", source)
+
+
 class TestNoDeadCodeModules(unittest.TestCase):
     """Bug 2: Dead code files left over from the backend cleanup must be removed."""
 


### PR DESCRIPTION
## Summary
- expose Rust-owned sketch selection and prompt resolution helpers through `fastled-cli` and `fastled._native`
- reduce `select_sketch_directory.py` to a compatibility prompt wrapper around native matching behavior
- make `BuildService` require the native PyO3 service instead of carrying a Python fallback implementation
- remove the runtime `fastled.args` import from `types.py` and add regression coverage for the native-first app layer

## Verification
- `cargo fmt --all --check`
- `cargo test -p fastled-cli --lib`
- `cargo test -p fastled-py --lib`
- `pytest tests/unit/test_select_sketch_directory.py tests/unit/test_build_service.py tests/unit/test_post_migration.py`

Refs #72
