### PR TITLE
ci: bump setup-soldr v0.9.39 → v0.9.40

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.39
+      - uses: zackees/setup-soldr@v0.9.40
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.39
+      - uses: zackees/setup-soldr@v0.9.40
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.39
+      - uses: zackees/setup-soldr@v0.9.40
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.39
+      - uses: zackees/setup-soldr@v0.9.40
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from `v0.9.39` → `v0.9.40` in all 4 workflow files.
- Picks up setup-soldr#323/#324 — final piece of the solo-toolchain-cache series. Skips ~8s `rustup toolchain install` no-op when solo-cache exact-hit verified.

## Test plan
- [ ] CI green on all 4 workflows (_build, _unit-test, _integration-test, _lint)
- [ ] Setup Soldr step skips the rustup install no-op on warm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)