### PR TITLE
ci: bump setup-soldr v0.9.35 → v0.9.38

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.35
+      - uses: zackees/setup-soldr@v0.9.38
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.35
+      - uses: zackees/setup-soldr@v0.9.38
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.35
+      - uses: zackees/setup-soldr@v0.9.38
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.35
+      - uses: zackees/setup-soldr@v0.9.38
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bump `zackees/setup-soldr` pin from v0.9.35 → v0.9.38 across all four reusable workflows (`_build.yml`, `_lint.yml`, `_integration-test.yml`, `_unit-test.yml`).
- Picks up #313/#314/#317/#319 (pre-save `lookupOnly` probes that skip wasted concurrent solo-toolchain-cache uploads, ~3–4 min/cold-cycle on multi-job workflows), #310 (solo-toolchain-cache default zstd -19 → -9, ~92s/cold-save), and #316/#320 plumbing for cache LRU-pressure investigation.

## Test plan
- [ ] CI green across `_build`, `_lint`, `_integration-test`, `_unit-test`.
- [ ] Compare cold-cycle wall clock vs the previous v0.9.35 baseline; expect ~7 min savings per cold cycle on the multi-job matrix.
- [ ] Confirm Post Setup Soldr logs no longer show concurrent solo-toolchain-cache upload contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)