### PR TITLE
fix(ci): authenticate setup-soldr downloads

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
           # Include github.workflow because some callers (e.g. Windows

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
           # Include github.workflow because some callers (e.g. Windows

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
           # Include github.workflow because some callers (e.g. Windows

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
           # Include github.workflow because some callers (e.g. Windows


### PR DESCRIPTION
## Summary
- pass the workflow GITHUB_TOKEN into setup-soldr in build, lint, unit-test, and integration-test reusable workflows
- fixes builders failing before project code runs with GitHub API HTTP 403 while resolving zackees/soldr release v0.7.18

## Verification
- git diff --check