### PR TITLE
ci: bump setup-soldr v0.9.24 → v0.9.35 (~7s warm-run win)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.24
+      - uses: zackees/setup-soldr@v0.9.35
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.24
+      - uses: zackees/setup-soldr@v0.9.35
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.24
+      - uses: zackees/setup-soldr@v0.9.35
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.24
+      - uses: zackees/setup-soldr@v0.9.35
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

Bumps `zackees/setup-soldr` from `v0.9.24` to `v0.9.35` across all workflows in `.github/workflows/`.

Picks up the cumulative perf + observability wins:

- **#302/#303**: sub-phase timing observability (each setup phase now prints a `{sub=Xs sub=Ys}` breakdown inline).
- **#304/#308**: FS-first rustup probe — eliminates ~7s `rustup toolchain list` subprocess on every warm CI run. Validated on zccache CI: linux/Test wall clock dropped 30.0s → 14.8s (-15.2s).

## Files touched

- `.github/workflows/_build.yml`
- `.github/workflows/_lint.yml`
- `.github/workflows/_integration-test.yml`
- `.github/workflows/_unit-test.yml`

## Test plan

- [ ] CI green on all four workflows
- [ ] Confirm `{sub=Xs sub=Ys}` breakdowns appear in setup-soldr step logs
- [ ] Compare warm-run wall clock vs prior v0.9.24 runs on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)