### PR TITLE
chore: remove stale cache-key-suffix comment from 3 reusable workflows

### DIFF
--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           cache: true
           linker: platform-default
-          # Include github.workflow because some callers (e.g. Windows
-          # x86/ARM) currently share the same runs-on. Without this they
-          # collide on the same cache key and one job fails to save.
           cache-key-suffix: ${{ inputs.runs-on }}
           # `./test` runs `soldr cargo test --workspace` (dev/debug profile).
           # Cook in debug so its prebuilt deps share the compile-cache key with

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           cache: true
           linker: platform-default
-          # Include github.workflow because some callers (e.g. Windows
-          # x86/ARM) currently share the same runs-on. Without this they
-          # collide on the same cache key and one job fails to save.
           cache-key-suffix: ${{ inputs.runs-on }}
           # `./lint` runs `soldr cargo clippy --workspace --all-targets`
           # (dev/debug profile). Cook in debug so its prebuilt deps share the

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           cache: true
           linker: platform-default
-          # Include github.workflow because some callers (e.g. Windows
-          # x86/ARM) currently share the same runs-on. Without this they
-          # collide on the same cache key and one job fails to save.
           cache-key-suffix: ${{ inputs.runs-on }}
           # `./test` runs `soldr cargo test --workspace` (dev/debug profile).
           # Cook in debug so its prebuilt deps share the compile-cache key with


### PR DESCRIPTION
The 3 reusable workflows (`_lint.yml`, `_unit-test.yml`, `_integration-test.yml`) carry a comment block justifying `\${{ github.workflow }}` in the cache-key-suffix, but PR #107 removed `github.workflow` from the suffix in iter #2 of the cache-efficiency loop. The actual value is now just `\${{ inputs.runs-on }}` — the comment documents a configuration that hasn't existed for several PRs.

The concern in the comment (multiple parallel jobs with the same runs-on colliding on the cache key and "one job fails to save") was empirically moot: actions/cache handles the contention gracefully — the runner-up emits an "already exists" warning and the workflow proceeds, no real failure. PR #107's CI confirmed this across 22+ jobs.

Strip the misleading 3-line comment block from all three files. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)