### PR TITLE
ci: bump setup-soldr v0.9.43 → v0.9.44

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.43
+      - uses: zackees/setup-soldr@v0.9.44
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.43
+      - uses: zackees/setup-soldr@v0.9.44
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.43
+      - uses: zackees/setup-soldr@v0.9.44
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.43
+      - uses: zackees/setup-soldr@v0.9.44
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

- Bumps `zackees/setup-soldr` from `v0.9.43` to `v0.9.44` across `.github/workflows/`.
- Picks up setup-soldr#335/#336: hardlinks in seed-isolated-cache save ~27s/cycle on workloads using `seed-isolated-build-cache`.

## Test plan

- [ ] CI green on this PR (build / unit / integration / lint)
- [ ] Seed-isolated-cache restore step shows hardlink path

🤖 Generated with [Claude Code](https://claude.com/claude-code)