### PR TITLE
chore(ci): adopt cache-preset: foundation + drop redundant INPUT_* env shim

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -40,14 +40,11 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          # setup-soldr@v0 reads underscore-normalized INPUT_* values
-          # directly, so mirror hyphenated inputs until the action handles
-          # them natively.
-          INPUT_CACHE_KEY_SUFFIX: ${{ inputs.runs-on }}
-          INPUT_LINKER: platform-default
-          INPUT_TOOLCHAIN_FILE: rust-toolchain.ci.toml
         with:
-          cache: true
+          # cache-preset: foundation expands to build-cache: true +
+          # target-cache: false + cargo-registry-cache: false +
+          # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).
+          cache-preset: foundation
           cache-key-suffix: ${{ inputs.runs-on }}
           linker: platform-default
           toolchain-file: rust-toolchain.ci.toml

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -30,13 +30,14 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          INPUT_CACHE_KEY_SUFFIX: ${{ inputs.runs-on }}
-          INPUT_LINKER: platform-default
-          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
-          cache: true
-          linker: platform-default
+          # cache-preset: foundation expands to build-cache: true +
+          # target-cache: false + cargo-registry-cache: false +
+          # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).
+          cache-preset: foundation
           cache-key-suffix: ${{ inputs.runs-on }}
+          linker: platform-default
+          toolchain-file: rust-toolchain.toml
           # `./test` runs `soldr cargo test --workspace` (dev/debug profile).
           # Cook in debug so its prebuilt deps share the compile-cache key with
           # the test compile; the default `--release` cook is zero-reuse here

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -28,13 +28,14 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          INPUT_CACHE_KEY_SUFFIX: ${{ inputs.runs-on }}
-          INPUT_LINKER: platform-default
-          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
-          cache: true
-          linker: platform-default
+          # cache-preset: foundation expands to build-cache: true +
+          # target-cache: false + cargo-registry-cache: false +
+          # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).
+          cache-preset: foundation
           cache-key-suffix: ${{ inputs.runs-on }}
+          linker: platform-default
+          toolchain-file: rust-toolchain.toml
           # `./lint` runs `soldr cargo clippy --workspace --all-targets`
           # (dev/debug profile). Cook in debug so its prebuilt deps share the
           # compile-cache key with the clippy compile; the default `--release`

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -30,13 +30,14 @@ jobs:
       - uses: zackees/setup-soldr@v0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          INPUT_CACHE_KEY_SUFFIX: ${{ inputs.runs-on }}
-          INPUT_LINKER: platform-default
-          INPUT_TOOLCHAIN_FILE: rust-toolchain.toml
         with:
-          cache: true
-          linker: platform-default
+          # cache-preset: foundation expands to build-cache: true +
+          # target-cache: false + cargo-registry-cache: false +
+          # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).
+          cache-preset: foundation
           cache-key-suffix: ${{ inputs.runs-on }}
+          linker: platform-default
+          toolchain-file: rust-toolchain.toml
           # `./test` runs `soldr cargo test --workspace` (dev/debug profile).
           # Cook in debug so its prebuilt deps share the compile-cache key with
           # the test compile; the default `--release` cook is zero-reuse here


### PR DESCRIPTION
Cleanup PR for the 4 reusable workflows (`_build`, `_lint`, `_unit-test`, `_integration-test`):

1. **Drop the `INPUT_*` env shim.** The original comment said *"setup-soldr@v0 reads underscore-normalized INPUT_* values directly, so mirror hyphenated inputs until the action handles them natively."* Modern setup-soldr v0.9.19 reads BOTH forms (see [`src/lib/raw-inputs.ts:15-17`](https://github.com/zackees/setup-soldr/blob/main/src/lib/raw-inputs.ts#L15-L17)). The shim is redundant.
2. **Migrate `cache: true` → `cache-preset: foundation`** (setup-soldr v0.9.17 [#251](https://github.com/zackees/setup-soldr/issues/251)) — same pattern fastled/fbuild adopted in [#289](https://github.com/FastLED/fbuild/pull/289). `cache: true` was the umbrella switch (default-on) and `cache-preset: foundation` makes the layer policy explicit — both together resolve to the same effective config.
3. **Promote `linker` + `toolchain-file` from env shim to first-class `with:` inputs.**

`GITHUB_TOKEN` is kept in `env:` because it's a real token pass, not a shim.

**No behavior change** — `cache-preset: foundation` expands to the same defaults these workflows previously got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)