### PR TITLE
ci: bump setup-soldr v0.9.41 → v0.9.42

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.41
+      - uses: zackees/setup-soldr@v0.9.42
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.41
+      - uses: zackees/setup-soldr@v0.9.42
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.41
+      - uses: zackees/setup-soldr@v0.9.42
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.41
+      - uses: zackees/setup-soldr@v0.9.42
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from `v0.9.41` to `v0.9.42` across all `.github/workflows/*.yml`.
- Picks up setup-soldr#328/#329 — solo-cache schema-version (v2) auto-invalidates stale caches saved by older releases.

## Test plan
- [ ] CI green on `_build.yml`, `_unit-test.yml`, `_integration-test.yml`, `_lint.yml`
- [ ] Verify solo-cache layer invalidates cleanly on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)