### PR TITLE
ci: bump setup-soldr v0.9.40 → v0.9.41

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.40
+      - uses: zackees/setup-soldr@v0.9.41
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.40
+      - uses: zackees/setup-soldr@v0.9.41
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.40
+      - uses: zackees/setup-soldr@v0.9.41
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.40
+      - uses: zackees/setup-soldr@v0.9.41
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from v0.9.40 → v0.9.41 across all four workflow files.
- v0.9.41 ships setup-soldr#326 — staging basename alignment fix that closes the solo-toolchain-cache series end-to-end. v0.9.40 had a leftover bug where save's tar top-level didn't match what restore expected, masking the HIT.

## Test plan
- [ ] CI passes on all four workflows (_build, _integration-test, _lint, _unit-test).
- [ ] Solo-toolchain-cache restore now reports HIT on warm runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)