### PR TITLE
Finish native app migration shims

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -54,25 +54,25 @@ jobs:
 
       - name: Build fastled CLI binary (for wheel bundling)
         run: |
-          # Compile the Rust `fastled` CLI and stage it under wheel-data/scripts/
+          # Compile the Rust `fastled-rs` CLI and stage it under wheel-data/scripts/
           # so maturin packages it into <pkg>-<ver>.data/scripts/ in the wheel.
           # See `build-wheel` and `[tool.maturin] data` in pyproject.toml.
           if [ -n "${{ inputs.maturin-target }}" ]; then
-            soldr cargo build --release --bin fastled --target "${{ inputs.maturin-target }}"
+            soldr cargo build --release --bin fastled-rs --target "${{ inputs.maturin-target }}"
             case "${{ inputs.maturin-target }}" in
-              *windows*) EXE_NAME="fastled.exe" ;;
-              *)         EXE_NAME="fastled" ;;
+              *windows*) EXE_NAME="fastled-rs.exe" ;;
+              *)         EXE_NAME="fastled-rs" ;;
             esac
             BIN_SRC="target/${{ inputs.maturin-target }}/release/${EXE_NAME}"
           else
-            soldr cargo build --release --bin fastled
+            soldr cargo build --release --bin fastled-rs
             case "$(uname -s)" in
-              MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled.exe" ;;
-              *)                    EXE_NAME="fastled" ;;
+              MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled-rs.exe" ;;
+              *)                    EXE_NAME="fastled-rs" ;;
             esac
             # On Windows the rustup default host triple is MSVC; cargo writes
             # the binary under target/<triple>/release/ even without --target.
-            if [ -n "${CARGO_BUILD_TARGET:-}" ] || [ "$EXE_NAME" = "fastled.exe" ]; then
+            if [ -n "${CARGO_BUILD_TARGET:-}" ] || [ "$EXE_NAME" = "fastled-rs.exe" ]; then
               ARCH="$(uname -m)"
               if [ "$ARCH" = "x86_64" ]; then TRIPLE="x86_64-pc-windows-msvc"; else TRIPLE="aarch64-pc-windows-msvc"; fi
               if [ -f "target/${TRIPLE}/release/${EXE_NAME}" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ uv run pytest tests/unit --ignore=tests/unit/test_cli.py -v
 
 ## Common gotchas
 
-- The installed `fastled` CLI on PATH (e.g. `/c/tools/python13/Scripts/fastled.exe`) may be stale; `find_rust_fastled_cli` in `src/fastled/_rust_cli.py` prefers `target/{release,debug}/fastled.exe` over PATH for exactly this reason. If a CLI test fails, check `uv run python -c "from fastled._rust_cli import find_rust_fastled_cli; print(find_rust_fastled_cli())"`.
+- The installed `fastled` CLI on PATH (e.g. `/c/tools/python13/Scripts/fastled.exe`) may be a Python compatibility shim or stale script; the Rust CLI binary is named `fastled-rs[.exe]` during the migration. If a CLI test fails, check `uv run python -c "from fastled._rust_cli import find_rust_fastled_cli; print(find_rust_fastled_cli())"`.
 - Error messages from the Rust CLI go to **stderr**. Tests asserting `result.stdout` for error text should use `result.stdout + result.stderr` (the parse_args.py removal in #72 exposed this).
 - `tasklist` on Windows may report tens of thousands of `python.exe` zombies — most are stale tasklist artifacts, not real processes. `ps -ef | grep python` is more reliable for live ones.
 

--- a/build-wheel
+++ b/build-wheel
@@ -14,16 +14,16 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 # Platform-specific binary name and target directory.
 case "$(uname -s)" in
-  MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled.exe" ;;
-  *)                    EXE_NAME="fastled" ;;
+  MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled-rs.exe" ;;
+  *)                    EXE_NAME="fastled-rs" ;;
 esac
 
 echo "Compiling fastled CLI (release)..."
 if command -v soldr &> /dev/null; then
-  soldr cargo build --release --bin fastled
+  soldr cargo build --release --bin fastled-rs
 else
   echo "Warning: soldr not found; falling back to plain cargo (slow). Install with: uv tool install soldr"
-  cargo build --release --bin fastled
+  cargo build --release --bin fastled-rs
 fi
 
 # Resolve where cargo wrote the binary. cargo on Windows MSVC writes the

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "fastled_cli"
 path = "src/lib.rs"
 
 [[bin]]
-name = "fastled"
+name = "fastled-rs"
 path = "src/main.rs"
 
 [dependencies]
@@ -41,7 +41,7 @@ tempfile = "3"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/fastled-{ target }{ archive-suffix }"
-bin-dir = "fastled{ binary-ext }"
+bin-dir = "fastled-rs{ binary-ext }"
 pkg-fmt = "zip"
 
 [dev-dependencies]

--- a/crates/fastled-cli/src/build.rs
+++ b/crates/fastled-cli/src/build.rs
@@ -1,7 +1,6 @@
 //! Build orchestration for WASM compilation.
 //!
-//! The Rust CLI now drives the Python build service in-process through PyO3
-//! instead of shelling out through `python -m fastled.app`.
+//! The Rust CLI now drives the Python build service in-process through PyO3.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -61,13 +60,6 @@ pub struct BuildRequest {
     pub force_clean: bool,
 }
 
-impl BuildRequest {
-    /// Derive the conventional output directory for this request.
-    pub fn output_dir(&self) -> PathBuf {
-        self.sketch_dir.join("fastled_js")
-    }
-}
-
 /// Mirrors the useful fields returned from `build_types.BuildResult`.
 #[derive(Debug)]
 pub struct BuildResult {
@@ -106,6 +98,65 @@ fn normalize_path(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+fn python_executable_name() -> &'static str {
+    if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python"
+    }
+}
+
+fn python_executable_from_virtual_env() -> Option<PathBuf> {
+    let venv = std::env::var_os("VIRTUAL_ENV")?;
+    let venv = PathBuf::from(venv);
+    let bindir = if cfg!(windows) { "Scripts" } else { "bin" };
+    let candidate = venv.join(bindir).join(python_executable_name());
+    candidate.is_file().then_some(candidate)
+}
+
+fn python_executable_from_path() -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(python_executable_name());
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !cfg!(windows) {
+            let candidate = dir.join("python3");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn resolve_python_executable() -> Option<PathBuf> {
+    std::env::var_os("FASTLED_PYTHON_EXECUTABLE")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .or_else(python_executable_from_virtual_env)
+        .or_else(python_executable_from_path)
+}
+
+fn configure_embedded_python_executable(py: Python<'_>) -> PyResult<()> {
+    let Some(python) = resolve_python_executable() else {
+        return Ok(());
+    };
+    let python = python.to_string_lossy().into_owned();
+    let sys = PyModule::import(py, "sys")?;
+    sys.setattr("executable", python.as_str())?;
+    let _ = sys.setattr("_base_executable", python.as_str());
+
+    let os = PyModule::import(py, "os")?;
+    let environ = os.getattr("environ")?;
+    environ.set_item("PYTHON", python.as_str())?;
+    environ.set_item("EMSDK_PYTHON", python.as_str())?;
+    std::env::set_var("PYTHON", python.as_str());
+    std::env::set_var("EMSDK_PYTHON", python.as_str());
+    Ok(())
+}
+
 /// Canonicalize a sketch/`fastled_path` so the toolchain key registered with
 /// `NativeBuildService.register_toolchain` matches the key passed into
 /// `NativeBuildService.build` — mirrors `_toolchain_key` in
@@ -135,6 +186,8 @@ fn run_build_embedded(request: &BuildRequest) -> Result<BuildResult> {
     Python::with_gil(|py| -> Result<BuildResult> {
         ensure_workspace_src_on_sys_path(py)
             .context("failed to add workspace Python sources to sys.path")?;
+        configure_embedded_python_executable(py)
+            .context("failed to configure embedded Python executable")?;
 
         let native_mod =
             PyModule::import(py, "fastled._native").context("import fastled._native")?;
@@ -256,84 +309,19 @@ fn run_build_embedded(request: &BuildRequest) -> Result<BuildResult> {
     })
 }
 
-fn run_build_subprocess(request: &BuildRequest, reason: &str) -> Result<BuildResult> {
-    use std::process::Command;
-
-    let python = if Command::new("python")
-        .args(["--version"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-    {
-        "python"
-    } else {
-        "python3"
-    };
-
-    let output_dir = request.output_dir();
-    let mut cmd = Command::new(python);
-    cmd.args(["-m", "fastled.app", "--just-compile"]);
-    cmd.arg(&request.sketch_dir);
-
-    match request.build_mode {
-        BuildMode::Quick => {}
-        BuildMode::Debug => {
-            cmd.arg("--debug");
-        }
-        BuildMode::Release => {
-            cmd.arg("--release");
-        }
-    }
-
-    if request.profile {
-        cmd.arg("--profile");
-    }
-    if let Some(fp) = &request.fastled_path {
-        cmd.arg("--fastled-path");
-        cmd.arg(fp);
-    }
-    if request.force_clean {
-        cmd.arg("--purge");
-    }
-
-    eprintln!("fastled: falling back to subprocess build path: {reason}");
-    let start = Instant::now();
-    let output = cmd
-        .output()
-        .with_context(|| format!("failed to launch `{python} -m fastled.app`"))?;
-    let duration_secs = start.elapsed().as_secs_f64();
-
-    let combined = {
-        let mut s = String::new();
-        s.push_str(&String::from_utf8_lossy(&output.stdout));
-        if !output.stderr.is_empty() {
-            s.push('\n');
-            s.push_str(&String::from_utf8_lossy(&output.stderr));
-        }
-        s
-    };
-
-    Ok(BuildResult {
-        success: output.status.success(),
-        output_dir,
-        duration_secs,
-        sketch_time_secs: duration_secs,
-        strategy: "unknown".to_string(),
-        output: combined,
-    })
-}
-
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Run a WASM build through the Python build service without the legacy
-/// `fastled.app` CLI trampoline.
+/// Run a WASM build through the in-process Python build service.
 pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
-    match run_build_embedded(request) {
-        Ok(result) => Ok(result),
-        Err(err) => run_build_subprocess(request, &format!("{err:#}")),
-    }
+    run_build_embedded(request).with_context(|| {
+        format!(
+            "native build failed for sketch `{}` in {} mode",
+            request.sketch_dir.display(),
+            request.build_mode
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -396,20 +384,6 @@ mod tests {
         assert!(!req.profile);
         assert!(req.fastled_path.is_none());
         assert!(!req.force_clean);
-    }
-
-    #[test]
-    fn test_build_request_output_dir() {
-        let sketch = PathBuf::from("/tmp/my_sketch");
-        let req = BuildRequest {
-            sketch_dir: sketch.clone(),
-            build_mode: BuildMode::Debug,
-            profile: false,
-            fastled_path: None,
-            force_clean: false,
-        };
-
-        assert_eq!(req.output_dir(), sketch.join("fastled_js"));
     }
 
     #[test]

--- a/install
+++ b/install
@@ -23,7 +23,7 @@ uv pip install "maturin>=1.7,<2"
 # `[tool.maturin] data = "wheel-data"` config points here; maturin treats a
 # missing path as an error during `pep517 build-wheel`. The cargo-build step
 # later in this script will populate `wheel-data/scripts/` with the Rust
-# fastled binary so subsequent `./build-wheel` invocations bundle it; an
+# fastled-rs binary so subsequent `./build-wheel` invocations bundle it; an
 # empty dir is fine for the editable-install path that pip is about to run.
 mkdir -p wheel-data/scripts
 
@@ -104,22 +104,22 @@ if command -v cargo-binstall &> /dev/null; then
   fi
 fi
 
-# Ensure the Rust `fastled` CLI binary is materialised somewhere our Python
+# Ensure the Rust `fastled-rs` CLI binary is materialised somewhere our Python
 # helpers (src/fastled/_rust_cli.py) can find it. The Python `[project.scripts]`
-# entry-point shim collides with the Rust binary's name on PATH, so the helper
-# explicitly looks in target/{release,debug}/ and $CARGO_HOME/bin. If
+# entry-point shim owns the user-facing `fastled` command during the migration,
+# while the Rust binary uses a distinct `fastled-rs` name. If
 # cargo-binstall didn't supply a pre-built copy, build from source so unit
 # tests and the deploy workflow can subprocess the binary for the internal
 # auto-install plumbing flags (--internal-ensure-fastled-repo, etc.).
 if [[ "$FASTLED_CLI_BINSTALLED" -eq 0 ]]; then
   echo "Building fastled CLI from source..."
   if command -v soldr &> /dev/null; then
-    soldr cargo build --release --bin fastled \
-      || { echo "Error: soldr cargo build --bin fastled failed"; exit 1; }
+    soldr cargo build --release --bin fastled-rs \
+      || { echo "Error: soldr cargo build --bin fastled-rs failed"; exit 1; }
   else
     echo "Warning: soldr not found; falling back to plain cargo (slow). Install with: uv tool install soldr"
-    cargo build --release --bin fastled \
-      || { echo "Error: cargo build --bin fastled failed"; exit 1; }
+    cargo build --release --bin fastled-rs \
+      || { echo "Error: cargo build --bin fastled-rs failed"; exit 1; }
   fi
 fi
 
@@ -127,16 +127,15 @@ fi
 # downstream tooling will find it. Editable installs (`uv pip install -e .`)
 # don't extract the maturin `data` dir to the venv's Scripts/, so we mimic
 # the wheel-install layout manually:
-#   * `.venv/Scripts/fastled[.exe]` (or `.venv/bin/fastled`) — so PATH lookup
-#     resolves the Rust binary for callers like `build_site.py` that shell
-#     out to plain `fastled`.
-#   * `wheel-data/scripts/fastled[.exe]` — so a subsequent `./build-wheel`
+#   * `.venv/Scripts/fastled-rs[.exe]` (or `.venv/bin/fastled-rs`) so the
+#     Python `fastled` compatibility shim can find the Rust binary.
+#   * `wheel-data/scripts/fastled-rs[.exe]` so a subsequent `./build-wheel`
 #     produces a wheel that bundles the binary.
 if [[ "$OSTYPE" == "msys" ]]; then
-  EXE_NAME="fastled.exe"
+  EXE_NAME="fastled-rs.exe"
   VENV_BIN_DIR=".venv/Scripts"
 else
-  EXE_NAME="fastled"
+  EXE_NAME="fastled-rs"
   VENV_BIN_DIR=".venv/bin"
 fi
 
@@ -161,5 +160,5 @@ if [[ -n "$BIN_SRC" ]]; then
   cp -f "$BIN_SRC" "wheel-data/scripts/$EXE_NAME"
   echo "Staged $BIN_SRC -> $VENV_BIN_DIR/$EXE_NAME (and wheel-data/scripts/)"
 else
-  echo "Warning: Rust fastled binary not found; PATH lookups for 'fastled' will miss" >&2
+  echo "Warning: Rust fastled-rs binary not found; Python fastled shims will fail" >&2
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ features = ["pyo3/extension-module", "pyo3/abi3-py310"]
 # Pre-built Rust binaries get dropped into wheel-data/scripts/ by the
 # build-wheel helper before maturin runs. maturin packages this directory as
 # the wheel's <pkg>-<ver>.data/ tree; pip then extracts scripts/ to the
-# venv's Scripts/ (Windows) or bin/ (Unix) at install time, so end users get
-# the Rust `fastled` binary directly — no Python entry-point shim, no
-# cargo build at install time.
+# venv's Scripts/ (Windows) or bin/ (Unix) at install time, so the Python
+# compatibility shim can launch the Rust `fastled-rs` binary without a cargo
+# build at runtime.
 data = "wheel-data"
 
 [tool.ruff]
@@ -71,10 +71,9 @@ ignore_missing_imports = true
 disable_error_code = ["import-untyped"]
 
 [project.scripts]
-# `fastled` is intentionally NOT a Python entry-point; the Rust binary is
-# bundled into the wheel via [tool.maturin] data (see above) and pip
-# installs it directly to the venv's Scripts/bin directory. The Python
-# aliases below are kept as thin shims for the rarely-used `python -m`
-# invocation paths.
+# `fastled` remains a Python compatibility entry point during the migration.
+# It resolves and execs the Rust binary under the distinct `fastled-rs` name
+# so the shim cannot recursively find itself on PATH.
+fastled = "fastled.cli:main"
 fastled-wasm = "fastled.cli:main"
 fled = "fastled.cli:main"

--- a/src/fastled/_rust_cli.py
+++ b/src/fastled/_rust_cli.py
@@ -1,15 +1,15 @@
-"""Locate the Rust ``fastled`` binary.
+"""Locate the Rust ``fastled-rs`` binary.
 
 In wheel-installed deployments the Rust binary is bundled directly into the
 venv's ``Scripts/`` / ``bin/`` directory via ``[tool.maturin] data`` (see
-``pyproject.toml``), so ``shutil.which(\"fastled\")`` returns it. In editable
+``pyproject.toml``), so ``shutil.which(\"fastled-rs\")`` returns it. In editable
 dev installs the Rust binary lives under ``target/`` from a local
-``cargo build --bin fastled``.
+``cargo build --bin fastled-rs``.
 
 Search order:
-    1. Workspace ``target/{release,debug}/fastled[.exe]`` (dev / editable).
-    2. ``$CARGO_HOME/bin/fastled[.exe]`` (where ``cargo binstall`` installs).
-    3. ``shutil.which(\"fastled\")`` (wheel install puts it on ``PATH``).
+    1. Workspace ``target/{release,debug}/fastled-rs[.exe]`` (dev / editable).
+    2. ``$CARGO_HOME/bin/fastled-rs[.exe]`` (where ``cargo binstall`` installs).
+    3. ``shutil.which(\"fastled-rs\")`` (wheel install puts it on ``PATH``).
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from pathlib import Path
 
 
 def _exe_name() -> str:
-    return "fastled.exe" if sys.platform == "win32" else "fastled"
+    return "fastled-rs.exe" if sys.platform == "win32" else "fastled-rs"
 
 
 def _find_workspace_root() -> Path | None:
@@ -38,7 +38,7 @@ def _find_workspace_root() -> Path | None:
 
 
 def find_rust_fastled_cli() -> Path | None:
-    """Return the path to the Rust ``fastled`` binary, or ``None``."""
+    """Return the path to the Rust ``fastled-rs`` binary, or ``None``."""
     exe = _exe_name()
 
     # 1. Workspace target/ tree (dev / editable).
@@ -68,9 +68,8 @@ def find_rust_fastled_cli() -> Path | None:
         return candidate
 
     # 3. Wheel install drops the Rust binary directly into the venv's
-    # Scripts/bin dir; there is no Python `fastled` entry-point shim
-    # competing for the name anymore (see pyproject.toml). Plain PATH lookup
-    # finds it.
+    # Scripts/bin dir under the distinct fastled-rs name, so a Python
+    # `fastled` compatibility shim cannot resolve itself here.
     found = shutil.which(exe)
     if found:
         return Path(found)
@@ -80,16 +79,22 @@ def find_rust_fastled_cli() -> Path | None:
 def invoke_rust_fastled_cli(argv: list[str] | None = None) -> int:
     """Run the Rust FastLED CLI and return its exit code."""
     args = list(argv or [])
+    env = os.environ.copy()
+    env.setdefault("FASTLED_PYTHON_EXECUTABLE", sys.executable)
+
     cli = find_rust_fastled_cli()
     if cli is not None:
-        return subprocess.run([str(cli), *args], check=False).returncode
+        return subprocess.run([str(cli), *args], check=False, env=env).returncode
 
     workspace_root = _find_workspace_root()
     if workspace_root is not None:
+        soldr = shutil.which("soldr")
+        cargo = [soldr, "cargo"] if soldr else ["cargo"]
         return subprocess.run(
-            ["cargo", "run", "--quiet", "--bin", "fastled", "--", *args],
+            [*cargo, "run", "--quiet", "--bin", "fastled-rs", "--", *args],
             check=False,
             cwd=workspace_root,
+            env=env,
         ).returncode
 
-    raise RuntimeError("Could not locate the Rust fastled CLI binary.")
+    raise RuntimeError("Could not locate the Rust fastled-rs CLI binary.")

--- a/src/fastled/build_service.py
+++ b/src/fastled/build_service.py
@@ -1,3 +1,10 @@
+"""Compatibility build-service facade backed by the native Rust service.
+
+This module preserves the Python ``BuildService`` API for callers that still
+import it directly. Build orchestration is owned by ``NativeBuildService``;
+Python only adapts request/result types and registers compiler toolchains.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/fastled/build_types.py
+++ b/src/fastled/build_types.py
@@ -1,3 +1,9 @@
+"""Python request/result DTOs for the native build service wrapper.
+
+These dataclasses are part of the public Python compatibility surface. They do
+not own build orchestration or fallback service behavior.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/fastled/open_browser.py
+++ b/src/fastled/open_browser.py
@@ -1,3 +1,9 @@
+"""Compatibility process launcher for the native Rust HTTP server.
+
+The Rust CLI owns server startup and viewer launch. Python keeps this module as
+an API-compatible subprocess wrapper for existing callers.
+"""
+
 import atexit
 import subprocess
 import time
@@ -73,7 +79,7 @@ def spawn_http_server(
 
     if actual_port is None:
         # The Rust CLI prints its listening URL once the socket is bound, so the
-        # URL parse above already gates "server is up". Only the fallback path
+        # URL parse above already gates "server is up". Only the unknown-port path
         # (URL line not seen yet) needs a small grace period.
         time.sleep(1.0)
 

--- a/src/fastled/playwright/playwright_browser.py
+++ b/src/fastled/playwright/playwright_browser.py
@@ -258,14 +258,16 @@ class PlaywrightBrowser:
             if self.enable_extensions and self._extensions_dir:
                 try:
                     # Check if the extension is available in the DevTools
-                    extensions_available = await self.page.evaluate("""
+                    extensions_available = await self.page.evaluate(
+                        """
                         () => {
                             // Check if chrome.devtools is available (extension context)
                             return typeof chrome !== 'undefined' && 
                                    typeof chrome.runtime !== 'undefined' &&
                                    chrome.runtime.id !== undefined;
                         }
-                    """)
+                    """
+                    )
 
                     if extensions_available:
                         print(

--- a/src/fastled/playwright/resize_tracking.py
+++ b/src/fastled/playwright/resize_tracking.py
@@ -32,7 +32,8 @@ class ResizeTracker:
             return None
 
         try:
-            return await self.page.evaluate("""
+            return await self.page.evaluate(
+                """
                 () => {
                     return {
                         outerWidth: window.outerWidth,
@@ -43,7 +44,8 @@ class ResizeTracker:
                         contentHeight: document.documentElement.clientHeight
                     };
                 }
-                """)
+                """
+            )
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
         except Exception:

--- a/src/fastled/project_init.py
+++ b/src/fastled/project_init.py
@@ -1,3 +1,10 @@
+"""Compatibility project-init helpers backed by native Rust operations.
+
+Python keeps the prompt/API surface and local-repo detection glue. Repository
+download, example discovery, and project materialization are delegated to
+``fastled._native`` helpers.
+"""
+
 import os
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/fastled/select_sketch_directory.py
+++ b/src/fastled/select_sketch_directory.py
@@ -1,3 +1,9 @@
+"""Compatibility prompt helpers backed by native Rust matching logic.
+
+Python owns the interactive prompt loop for existing callers. Sketch selection
+preparation and choice resolution are delegated to ``fastled._native``.
+"""
+
 from pathlib import Path
 from typing import Callable, TypeVar, Union
 

--- a/src/fastled/sketch.py
+++ b/src/fastled/sketch.py
@@ -6,7 +6,7 @@ This module is a thin Python wrapper around the native Rust implementation in
 * normalize ``Path``-vs-``str`` inputs for callers, and
 * return ``pathlib.Path`` instances rather than strings.
 
-There is no longer a Python fallback — the native extension is the
+There is no longer a Python fallback; the native extension is the
 authoritative implementation. Stream A of the Rust orchestration migration
 deliberately removed all Python-side fallback code paths.
 """

--- a/src/fastled/string_diff.py
+++ b/src/fastled/string_diff.py
@@ -1,3 +1,5 @@
+"""Compatibility wrappers for native string matching helpers."""
+
 from pathlib import Path
 
 from fastled._native import is_in_order_match, string_diff

--- a/tests/integration/test_animartrix_e2e.py
+++ b/tests/integration/test_animartrix_e2e.py
@@ -20,6 +20,8 @@ import pytest  # type: ignore[reportMissingImports]
 from playwright.async_api import async_playwright  # type: ignore[reportMissingImports]
 
 from fastled import Test
+from fastled._rust_cli import find_rust_fastled_cli
+from fastled.interrupts import handle_keyboard_interrupt
 
 ANIMARTRIX_DIR = Path.home() / "dev" / "fastled" / "examples" / "Animartrix"
 FASTLED_JS_DIR = ANIMARTRIX_DIR / "fastled_js"
@@ -41,9 +43,11 @@ class AnimartrixE2ETest(unittest.TestCase):
         original_dir = os.getcwd()
         try:
             os.chdir(str(ANIMARTRIX_DIR))
+            cli = find_rust_fastled_cli()
+            if cli is None:
+                self.skipTest("Rust fastled-rs CLI binary not found")
             cp = subprocess.run(
-                "fastled --just-compile",
-                shell=True,
+                [str(cli), "--just-compile"],
                 capture_output=True,
                 check=False,
                 timeout=300,
@@ -55,6 +59,9 @@ class AnimartrixE2ETest(unittest.TestCase):
                     f"Compilation failed (rc={cp.returncode}):\n"
                     f"stdout:\n{stdout}\nstderr:\n{stderr}"
                 )
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
         finally:
             os.chdir(original_dir)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,6 +9,9 @@ from pathlib import Path
 
 import pytest  # type: ignore[reportMissingImports]
 
+from fastled._rust_cli import find_rust_fastled_cli
+from fastled.interrupts import handle_keyboard_interrupt
+
 HERE = Path(__file__).parent
 TEST_DIR = HERE / "test_ino" / "wasm"
 
@@ -26,14 +29,20 @@ class MainTester(unittest.TestCase):
         original_dir = os.getcwd()
         try:
             os.chdir(str(TEST_DIR))
-            cp: subprocess.CompletedProcess = subprocess.run(
-                "fastled --just-compile",
-                shell=True,
+            cli = find_rust_fastled_cli()
+            if cli is None:
+                self.skipTest("Rust fastled-rs CLI binary not found")
+            cp: subprocess.CompletedProcess[bytes] = subprocess.run(
+                [str(cli), "--just-compile"],
                 check=False,
+                timeout=300,
             )
             ok = cp.returncode == 0
             if not ok:
                 self.fail(f"Command failed with return code {cp.returncode}")
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
         finally:
             os.chdir(original_dir)
 

--- a/tests/unit/test_http_server.py
+++ b/tests/unit/test_http_server.py
@@ -20,13 +20,12 @@ from fastled.interrupts import handle_keyboard_interrupt
 
 
 def _find_rust_cli() -> Path | None:
-    """Locate the *Rust* fastled CLI binary (not the Python shim).
+    """Locate the *Rust* fastled-rs CLI binary.
 
-    The Rust binary handles ``--serve-dir`` natively.  To distinguish it
-    from the Python entry-point shim (which is also called ``fastled.exe``),
-    we run a quick ``--serve-dir`` probe on any candidate before accepting it.
+    The Rust binary handles ``--serve-dir`` natively.  It uses the distinct
+    ``fastled-rs`` name during the Python compatibility-shim migration.
     """
-    exe_name = "fastled.exe" if sys.platform == "win32" else "fastled"
+    exe_name = "fastled-rs.exe" if sys.platform == "win32" else "fastled-rs"
 
     candidates: list[Path] = []
 

--- a/tests/unit/test_post_migration.py
+++ b/tests/unit/test_post_migration.py
@@ -1,9 +1,19 @@
 """Tests for post-migration cleanup: dead code removal, stale exports, and bug fixes."""
 
+import ast
 import unittest
 from pathlib import Path
 
-SRC_DIR = Path(__file__).parent.parent.parent / "src" / "fastled"
+ROOT_DIR = Path(__file__).parent.parent.parent
+SRC_DIR = ROOT_DIR / "src" / "fastled"
+FASTLED_CLI_SRC_DIR = ROOT_DIR / "crates" / "fastled-cli" / "src"
+
+
+def _implementation_source(path: Path) -> str:
+    lines = path.read_text().splitlines()
+    return "\n".join(
+        line for line in lines if not line.lstrip().startswith(("#", "//", "//!"))
+    )
 
 
 class TestPythonEntrypointsDelegateToRust(unittest.TestCase):
@@ -17,9 +27,81 @@ class TestPythonEntrypointsDelegateToRust(unittest.TestCase):
         source = (SRC_DIR / "app.py").read_text()
         self.assertIn("invoke_rust_fastled_cli", source)
 
+    def test_primary_runtime_has_no_fastled_app_module_fallback(self) -> None:
+        runtime_files = [
+            SRC_DIR / "app.py",
+            SRC_DIR / "cli.py",
+            SRC_DIR / "_rust_cli.py",
+            SRC_DIR / "open_browser.py",
+            *FASTLED_CLI_SRC_DIR.glob("*.rs"),
+        ]
+
+        fallback_patterns = [
+            "python -m fastled.app",
+            '"-m", "fastled.app"',
+            "'-m', 'fastled.app'",
+            '"-m",\n        "fastled.app"',
+            "'-m',\n        'fastled.app'",
+        ]
+
+        for path in runtime_files:
+            source = _implementation_source(path)
+            for pattern in fallback_patterns:
+                self.assertNotIn(
+                    pattern,
+                    source,
+                    f"{path.relative_to(ROOT_DIR)} must not invoke the old Python app fallback",
+                )
+
+    def test_rust_cli_binary_uses_distinct_migration_name(self) -> None:
+        cli_source = (SRC_DIR / "_rust_cli.py").read_text()
+        cargo_manifest = ROOT_DIR / "crates" / "fastled-cli" / "Cargo.toml"
+        self.assertIn("fastled-rs", cli_source)
+        self.assertIn('name = "fastled-rs"', cargo_manifest.read_text())
+
+    def test_python_fastled_shim_cannot_resolve_itself_on_path(self) -> None:
+        cli_source = _implementation_source(SRC_DIR / "_rust_cli.py")
+        self.assertNotIn('shutil.which("fastled")', cli_source)
+        self.assertNotIn('"fastled.exe"', cli_source)
+        self.assertIn('"fastled-rs.exe"', cli_source)
+        self.assertIn("shutil.which(exe)", cli_source)
+        self.assertIn("FASTLED_PYTHON_EXECUTABLE", cli_source)
+
+    def test_embedded_python_uses_real_python_executable(self) -> None:
+        build_source = (FASTLED_CLI_SRC_DIR / "build.rs").read_text()
+        self.assertIn("configure_embedded_python_executable", build_source)
+        self.assertIn("FASTLED_PYTHON_EXECUTABLE", build_source)
+        self.assertIn("EMSDK_PYTHON", build_source)
+
 
 class TestNativeAppOrchestration(unittest.TestCase):
     """App-layer compatibility modules should prefer native Rust behavior."""
+
+    COMPATIBILITY_MODULES = {
+        "build_service.py": "Compatibility build-service facade backed by the native Rust service.",
+        "build_types.py": "Python request/result DTOs for the native build service wrapper.",
+        "frontend_esbuild.py": "Compatibility shim. Frontend bundling is implemented in Rust.",
+        "open_browser.py": "Compatibility process launcher for the native Rust HTTP server.",
+        "project_init.py": "Compatibility project-init helpers backed by native Rust operations.",
+        "select_sketch_directory.py": "Compatibility prompt helpers backed by native Rust matching logic.",
+        "sketch.py": "Sketch detection helpers.",
+        "string_diff.py": "Compatibility wrappers for native string matching helpers.",
+    }
+
+    WRAPPER_MODULES_WITH_NATIVE_DELEGATES = [
+        "build_service.py",
+        "frontend_esbuild.py",
+        "open_browser.py",
+        "project_init.py",
+        "select_sketch_directory.py",
+        "sketch.py",
+        "string_diff.py",
+    ]
+
+    EXPLICIT_PYTHON_HOLDOUTS = [
+        "build_types.py",
+        "select_sketch_directory.py",
+    ]
 
     def test_select_sketch_directory_uses_native_resolver(self) -> None:
         source = (SRC_DIR / "select_sketch_directory.py").read_text()
@@ -32,6 +114,48 @@ class TestNativeAppOrchestration(unittest.TestCase):
         self.assertIn("from fastled._native import NativeBuildService", source)
         self.assertNotIn("class _PythonBuildService", source)
         self.assertNotIn("if self._native is None", source)
+        self.assertNotIn("python -m fastled.app", source)
+
+    def test_remaining_python_modules_document_wrapper_or_holdout_role(self) -> None:
+        for filename, expected_summary in self.COMPATIBILITY_MODULES.items():
+            module = ast.parse((SRC_DIR / filename).read_text())
+            docstring = ast.get_docstring(module)
+            if docstring is None:
+                self.fail(
+                    f"{filename} should document its post-migration compatibility role"
+                )
+            self.assertEqual(
+                docstring.splitlines()[0],
+                expected_summary,
+                f"{filename} should document its post-migration compatibility role",
+            )
+
+    def test_remaining_python_wrappers_delegate_to_native_helpers(self) -> None:
+        for filename in self.WRAPPER_MODULES_WITH_NATIVE_DELEGATES:
+            source = (SRC_DIR / filename).read_text()
+            self.assertIn(
+                "fastled._native",
+                source,
+                f"{filename} should delegate core behavior to native helpers",
+            )
+
+    def test_remaining_python_holdouts_are_not_fallback_service_owners(self) -> None:
+        service_owner_markers = [
+            "class _PythonBuildService",
+            "class BuildService",
+            "def build(",
+            "NativeBuildService",
+            "python -m fastled.app",
+        ]
+
+        for filename in self.EXPLICIT_PYTHON_HOLDOUTS:
+            source = (SRC_DIR / filename).read_text()
+            for marker in service_owner_markers:
+                self.assertNotIn(
+                    marker,
+                    source,
+                    f"{filename} is a compatibility holdout, not a fallback service owner",
+                )
 
     def test_types_do_not_import_legacy_args_at_runtime(self) -> None:
         source = (SRC_DIR / "types.py").read_text()


### PR DESCRIPTION
Closes #72

## Summary
- Renames the Rust CLI binary to `fastled-rs[.exe]` during the migration while restoring `fastled` as the Python compatibility entry point.
- Removes the Rust build fallback to `python -m fastled.app`; native build failures now surface directly.
- Prevents Python shim recursion by resolving only `fastled-rs`, and passes a real Python executable into embedded PyO3 builds so Emscripten helpers do not invoke `fastled-rs.exe` as Python.
- Documents remaining Python wrapper/holdout modules and adds regression tests for the native-first app path.
- Updates issue #72 with the directive to promote `fastled-rs[.exe]` back to `fastled[.exe]` once the migration is complete.

## Parallel agent work
- Build bridge stream removed the subprocess fallback and tightened Rust build behavior.
- Python wrapper stream documented compatibility/holdout modules and added post-migration assertions.
- CLI packaging stream renamed the Rust binary and updated wheel/install/CI staging.

## Test plan
- [x] `bash lint`
- [x] `bash test`
- [x] `uv run pytest -q -s tests/unit/test_cli.py::MainTester::test_command`
- [x] `uv run fastled --version`
- [x] `tasklist /FI "IMAGENAME eq fastled.exe" /NH`
- [x] `tasklist /FI "IMAGENAME eq fastled-rs.exe" /NH`