### PR TITLE
ci: cook debug deps for debug jobs (effective setup-soldr use)

### DIFF
--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -40,6 +40,11 @@ jobs:
           # x86/ARM) currently share the same runs-on. Without this they
           # collide on the same cache key and one job fails to save.
           cache-key-suffix: integration-test-${{ inputs.runs-on }}-${{ github.workflow }}
+          # `./test` runs `soldr cargo test --workspace` (dev/debug profile).
+          # Cook in debug so its prebuilt deps share the compile-cache key with
+          # the test compile; the default `--release` cook is zero-reuse here
+          # and only bloats the build-cache (setup-soldr#235).
+          prebuild-deps-flags: ""
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -38,6 +38,12 @@ jobs:
           # x86/ARM) currently share the same runs-on. Without this they
           # collide on the same cache key and one job fails to save.
           cache-key-suffix: lint-${{ inputs.runs-on }}-${{ github.workflow }}
+          # `./lint` runs `soldr cargo clippy --workspace --all-targets`
+          # (dev/debug profile). Cook in debug so its prebuilt deps share the
+          # compile-cache key with the clippy compile; the default `--release`
+          # cook is zero-reuse here and only bloats the build-cache
+          # (setup-soldr#235).
+          prebuild-deps-flags: ""
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -40,6 +40,11 @@ jobs:
           # x86/ARM) currently share the same runs-on. Without this they
           # collide on the same cache key and one job fails to save.
           cache-key-suffix: unit-test-${{ inputs.runs-on }}-${{ github.workflow }}
+          # `./test` runs `soldr cargo test --workspace` (dev/debug profile).
+          # Cook in debug so its prebuilt deps share the compile-cache key with
+          # the test compile; the default `--release` cook is zero-reuse here
+          # and only bloats the build-cache (setup-soldr#235).
+          prebuild-deps-flags: ""
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## What
Set `prebuild-deps-flags: ""` on the three debug jobs (`_unit-test`, `_lint`, `_integration-test`), so `soldr cook` prebuilds **debug** dependency artifacts that match what those jobs actually compile:

- `./test` → `soldr cargo test --workspace` (dev/debug)
- `./lint` → `soldr cargo clippy --workspace --all-targets` (dev/debug)

## Why
These jobs left `prebuild-deps-flags` at the `--release` default, so cook prebuilt **release** deps the debug compile can never reuse — zero cook reuse, plus the never-read release dep slice bloats the saved build-cache (the exact footgun in zackees/setup-soldr#235). Matching the cook profile to the compile profile recovers cook's prewarm and shrinks the cache.

The release `_build` job (`soldr cargo build --release`) is already aligned with the `--release` cook default and is left unchanged.

## setup-soldr version
The workflows pin `zackees/setup-soldr@v0`, which now resolves to **v0.9.16** — carrying the soldr **0.7.44** `cargo cook` project-restore fix (zackees/soldr#566), so first-party crates hit the compile-cache on the **first** warm run instead of converging on the second. No version-ref change needed; this PR just aligns the cook profile to make that caching effective for the debug jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)