### PR TITLE
ci: use uv-managed Python in actions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11.9"
-
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          python-version: "3.11.9"
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11.9"
-
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          python-version: "3.11.9"
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11.9"
-
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          python-version: "3.11.9"
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11.9"
-
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          python-version: "3.11.9"
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -72,12 +72,13 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v5
       with:
+        enable-cache: true
         python-version: '3.11.9'
 
-    - name: Install UV
-      run: pip install uv
+    - name: Install Python
+      run: uv python install "$UV_PYTHON"
 
     - name: Install dependencies  
       run: ./install
@@ -171,14 +172,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.9'
-
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          python-version: '3.11.9'
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
 
       - uses: zackees/setup-soldr@v0
         env:

--- a/install
+++ b/install
@@ -16,7 +16,7 @@ if ! command -v uv &> /dev/null; then
   fi
 fi
 
-uv venv --python 3.11 --seed
+uv venv --python "${UV_PYTHON:-3.11}" --seed
 uv pip install "build>=1" "setuptools>=69" "wheel>=0.43"
 uv pip install -r requirements.testing.txt
 


### PR DESCRIPTION
## Summary
- remove `actions/setup-python` from reusable CI workflows and release workflows
- configure `astral-sh/setup-uv@v5` with `python-version: 3.11.9`
- install the pinned interpreter through `uv python install $UV_PYTHON`
- make `./install` honor `UV_PYTHON` instead of forcing floating `3.11`

## Verification
- `git diff --check`
- `bash -n install build-wheel lint test`
- parsed all `.github/workflows/*.yml` with PyYAML
- confirmed `.github/workflows` no longer references `actions/setup-python`