### PR TITLE
ci: bump setup-soldr v0.9.38 → v0.9.39

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.38
+      - uses: zackees/setup-soldr@v0.9.39
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.38
+      - uses: zackees/setup-soldr@v0.9.39
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.38
+      - uses: zackees/setup-soldr@v0.9.39
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.38
+      - uses: zackees/setup-soldr@v0.9.39
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from v0.9.38 to v0.9.39 across all `.github/workflows/` files.
- v0.9.39 ships setup-soldr#316/#321 — THE root-cause fix for solo-toolchain-cache restore-MISS-despite-cache-exists.
- Save and restore now use the same canonical archive path, fixing the @actions/cache version mismatch that nullified solo-cache HIT/restore since #305.

## Test plan
- [ ] CI green on `_build.yml`, `_integration-test.yml`, `_unit-test.yml`, `_lint.yml`
- [ ] Verify solo-toolchain-cache reports HIT (not just save) in subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)