### PR TITLE
ci: stabilize post-cli-only workflows

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -35,6 +35,7 @@ jobs:
         with:
           cache: true
           cache-key-suffix: build-${{ inputs.runs-on }}-${{ github.workflow }}
+          linker: platform-default
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -32,6 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
+          linker: platform-default
           # Include github.workflow because some callers (e.g. Windows
           # x86/ARM) currently share the same runs-on. Without this they
           # collide on the same cache key and one job fails to save.

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -30,6 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
+          linker: platform-default
           # Include github.workflow because some callers (e.g. Windows
           # x86/ARM) currently share the same runs-on. Without this they
           # collide on the same cache key and one job fails to save.

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -32,6 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           cache: true
+          linker: platform-default
           # Include github.workflow because some callers (e.g. Windows
           # x86/ARM) currently share the same runs-on. Without this they
           # collide on the same cache key and one job fails to save.

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -43,8 +43,13 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git tag -a "v${{ steps.version_check.outputs.current }}" -m "Release v${{ steps.version_check.outputs.current }}"
-        git push origin "v${{ steps.version_check.outputs.current }}"
+        TAG="v${{ steps.version_check.outputs.current }}"
+        if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+          echo "Tag ${TAG} already exists; continuing release workflow."
+        else
+          git tag -a "${TAG}" -m "Release ${{ steps.version_check.outputs.current }}"
+          git push origin "${TAG}"
+        fi
 
   build-executables:
     needs: [create-tag]
@@ -69,7 +74,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.11.9'
 
     - name: Install UV
       run: pip install uv
@@ -169,7 +174,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11.9'
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -181,6 +186,7 @@ jobs:
         with:
           cache: true
           cache-key-suffix: publish-pypi
+          linker: platform-default
 
       - name: Install system dependencies (Linux)
         run: |


### PR DESCRIPTION
Refs #91.

## Summary
- pins GitHub Actions Python setup to `3.11.9` so ARM runners stop resolving the transient/missing floating `3.11` artifact
- sets `linker: platform-default` for `zackees/setup-soldr@v0` so macOS jobs do not receive `-fuse-ld=lld` from `SOLDR_LINKER=fast`
- makes the release tag step idempotent when `v<version>` already exists remotely

## Failing logs investigated
- PR #91 macOS build/unit/integration failed while linking build scripts with `clang: error: invalid linker name in argument '-fuse-ld=lld'`
- PR #91 Linux ARM integration failed in `actions/setup-python` with a 404 while resolving floating Python `3.11`
- main `Publish Release` failed because pushing `v2.0.7` was rejected when the tag already existed

## Verification
- `git diff --check`
- parsed all `.github/workflows/*.yml` with PyYAML