### PR TITLE
chore: bump version to 2.0.9 (first Auto Release run)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
 
 [project]
 name = "fastled"
-version = "2.0.8"
+version = "2.0.9"
 readme = "README.md"
 description = "FastLED Wasm Compiler"
 requires-python = ">=3.10"

--- a/src/fastled/__version__.py
+++ b/src/fastled/__version__.py
@@ -1,2 +1,2 @@
 # Version is read directly from this file by the GitHub Actions release workflow.
-__version__ = "2.0.8"
+__version__ = "2.0.9"


### PR DESCRIPTION
Trigger the first end-to-end Auto Release run with the new workflow.

If all 6 platform builds succeed, this publishes 6 native wheels to PyPI plus 6 signed GitHub Release zips.

Follow-up tracked in #99: move version source-of-truth out of \`__version__.py\` into Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)