### PR TITLE
build: drop sccache fallback; zccache is the only compile cache

### DIFF
--- a/ci/env.py
+++ b/ci/env.py
@@ -166,20 +166,18 @@ def activate() -> None:
 
 
 def _apply_rustc_wrapper(env: dict[str, str]) -> dict[str, str]:
-    """Set RUSTC_WRAPPER to zccache when available, falling back to sccache.
+    """Set RUSTC_WRAPPER to zccache when available.
 
-    The project uses zccache (via soldr) for compile caching. Prefer it; fall
-    back to sccache for environments where only that is installed. Bare cargo
-    invocations that consume this env still benefit from the cache even though
-    most callers in this repo now route through ``soldr cargo`` directly.
+    The project uses zccache (via soldr) for compile caching. Bare cargo
+    invocations that consume this env still benefit from the cache even
+    though most callers in this repo route through ``soldr cargo`` directly
+    (which manages the wrapper itself).
     """
     if env.get("RUSTC_WRAPPER"):
         return env
-    for tool in ("zccache", "sccache"):
-        found = shutil.which(tool, path=env.get("PATH"))
-        if found:
-            env["RUSTC_WRAPPER"] = found
-            return env
+    found = shutil.which("zccache", path=env.get("PATH"))
+    if found:
+        env["RUSTC_WRAPPER"] = found
     return env
 
 


### PR DESCRIPTION
## Summary

Drop the residual sccache fallback in `ci/env.py::_apply_rustc_wrapper`. Soldr (via zccache) is the project's only compile cache; the sccache half was a leftover from the pre-soldr era and was already redundant once PR #79 closed #75.

After this change, `grep -rn 'sccache\|SCCACHE' .` returns zero hits across the tree.

## Diff

```
 ci/env.py | 18 +++++++-----------
 1 file changed, 8 insertions(+), 10 deletions(-)
```

## Test plan

- [x] `bash lint` — green
- [x] `grep -rn 'sccache\|SCCACHE'` repo-wide returns zero hits

## Related

- #75 (PR #79) — aligned everything on zccache; this is the final mop-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
