### PR TITLE
build: align rustc wrapper on zccache; drop redundant sccache from CI (closes #75)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -18,9 +18,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -31,8 +28,6 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -15,8 +15,6 @@ jobs:
       run:
         shell: bash
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +26,6 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -14,9 +14,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -27,8 +24,6 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -15,8 +15,6 @@ jobs:
       run:
         shell: bash
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +26,6 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/ci/env.py
+++ b/ci/env.py
@@ -165,13 +165,21 @@ def activate() -> None:
     )
 
 
-def _apply_sccache(env: dict[str, str]) -> dict[str, str]:
-    """Set RUSTC_WRAPPER=sccache when sccache is available."""
+def _apply_rustc_wrapper(env: dict[str, str]) -> dict[str, str]:
+    """Set RUSTC_WRAPPER to zccache when available, falling back to sccache.
+
+    The project uses zccache (via soldr) for compile caching. Prefer it; fall
+    back to sccache for environments where only that is installed. Bare cargo
+    invocations that consume this env still benefit from the cache even though
+    most callers in this repo now route through ``soldr cargo`` directly.
+    """
     if env.get("RUSTC_WRAPPER"):
         return env
-    sccache = shutil.which("sccache", path=env.get("PATH"))
-    if sccache:
-        env["RUSTC_WRAPPER"] = sccache
+    for tool in ("zccache", "sccache"):
+        found = shutil.which(tool, path=env.get("PATH"))
+        if found:
+            env["RUSTC_WRAPPER"] = found
+            return env
     return env
 
 
@@ -185,7 +193,7 @@ def clean_env() -> dict[str, str]:
         env.pop("VIRTUAL_ENV", None)
         env.setdefault("PYTHONUTF8", "1")
     env.setdefault("RUSTUP_TOOLCHAIN", toolchain_name())
-    env = _apply_sccache(env)
+    env = _apply_rustc_wrapper(env)
     return env
 
 


### PR DESCRIPTION
## Summary

Closes #75. Companion to #76 (PR #78, already merged).

Two remaining items from #75 after PR #78 retired the `_cargo` trampolines:

1. **`ci/env.py::_apply_sccache`** set `RUSTC_WRAPPER=sccache` when sccache was on PATH, but this project uses **zccache** (via soldr). Renamed to `_apply_rustc_wrapper`; prefer zccache, fall back to sccache. The helper currently has no in-tree callers but is defensive for any future direct caller that builds `cargo` env from `build_env()`.

2. **CI workflows installed BOTH** `mozilla-actions/sccache-action@v0.0.9` AND `zackees/setup-soldr@v0`, then set `RUSTC_WRAPPER: sccache` via env. With every script caller now routing through `soldr cargo` (which manages the zccache wrapper automatically), the sccache half is redundant. Dropped `SCCACHE_GHA_ENABLED`, `RUSTC_WRAPPER: sccache`, and the sccache-action step from `_build.yml`, `_lint.yml`, `_unit-test.yml`, `_integration-test.yml`. `setup-soldr` remains and provides zccache + GitHub Actions cache for its state.

## Files

- **Updated**: `ci/env.py`, `.github/workflows/_build.yml`, `.github/workflows/_lint.yml`, `.github/workflows/_unit-test.yml`, `.github/workflows/_integration-test.yml`

## Test plan

- [x] `bash lint` — green; goes through `soldr cargo fmt` + `soldr cargo clippy`
- [x] `grep -rn 'sccache\|SCCACHE' .github/workflows/ ci/env.py` shows only the docstring/code fallback in `_apply_rustc_wrapper` — no more workflow references
- [ ] CI must re-validate `_lint`, `_unit-test`, `_build`, `_integration-test` workflows hit zccache cache hits (visible in soldr session log)

## Related

- #72 / PR #77 — original migration that surfaced the slow-build pain
- #76 / PR #78 — retired `_cargo` trampolines, added the PreToolUse hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
