### PR TITLE
Migrate pre-tool guard to Codex hooks

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python ci/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/ci/hooks/README.md
+++ b/ci/hooks/README.md
@@ -1,17 +1,19 @@
-# Claude Code hooks
+# Agent hooks
 
-Python scripts invoked by Claude Code hooks (configured in `.claude/settings.json`).
+Python scripts invoked by Claude Code and Codex hooks. Claude Code loads the
+hook config from `.claude/settings.json`; Codex loads the migrated config from
+`.codex/hooks.json`.
 
 All hooks run via `uv run python ci/hooks/<name>.py` so they share the project
 Python environment.
 
 ## Hooks
 
-- `tool_guard.py` — **PreToolUse / Bash**. Blocks bare `cargo`, `rustc`,
+- `tool_guard.py` - **PreToolUse / Bash**. Blocks bare `cargo`, `rustc`,
   `rustfmt`, `clippy-driver`, the `cargo-clippy` / `cargo-fmt` aliases, and the
   legacy `./_cargo`, `./_rustc`, `./_rustfmt` trampolines (retired in #76). All
   Rust tooling must go through `soldr` so zccache is consulted; otherwise cold
-  builds take 8–10 minutes (see #75).
+  builds take 8-10 minutes (see #75).
 
   Also rejects `uv run cargo ...` and friends because `uv run <rust-tool>`
   bypasses soldr's toolchain selection.

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -12,7 +12,7 @@ Blocks invocations that bypass soldr/zccache:
 * ``uv run <rust-tool>``. Bypasses soldr's toolchain selection.
 
 Exit code 0 always; denial signalled via JSON payload on stdout so the
-Claude Code harness reports the reason inline.
+agent harness reports the reason inline.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Add `.codex/hooks.json` with the migrated `PreToolUse` Bash guard from `.claude/settings.json`.
- Keep Claude and Codex hook commands aligned on `uv run --no-project python ci/hooks/tool_guard.py` so the stdlib-only guard does not trigger a project build before every tool call.
- Update hook docs/comments to describe shared Claude Code and Codex usage.

## Test plan
- [x] `python -m json.tool .claude/settings.json`
- [x] `python -m json.tool .codex/hooks.json`
- [x] `uv run --no-project python ci/hooks/tool_guard.py` denies `cargo build`
- [x] `uv run --no-project python ci/hooks/tool_guard.py` allows `soldr cargo build`
- [x] `uv run --no-project python ci/hooks/tool_guard.py` denies `uv run rustfmt src/lib.rs`
- [x] `uv run --no-project python -m py_compile ci/hooks/tool_guard.py`
- [x] `git diff --check`