### PR TITLE
fix: bundled CLI version + emscripten manifest parse (#101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,18 +754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctcb-manifest"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c47fc9cd2017787aad53c7a11fb8529291cadb369dc15ad041eb81fbc06221"
-dependencies = [
- "anyhow",
- "ctcb-core",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,14 +1078,13 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.7"
+version = "2.0.9"
 dependencies = [
  "anyhow",
  "axum",
  "clap",
  "crossterm",
  "ctcb-core",
- "ctcb-manifest",
  "dirs 5.0.1",
  "flate2",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.7"
+version = "2.0.9"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"
@@ -27,7 +27,6 @@ flate2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
-ctcb-manifest = "0.4.1"
 ctcb-core = "0.4.1"
 dirs = "5"
 strsim = "0.11"

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -34,7 +34,6 @@ flate2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-ctcb-manifest = { workspace = true }
 ctcb-core = { workspace = true }
 strsim = { workspace = true }
 crossterm = { workspace = true }

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -5,6 +5,7 @@
 //! Public entry points are intended to be called once at the top of the
 //! compile flow; results are cached on disk via a `done.txt` marker.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -12,10 +13,37 @@ use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use ctcb_core::Target;
-use ctcb_manifest::{PartRef, PlatformManifest};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::archive;
+
+/// Toolchain platform manifest as published in
+/// `clang-tool-chain-bins/assets/emscripten/{platform}/{arch}/manifest.json`.
+///
+/// Local mirror of the schema rather than relying on `ctcb-manifest` because
+/// the published manifests use a `"versions": { … }` map, while older
+/// `ctcb-manifest` releases expected version keys at the top level. Keeping
+/// the schema local insulates the CLI from upstream crate drift.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PlatformManifest {
+    latest: String,
+    versions: BTreeMap<String, VersionInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VersionInfo {
+    href: String,
+    sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parts: Option<Vec<PartRef>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PartRef {
+    href: String,
+    sha256: String,
+}
 
 const EMSCRIPTEN_MANIFEST_BASE_URL: &str =
     "https://raw.githubusercontent.com/zackees/clang-tool-chain-bins/main/assets/emscripten";
@@ -1085,4 +1113,68 @@ pub fn run_install(options: InstallOptions) -> Result<InstallOutcome> {
 
     println!("\nFastLED installation completed successfully!");
     Ok(InstallOutcome { launch_after })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DARWIN_ARM64_MANIFEST: &str = r#"{
+  "latest": "releases-d70a5da89b3e673bf6a482724478fc17e81e575e",
+  "versions": {
+    "releases-d70a5da89b3e673bf6a482724478fc17e81e575e": {
+      "version": "releases-d70a5da89b3e673bf6a482724478fc17e81e575e",
+      "href": "https://media.githubusercontent.com/media/zackees/clang-tool-chain-bins/main/assets/emscripten/darwin/arm64/emscripten-releases-d70a5da89b3e673bf6a482724478fc17e81e575e-darwin-arm64.tar.zst",
+      "sha256": "6af749f0d44927c7d4c93c9e407e195257ed690b8e3bd3a43d7a3f4badc52082"
+    }
+  }
+}"#;
+
+    const LINUX_X86_64_MANIFEST_WITH_PARTS: &str = r#"{
+  "latest": "4.0.21",
+  "versions": {
+    "4.0.21": {
+      "version": "4.0.21",
+      "href": "https://raw.githubusercontent.com/zackees/clang-tool-chain-bins/main/assets/emscripten/linux/x86_64/emscripten-4.0.21-linux-x86_64.tar.zst",
+      "sha256": "5cd3cbe0316d37c9b39bdc63691c014f136a5d82a9f08ed29bb7ad62f7a83655",
+      "parts": [
+        {
+          "href": "https://raw.githubusercontent.com/zackees/clang-tool-chain-bins/main/assets/emscripten/linux/x86_64/emscripten-4.0.21-linux-x86_64.tar.zst.part-aa",
+          "sha256": "e427aee7d1197f59bcbd7a82a581f8d0bdf484ea24036a3c52903bb26cfd4488",
+          "size": 99614720
+        }
+      ]
+    }
+  }
+}"#;
+
+    #[test]
+    fn parses_nested_versions_manifest_without_parts() {
+        let manifest: PlatformManifest =
+            serde_json::from_str(DARWIN_ARM64_MANIFEST).expect("parse darwin/arm64 manifest");
+        assert_eq!(
+            manifest.latest,
+            "releases-d70a5da89b3e673bf6a482724478fc17e81e575e"
+        );
+        let entry = manifest
+            .versions
+            .get(&manifest.latest)
+            .expect("entry for latest");
+        assert!(entry.href.contains("emscripten-releases-"));
+        assert_eq!(
+            entry.sha256,
+            "6af749f0d44927c7d4c93c9e407e195257ed690b8e3bd3a43d7a3f4badc52082"
+        );
+        assert!(entry.parts.is_none());
+    }
+
+    #[test]
+    fn parses_manifest_with_multipart_archive_and_extra_size_field() {
+        let manifest: PlatformManifest = serde_json::from_str(LINUX_X86_64_MANIFEST_WITH_PARTS)
+            .expect("parse linux/x86_64 manifest");
+        let entry = manifest.versions.get("4.0.21").expect("entry for 4.0.21");
+        let parts = entry.parts.as_ref().expect("parts present");
+        assert_eq!(parts.len(), 1);
+        assert!(parts[0].href.ends_with(".part-aa"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two issues from #101 reported on a clean macOS arm64 reinstall:

- **Bundled CLI binary reported `fastled 2.0.7` while the PyPI package was `2.0.9`.** The `pyproject.toml` and `src/fastled/__version__.py` were bumped to `2.0.9` in #100, but the Rust workspace was missed, so `clap`'s `version = env!("CARGO_PKG_VERSION")` baked `2.0.7` into the native binary. Bumped `Cargo.toml` `workspace.package.version` to `2.0.9`.

- **Toolchain install failed with `parse manifest JSON ... bad version entry 'versions': missing field \`href\``.** The emscripten manifests published in `zackees/clang-tool-chain-bins` use a nested shape:

  ```json
  { "latest": "…", "versions": { "<ver>": { "href": "…", "sha256": "…", "parts": […] } } }
  ```

  But `ctcb-manifest` 0.4.x expects version keys at the top level alongside `"latest"`. Its custom `Deserialize` iterates every non-`latest` key as a `VersionInfo`, so it hit `"versions"` (an object, no `href`) and failed.

  Fixed by replacing `ctcb_manifest::{PlatformManifest, PartRef}` with a local mirror in `crates/fastled-cli/src/install.rs` that matches the actual JSON, and dropping the now-unused `ctcb-manifest` workspace dep.

## Test plan

- [x] `soldr cargo test -p fastled-cli --no-default-features` — 98 passed, including two new install fixture tests covering both manifest shapes (with and without `parts`).
- [x] `target/.../release/fastled.exe --version` now prints `fastled 2.0.9`.
- [x] `soldr cargo fmt --all --check` clean.
- [x] `soldr cargo clippy --workspace --all-targets --no-default-features -- -D warnings` clean.
- [ ] On macOS arm64: `python3 -m pip install fastled && fastled /tmp/MatrixBlink --just-compile` reaches the actual emcc compile step (reporter verification).

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)