### PR TITLE
fix: reuse existing install virtualenv

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -29,13 +29,28 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
+      - name: Configure Rust target
+        run: |
+          cp rust-toolchain.toml rust-toolchain.ci.toml
+          if [ -n "${{ inputs.rust-target }}" ]; then
+            printf '\ntargets = ["%s"]\n' "${{ inputs.rust-target }}" >> rust-toolchain.ci.toml
+          fi
+          cat rust-toolchain.ci.toml
+
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # setup-soldr@v0 reads underscore-normalized INPUT_* values
+          # directly, so mirror hyphenated inputs until the action handles
+          # them natively.
+          INPUT_CACHE_KEY_SUFFIX: build-${{ inputs.runs-on }}-${{ github.workflow }}
+          INPUT_LINKER: platform-default
+          INPUT_TOOLCHAIN_FILE: rust-toolchain.ci.toml
         with:
           cache: true
           cache-key-suffix: build-${{ inputs.runs-on }}-${{ github.workflow }}
           linker: platform-default
+          toolchain-file: rust-toolchain.ci.toml
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_CACHE_KEY_SUFFIX: integration-test-${{ inputs.runs-on }}-${{ github.workflow }}
+          INPUT_LINKER: platform-default
+          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
           cache: true
           linker: platform-default

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_CACHE_KEY_SUFFIX: lint-${{ inputs.runs-on }}-${{ github.workflow }}
+          INPUT_LINKER: platform-default
+          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
           cache: true
           linker: platform-default

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_CACHE_KEY_SUFFIX: unit-test-${{ inputs.runs-on }}-${{ github.workflow }}
+          INPUT_LINKER: platform-default
+          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
           cache: true
           linker: platform-default

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -183,6 +183,9 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          INPUT_CACHE_KEY_SUFFIX: publish-pypi
+          INPUT_LINKER: platform-default
+          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
           cache: true
           cache-key-suffix: publish-pypi

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -1107,8 +1107,13 @@ mod tests {
         fs::write(sketch_dir.join("Blink.ino"), b"void setup() {}").unwrap();
         let _guard = CurrentDirGuard::enter(&sketch_dir);
 
-        let resolved = resolve_compile_directory(&base_cli()).unwrap();
-        assert_eq!(resolved, Some(display_path(&sketch_dir)));
+        let resolved = resolve_compile_directory(&base_cli())
+            .unwrap()
+            .expect("sketch directory");
+        assert_eq!(
+            canonical_display_path(Path::new(&resolved)),
+            canonical_display_path(&sketch_dir)
+        );
     }
 
     #[test]
@@ -1123,7 +1128,7 @@ mod tests {
         cli.directory = Some(display_path(&source_file));
 
         let resolved = resolve_compile_directory(&cli).unwrap();
-        assert_eq!(resolved, Some(display_path(&sketch_dir)));
+        assert_eq!(resolved, Some(canonical_display_path(&sketch_dir)));
     }
 
     #[test]
@@ -1165,7 +1170,7 @@ mod tests {
         let _guard = CurrentDirGuard::enter(&nested);
 
         let detected = detect_local_fastled_path();
-        assert_eq!(detected, Some(display_path(&repo_root)));
+        assert_eq!(detected, Some(canonical_display_path(&repo_root)));
     }
 
     #[test]

--- a/crates/fastled-cli/src/main.rs
+++ b/crates/fastled-cli/src/main.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -15,7 +14,7 @@ struct InternalViewerArgs {
 fn parse_internal_viewer_args() -> Option<Result<InternalViewerArgs, String>> {
     let mut args = std::env::args_os().skip(1);
     let first = args.next()?;
-    if first != OsString::from("--internal-viewer") {
+    if first != "--internal-viewer" {
         return None;
     }
 
@@ -31,12 +30,12 @@ fn parse_internal_viewer_args() -> Option<Result<InternalViewerArgs, String>> {
     };
 
     while let Some(arg) = args.next() {
-        if arg == OsString::from("--viewer-title") {
+        if arg == "--viewer-title" {
             let Some(value) = args.next() else {
                 return Some(Err("--viewer-title requires a value".to_string()));
             };
             parsed.title = value.to_string_lossy().into_owned();
-        } else if arg == OsString::from("--viewer-width") {
+        } else if arg == "--viewer-width" {
             let Some(value) = args.next() else {
                 return Some(Err("--viewer-width requires a value".to_string()));
             };
@@ -45,7 +44,7 @@ fn parse_internal_viewer_args() -> Option<Result<InternalViewerArgs, String>> {
                 Ok(width) => width,
                 Err(_) => return Some(Err("--viewer-width must be an integer".to_string())),
             };
-        } else if arg == OsString::from("--viewer-height") {
+        } else if arg == "--viewer-height" {
             let Some(value) = args.next() else {
                 return Some(Err("--viewer-height requires a value".to_string()));
             };

--- a/crates/fastled-cli/src/runtime.rs
+++ b/crates/fastled-cli/src/runtime.rs
@@ -541,6 +541,7 @@ fn lock_runtime_root(run_root: &Path) -> Result<File> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(&lock_path)
         .with_context(|| format!("cannot open {}", lock_path.display()))?;
     file.lock_exclusive()
@@ -617,16 +618,19 @@ fn is_runnable_update_file(path: &Path) -> bool {
     }
     #[cfg(not(windows))]
     {
-        path.extension().is_none()
+        path.file_name()
+            .and_then(OsStr::to_str)
+            .is_some_and(|name| {
+                FASTLED_EXE_NAMES
+                    .iter()
+                    .any(|candidate| candidate.eq_ignore_ascii_case(name))
+                    || version_from_name(name).is_some()
+            })
     }
 }
 
 fn version_from_path_name(path: &Path) -> Option<(String, ParsedVersion)> {
-    let name = if path.is_file() {
-        path.file_stem()?.to_string_lossy()
-    } else {
-        path.file_name()?.to_string_lossy()
-    };
+    let name = path.file_name()?.to_string_lossy();
     version_from_name(&name)
 }
 

--- a/crates/fastled-cli/src/viewer.rs
+++ b/crates/fastled-cli/src/viewer.rs
@@ -352,7 +352,7 @@ pub fn launch_tauri_viewer(frontend_dir: &std::path::Path) -> Result<ViewerProce
 
     #[cfg(windows)]
     {
-        return spawn_hidden_viewer(&binary, frontend_dir);
+        spawn_hidden_viewer(&binary, frontend_dir)
     }
 
     #[cfg(not(windows))]

--- a/install
+++ b/install
@@ -1,22 +1,37 @@
 #!/bin/bash
 set -e
 
+OS_NAME="$(uname -s 2>/dev/null || echo unknown)"
+
 # Check if UV is not found
 if ! command -v uv &> /dev/null; then
   # If Darwin (macOS), use brew to install UV
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ "$OS_NAME" == "Darwin"* ]]; then
     brew install uv
   else
     # If it's Windows, use pip to install UV, else use pip3
-    if [[ "$OSTYPE" == "msys" ]]; then
+    case "$OS_NAME" in
+    MINGW*|MSYS*|CYGWIN*)
       pip install uv
-    else
+      ;;
+    *)
       pip3 install uv
-    fi
+      ;;
+    esac
   fi
 fi
 
-uv venv --python "${UV_PYTHON:-3.11}" --seed
+if [[ -d .venv ]]; then
+  if [[ -f .venv/pyvenv.cfg ]]; then
+    echo "Reusing existing virtual environment at .venv"
+  else
+    echo "Error: .venv exists but does not look like a Python virtual environment" >&2
+    echo "Remove or rename .venv, or create a valid virtual environment there first." >&2
+    exit 1
+  fi
+else
+  uv venv --python "${UV_PYTHON:-3.11}" --seed
+fi
 uv pip install "build>=1" "setuptools>=69" "wheel>=0.43"
 uv pip install -r requirements.testing.txt
 
@@ -31,11 +46,14 @@ fi
 # many dev machines) lack; current windows-2025 images fail here even for
 # git-bash. Fall back to plain copy, then to a no-op with a warning. Not
 # fatal: ./activate is only used interactively.
-if [[ "$OSTYPE" == "msys" ]]; then
+case "$OS_NAME" in
+MINGW*|MSYS*|CYGWIN*)
   ACTIVATE_SRC=".venv/Scripts/activate"
-else
+  ;;
+*)
   ACTIVATE_SRC=".venv/bin/activate"
-fi
+  ;;
+esac
 
 if [[ -f "$ACTIVATE_SRC" ]]; then
   ln -s "$ACTIVATE_SRC" ./activate 2>/dev/null \
@@ -101,11 +119,14 @@ fi
 # into the venv's Scripts/bin directory, so stage the package-local binary:
 #   * `src/fastled/bin/fastled[.exe]` so the Python compatibility shim and a
 #     subsequent `./build-wheel` both use the bundled native binary.
-if [[ "$OSTYPE" == "msys" ]]; then
+case "$OS_NAME" in
+MINGW*|MSYS*|CYGWIN*)
   EXE_NAME="fastled.exe"
-else
+  ;;
+*)
   EXE_NAME="fastled"
-fi
+  ;;
+esac
 
 BIN_SRC=""
 # Discover where the binary landed. cargo on Windows MSVC writes under


### PR DESCRIPTION
## Summary
- Reuse an existing `.venv` in `./install` instead of always calling `uv venv`.
- Use `uname`-based platform detection in `./install` so Windows Git Bash variants consistently stage `fastled.exe`.
- Fix Unix update candidate parsing for dotted version filenames like `fastled-v2.1.0`.
- Generate a CI rust-toolchain file for cross-target build jobs so setup-soldr sees requested targets.
- Mirror setup-soldr hyphenated inputs into underscore `INPUT_*` env vars so `toolchain-file`, `cache-key-suffix`, and `linker` are honored by the current `@v0` action bundle.
- Fix Windows path assertions to compare canonical paths instead of raw 8.3 temp paths.

## Verification
- `bash -n install`
- `soldr cargo fmt --all --check`
- `soldr cargo test -p fastled-cli runtime --no-default-features`
- `CARGO_TARGET_DIR=E:\fastled-wasm-target soldr cargo test -p fastled-cli --lib --no-default-features` -> 96 passed, 0 failed
- Created `.venv` first with `uv venv --python 3.11 --seed`, then ran `bash ./install`; install reused the pre-existing `.venv`, staged `src/fastled/bin/fastled.exe`, and completed.
- `.venv\Scripts\fastled.exe --version` -> `fastled 2.0.7`
- `git diff --check`
- `rg -n "rustup target add|rustup component add|rustup" .github/workflows install .codex` found no direct rustup calls in workflow/install paths.
- GitHub Actions: Windows x86 Build on the first PR #95 run passed through Install, wheel build, and upload.
