### PR TITLE
chore(ci): pin setup-soldr to v0.9.24 (force upgrade)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@v0.9.24
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@v0.9.24
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@v0.9.24
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0
+      - uses: zackees/setup-soldr@v0.9.24
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Pin all `zackees/setup-soldr@v0` references to `zackees/setup-soldr@v0.9.24` so this repo explicitly carries the v0.9.21–v0.9.24 perf-fix cascade:

- **v0.9.21** — implicit `cargo-registry-cache=true` pairing when `prebuild-deps: soldr-cook` (closes the "cook is on, why is it still downloading?" trap).
- **v0.9.22** — pre-compress race probe avoids the 19-minute wall-clock waste pattern when a sibling job wins the cache reservation race (setup-soldr#268 Fix A).
- **v0.9.23** — soldr 0.7.48 (zccache 1.11.8 cross-clone .obj fix) + ncc side-chunk `dist/` copy hotfix.
- **v0.9.24** — raise `cache-payload-max-bytes` default 2GiB → 6GiB. Unblocks build-cache save on medium-large Rust workspaces that were chronic-skipping every run.

Validated end-to-end on zccache CI: post-step wall-clock dropped from **18m 8s → ~27s** and compile-cache `hit_rate` jumped from **0.7% → 100%** across the cascade.

Pinned (vs. `@v0` floating) for reproducibility — `v0` already points at this commit, so behavior is identical today, but future v0-tag moves can't accidentally regress this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)