### PR TITLE
ci: bump setup-soldr v0.9.42 → v0.9.43

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.42
+      - uses: zackees/setup-soldr@v0.9.43
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.42
+      - uses: zackees/setup-soldr@v0.9.43
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.42
+      - uses: zackees/setup-soldr@v0.9.43
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.42
+      - uses: zackees/setup-soldr@v0.9.43
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from v0.9.42 → v0.9.43 in all 4 workflow files
- Picks up setup-soldr#331/#332 — hardlinks in solo-cache apply, shaving ~5s per warm CI job

## Test plan
- [ ] CI passes on `_build.yml`, `_unit-test.yml`, `_lint.yml`, `_integration-test.yml`
- [ ] Warm-cache restore timings reflect the ~5s improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)