### PR TITLE
feat: use fastled as native binary

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -49,19 +49,19 @@ jobs:
       - name: Build fastled CLI binary (for wheel bundling)
         run: |
           if [ -n "${{ inputs.rust-target }}" ]; then
-            soldr cargo build --release --bin fastled-rs --target "${{ inputs.rust-target }}"
+            soldr cargo build --release --bin fastled --target "${{ inputs.rust-target }}"
             case "${{ inputs.rust-target }}" in
-              *windows*) EXE_NAME="fastled-rs.exe" ;;
-              *)         EXE_NAME="fastled-rs" ;;
+              *windows*) EXE_NAME="fastled.exe" ;;
+              *)         EXE_NAME="fastled" ;;
             esac
             BIN_SRC="target/${{ inputs.rust-target }}/release/${EXE_NAME}"
           else
-            soldr cargo build --release --bin fastled-rs
+            soldr cargo build --release --bin fastled
             case "$(uname -s)" in
-              MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled-rs.exe" ;;
-              *)                    EXE_NAME="fastled-rs" ;;
+              MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled.exe" ;;
+              *)                    EXE_NAME="fastled" ;;
             esac
-            if [ -n "${CARGO_BUILD_TARGET:-}" ] || [ "$EXE_NAME" = "fastled-rs.exe" ]; then
+            if [ -n "${CARGO_BUILD_TARGET:-}" ] || [ "$EXE_NAME" = "fastled.exe" ]; then
               ARCH="$(uname -m)"
               if [ "$ARCH" = "x86_64" ]; then TRIPLE="x86_64-pc-windows-msvc"; else TRIPLE="aarch64-pc-windows-msvc"; fi
               if [ -f "target/${TRIPLE}/release/${EXE_NAME}" ]; then

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -87,12 +87,12 @@ jobs:
     - name: Build executable
       shell: bash
       run: |
-        soldr cargo build --release --bin fastled-rs
+        soldr cargo build --release --bin fastled
         mkdir -p dist
         if [[ "$RUNNER_OS" == "Windows" ]]; then
-          cp target/release/fastled-rs.exe dist/fastled.exe
+          cp target/release/fastled.exe dist/fastled.exe
         else
-          cp target/release/fastled-rs dist/fastled
+          cp target/release/fastled dist/fastled
           chmod +x dist/fastled
         fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Do not pipe pytest through `| tail -N` if you want streaming output; it buffers 
 
 ## Architecture Notes
 
-- The user-facing CLI is the Rust binary `fastled`/`fastled-rs` built from `crates/fastled-cli`.
+- The user-facing CLI is the Rust binary `fastled` built from `crates/fastled-cli`.
 - Python `cli.py` and `app.py` are tiny shims that call `fastled._rust_cli.invoke_rust_fastled_cli`.
 - The Python package intentionally does not ship a PyO3 extension; it bundles and launches the native Rust CLI.
 - The compile path is Rust-owned through `crates/fastled-cli/src/build.rs` and `crates/fastled-cli/src/wasm_build.rs`.
@@ -46,7 +46,7 @@ Do not pipe pytest through `| tail -N` if you want streaming output; it buffers 
 
 ## Common Gotchas
 
-- The installed `fastled` CLI on PATH may be a Python compatibility shim or stale script; during migration the Rust CLI binary is named `fastled-rs[.exe]`.
+- The installed `fastled` CLI on PATH may be a Python compatibility shim or stale script; the bundled native binary is `fastled[.exe]`.
 - Error messages from the Rust CLI go to stderr.
 - On Windows, stale generated binaries under `src/fastled/bin/` are build artifacts and should not be committed.
 

--- a/build-wheel
+++ b/build-wheel
@@ -6,8 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$(uname -s)" in
-  MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled-rs.exe" ;;
-  *)                    EXE_NAME="fastled-rs" ;;
+  MINGW*|MSYS*|CYGWIN*) EXE_NAME="fastled.exe" ;;
+  *)                    EXE_NAME="fastled" ;;
 esac
 
 echo "Compiling fastled CLI (release)..."
@@ -15,7 +15,7 @@ if ! command -v soldr &> /dev/null; then
   echo "Error: soldr is required for Rust builds. Install with: uv tool install soldr" >&2
   exit 1
 fi
-soldr cargo build --release --bin fastled-rs
+soldr cargo build --release --bin fastled
 
 if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
   BIN_SRC="$SCRIPT_DIR/target/${CARGO_BUILD_TARGET}/release/${EXE_NAME}"

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -17,7 +17,7 @@ name = "fastled_cli"
 path = "src/lib.rs"
 
 [[bin]]
-name = "fastled-rs"
+name = "fastled"
 path = "src/main.rs"
 
 [dependencies]
@@ -60,7 +60,7 @@ windows-sys = { workspace = true, features = [
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/fastled-{ target }{ archive-suffix }"
-bin-dir = "fastled-rs{ binary-ext }"
+bin-dir = "fastled{ binary-ext }"
 pkg-fmt = "zip"
 
 [dev-dependencies]

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -945,7 +945,7 @@ fn serve_directory(dir: &str) -> ExitCode {
     })
 }
 
-/// Library entry point invoked by the `fastled-rs` binary.
+/// Library entry point invoked by the `fastled` binary.
 pub fn run() -> ExitCode {
     let mut cli = Cli::parse();
 

--- a/crates/fastled-cli/src/main.rs
+++ b/crates/fastled-cli/src/main.rs
@@ -86,7 +86,7 @@ fn run_internal_viewer(args: InternalViewerArgs) -> ExitCode {
 
     #[cfg(not(feature = "viewer"))]
     {
-        eprintln!("fastled: this fastled-rs binary was built without viewer support");
+        eprintln!("fastled: this fastled binary was built without viewer support");
         ExitCode::FAILURE
     }
 }

--- a/crates/fastled-cli/src/runtime.rs
+++ b/crates/fastled-cli/src/runtime.rs
@@ -31,9 +31,9 @@ const STALE_RUN_SECONDS: u64 = 14 * 24 * 60 * 60;
 const STALE_UPDATE_SECONDS: u64 = 7 * 24 * 60 * 60;
 
 #[cfg(windows)]
-const FASTLED_EXE_NAMES: &[&str] = &["fastled-rs.exe", "fastled.exe"];
+const FASTLED_EXE_NAMES: &[&str] = &["fastled.exe"];
 #[cfg(not(windows))]
-const FASTLED_EXE_NAMES: &[&str] = &["fastled-rs", "fastled"];
+const FASTLED_EXE_NAMES: &[&str] = &["fastled"];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ParsedVersion(Vec<u64>);

--- a/crates/fastled-cli/src/viewer.rs
+++ b/crates/fastled-cli/src/viewer.rs
@@ -1,6 +1,6 @@
 //! Tauri viewer launch utilities.
 //!
-//! The viewer is hosted by this same `fastled-rs` executable. The normal CLI
+//! The viewer is hosted by this same `fastled` executable. The normal CLI
 //! process self-spawns with a hidden `--internal-viewer` flag so packaging only
 //! needs one binary while the Tauri event loop still runs in its own process.
 
@@ -18,9 +18,9 @@ use running_process_core::{ContainedChild, ContainedProcessGroup};
 // ---------------------------------------------------------------------------
 
 #[cfg(windows)]
-const FASTLED_EXE_NAMES: &[&str] = &["fastled-rs.exe", "fastled.exe"];
+const FASTLED_EXE_NAMES: &[&str] = &["fastled.exe"];
 #[cfg(not(windows))]
-const FASTLED_EXE_NAMES: &[&str] = &["fastled-rs", "fastled"];
+const FASTLED_EXE_NAMES: &[&str] = &["fastled"];
 
 // ---------------------------------------------------------------------------
 // Discovery
@@ -29,7 +29,7 @@ const FASTLED_EXE_NAMES: &[&str] = &["fastled-rs", "fastled"];
 /// Search for the FastLED CLI binary that can host the Tauri viewer.
 ///
 /// Search order:
-/// 1. The currently running executable, when it is already `fastled-rs`.
+/// 1. The currently running executable, when it is already `fastled`.
 /// 2. Same directory as the currently running executable.
 /// 3. `target/debug/` and `target/release/` relative to the workspace root
 ///    (detected via the executable path heuristic or `CARGO_MANIFEST_DIR`).
@@ -45,7 +45,7 @@ pub fn find_tauri_viewer() -> Option<PathBuf> {
         }
 
         // 2. Sibling of the running executable. This covers wheel installs
-        // where Python lives in the same Scripts/bin directory as fastled-rs.
+        // where Python lives next to the bundled native fastled binary.
         if let Some(dir) = exe.parent() {
             for name in FASTLED_EXE_NAMES {
                 let candidate = dir.join(name);
@@ -348,7 +348,7 @@ fn spawn_hidden_viewer(binary: &Path, frontend_dir: &Path) -> Result<ViewerProce
 /// Returns a process handle whose lifetime controls the viewer lifetime.
 pub fn launch_tauri_viewer(frontend_dir: &std::path::Path) -> Result<ViewerProcess> {
     let binary =
-        find_tauri_viewer().context("fastled-rs binary not found; cannot launch Tauri viewer")?;
+        find_tauri_viewer().context("fastled binary not found; cannot launch Tauri viewer")?;
 
     #[cfg(windows)]
     {
@@ -465,7 +465,7 @@ mod tests {
     #[test]
     fn test_find_viewer_in_arch_dirs_finds_binary() {
         // Set up a fake target tree:
-        //   <tmp>/target/x86_64-pc-windows-msvc/release/fastled-rs[.exe]
+        //   <tmp>/target/x86_64-pc-windows-msvc/release/fastled[.exe]
         let tmp = TempDir::new().expect("tempdir");
         let target = tmp.path().join("target");
         let arch_dir = target.join("x86_64-pc-windows-msvc").join("release");

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -376,7 +376,7 @@ fn compute_source_file_hash(fastled_dir: &Path) -> Result<String> {
 fn write_native_cross_file(fastled_dir: &Path, tools: &ToolPaths) -> Result<PathBuf> {
     let path = fastled_dir
         .join(".build")
-        .join("fastled-rs-wasm-cross-file.ini");
+        .join("fastled-wasm-cross-file.ini");
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -821,7 +821,7 @@ fn resolve_fastled_dir(request: &BuildRequest) -> Result<(PathBuf, Option<PathBu
     if short_dir == repo {
         return Ok((repo, None));
     }
-    let marker = short_dir.join(".fastled-rs-source");
+    let marker = short_dir.join(".fastled-source");
     let source_key = repo.to_string_lossy().into_owned();
     if short_dir.join("library.json").is_file()
         && fs::read_to_string(&marker).unwrap_or_default() == source_key

--- a/install
+++ b/install
@@ -80,18 +80,16 @@ if command -v cargo-binstall &> /dev/null; then
   fi
 fi
 
-# Ensure the Rust `fastled-rs` CLI binary is materialised somewhere our Python
-# helpers (src/fastled/_rust_cli.py) can find it. The Python `[project.scripts]`
-# entry-point shim owns the user-facing `fastled` command during the migration,
-# while the Rust binary uses a distinct `fastled-rs` name. If
-# cargo-binstall didn't supply a pre-built copy, build from source so unit
+# Ensure the Rust `fastled` CLI binary is materialised somewhere our Python
+# helpers (src/fastled/_rust_cli.py) can find it. If cargo-binstall didn't
+# supply a pre-built copy, build from source so unit
 # tests and the deploy workflow can subprocess the binary for the internal
 # auto-install plumbing flags (--internal-ensure-fastled-repo, etc.).
 if [[ "$FASTLED_CLI_BINSTALLED" -eq 0 ]]; then
   echo "Building fastled CLI from source..."
   if command -v soldr &> /dev/null; then
-    soldr cargo build --release --bin fastled-rs \
-      || { echo "Error: soldr cargo build --bin fastled-rs failed"; exit 1; }
+    soldr cargo build --release --bin fastled \
+      || { echo "Error: soldr cargo build --bin fastled failed"; exit 1; }
   else
     echo "Error: soldr is required for Rust builds. Install with: uv tool install soldr" >&2
     exit 1
@@ -100,17 +98,13 @@ fi
 
 # Locate the just-built (or binstalled) Rust binary and stage it where
 # downstream tooling will find it. Editable installs do not copy package data
-# into the venv's Scripts/bin directory, so we stage both:
-#   * `.venv/Scripts/fastled-rs[.exe]` (or `.venv/bin/fastled-rs`) so the
-#     Python `fastled` compatibility shim can find the Rust binary.
-#   * `src/fastled/bin/fastled-rs[.exe]` so a subsequent `./build-wheel`
-#     produces a wheel that bundles the binary.
+# into the venv's Scripts/bin directory, so stage the package-local binary:
+#   * `src/fastled/bin/fastled[.exe]` so the Python compatibility shim and a
+#     subsequent `./build-wheel` both use the bundled native binary.
 if [[ "$OSTYPE" == "msys" ]]; then
-  EXE_NAME="fastled-rs.exe"
-  VENV_BIN_DIR=".venv/Scripts"
+  EXE_NAME="fastled.exe"
 else
-  EXE_NAME="fastled-rs"
-  VENV_BIN_DIR=".venv/bin"
+  EXE_NAME="fastled"
 fi
 
 BIN_SRC=""
@@ -129,12 +123,11 @@ for CANDIDATE in \
 done
 
 if [[ -n "$BIN_SRC" ]]; then
-  mkdir -p "$VENV_BIN_DIR" src/fastled/bin
-  cp -f "$BIN_SRC" "$VENV_BIN_DIR/$EXE_NAME"
+  mkdir -p src/fastled/bin
   cp -f "$BIN_SRC" "src/fastled/bin/$EXE_NAME"
-  echo "Staged $BIN_SRC -> $VENV_BIN_DIR/$EXE_NAME (and src/fastled/bin/)"
+  echo "Staged $BIN_SRC -> src/fastled/bin/$EXE_NAME"
 else
-  echo "Warning: Rust fastled-rs binary not found; Python fastled shims will fail" >&2
+  echo "Warning: Rust fastled binary not found; Python fastled shims will fail" >&2
 fi
 
 uv pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,8 @@ disable_error_code = ["import-untyped"]
 
 [project.scripts]
 # `fastled` remains a Python compatibility entry point during the migration.
-# It resolves and execs the Rust binary under the distinct `fastled-rs` name
-# so the shim cannot recursively find itself on PATH.
+# It resolves and execs the bundled Rust `fastled[.exe]` binary from package
+# data; the shim deliberately does not search PATH to avoid recursive launch.
 fastled = "fastled.cli:main"
 fastled-wasm = "fastled.cli:main"
 fled = "fastled.cli:main"

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 ROOT = Path(__file__).resolve().parent
 PACKAGE_BIN_DIR = ROOT / "src" / "fastled" / "bin"
-EXE_NAME = "fastled-rs.exe" if sys.platform == "win32" else "fastled-rs"
+EXE_NAME = "fastled.exe" if sys.platform == "win32" else "fastled"
 
 
 def _cargo_command() -> list[str]:
     soldr = shutil.which("soldr")
     if soldr:
         return [soldr, "cargo"]
-    raise RuntimeError("soldr was not found; cannot build bundled fastled-rs")
+    raise RuntimeError("soldr was not found; cannot build bundled fastled")
 
 
 def _candidate_binaries() -> list[Path]:
@@ -60,15 +60,15 @@ def ensure_bundled_fastled_binary() -> None:
         return
 
     if not (ROOT / "Cargo.toml").is_file():
-        raise RuntimeError("Cargo.toml was not found; cannot build bundled fastled-rs")
+        raise RuntimeError("Cargo.toml was not found; cannot build bundled fastled")
 
-    command = [*_cargo_command(), "build", "--release", "--bin", "fastled-rs"]
+    command = [*_cargo_command(), "build", "--release", "--bin", "fastled"]
     target = os.environ.get("FASTLED_RUST_TARGET")
     if target:
         command.extend(["--target", target])
     subprocess.check_call(command, cwd=ROOT)
     if not _copy_first_available_binary():
-        raise RuntimeError("built fastled-rs binary was not found")
+        raise RuntimeError("built fastled binary was not found")
 
 
 class BinaryDistribution(Distribution):

--- a/src/fastled/_rust_cli.py
+++ b/src/fastled/_rust_cli.py
@@ -1,14 +1,13 @@
-"""Locate the Rust ``fastled-rs`` binary.
+"""Locate the native Rust ``fastled`` binary.
 
 Wheel-installed deployments bundle the Rust binary under ``fastled/bin``.
 Editable dev installs usually resolve the binary from ``target/`` after a
-local ``soldr cargo build --bin fastled-rs``.
+local ``soldr cargo build --bin fastled``.
 
 Search order:
-    1. Package-local ``fastled/bin/fastled-rs[.exe]`` (wheel install).
-    2. Workspace ``target/{release,debug}/fastled-rs[.exe]`` (dev / editable).
-    3. ``$CARGO_HOME/bin/fastled-rs[.exe]`` (where ``cargo binstall`` installs).
-    4. ``shutil.which(\"fastled-rs\")``.
+    1. Package-local ``fastled/bin/fastled[.exe]`` (wheel install).
+    2. Workspace ``target/{release,debug}/fastled[.exe]`` (dev / editable).
+    3. ``$CARGO_HOME/bin/fastled[.exe]`` (where ``cargo-binstall`` installs).
 """
 
 from __future__ import annotations
@@ -21,7 +20,7 @@ from pathlib import Path
 
 
 def _exe_name() -> str:
-    return "fastled-rs.exe" if sys.platform == "win32" else "fastled-rs"
+    return "fastled.exe" if sys.platform == "win32" else "fastled"
 
 
 def _find_workspace_root() -> Path | None:
@@ -37,7 +36,7 @@ def _find_workspace_root() -> Path | None:
 
 
 def find_rust_fastled_cli() -> Path | None:
-    """Return the path to the Rust ``fastled-rs`` binary, or ``None``."""
+    """Return the path to the Rust ``fastled`` binary, or ``None``."""
     exe = _exe_name()
 
     # 1. Wheel-bundled native binary.
@@ -71,10 +70,6 @@ def find_rust_fastled_cli() -> Path | None:
     if candidate.is_file():
         return candidate
 
-    # 4. PATH lookup.
-    found = shutil.which(exe)
-    if found:
-        return Path(found)
     return None
 
 
@@ -93,13 +88,13 @@ def invoke_rust_fastled_cli(argv: list[str] | None = None) -> int:
         soldr = shutil.which("soldr")
         if soldr is None:
             raise RuntimeError(
-                "soldr is required to build the Rust fastled-rs CLI binary."
+                "soldr is required to build the Rust fastled CLI binary."
             )
         return subprocess.run(
-            [soldr, "cargo", "run", "--quiet", "--bin", "fastled-rs", "--", *args],
+            [soldr, "cargo", "run", "--quiet", "--bin", "fastled", "--", *args],
             check=False,
             cwd=workspace_root,
             env=env,
         ).returncode
 
-    raise RuntimeError("Could not locate the Rust fastled-rs CLI binary.")
+    raise RuntimeError("Could not locate the Rust fastled CLI binary.")


### PR DESCRIPTION
## Summary
- Rename the Rust CLI binary from `fastled-rs` to `fastled` / `fastled.exe` across Cargo metadata, CI, release packaging, and local build scripts.
- Bundle the native executable as `fastled/bin/fastled[.exe]` in the Python package.
- Update the Python compatibility shim to invoke the package-local native `fastled[.exe]` and avoid PATH lookup so it cannot recursively invoke the Python launcher.

## Verification
- `soldr cargo fmt --all --check`
- `uv run ruff check src setup.py tests ci`
- `uv run black --check src setup.py tests ci`
- `uv run isort --check-only --profile black src setup.py tests ci`
- `PYTHONPATH=src uv run pytest --rootdir . -q tests/unit/test_python_api.py tests/unit/test_tool_guard_hook.py`
- `soldr cargo test -p fastled-cli --no-default-features`
- `soldr cargo build -p fastled-cli --bin fastled --no-default-features`
- `uv run --with setuptools>=69 --with wheel>=0.43 python setup.py bdist_wheel`
- Wheel contents checked: contains `fastled/bin/fastled.exe`, no `fastled-rs`, no `_native.pyd`
- `python -m fastled.cli --version` -> `fastled 2.0.7`
- `fastled.exe --version` -> `fastled 2.0.7`