### PR TITLE
ci: bump setup-soldr v0.9.44 → v0.9.46

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.44
+      - uses: zackees/setup-soldr@v0.9.46
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.44
+      - uses: zackees/setup-soldr@v0.9.46
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.44
+      - uses: zackees/setup-soldr@v0.9.46
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.44
+      - uses: zackees/setup-soldr@v0.9.46
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from `v0.9.44` to `v0.9.46` across all four reusable workflows (`_build.yml`, `_integration-test.yml`, `_lint.yml`, `_unit-test.yml`).
- Picks up setup-soldr#343/#344: `solo-toolchain-cache` is now default-on.
- This repo doesn't set the input explicitly, so v0.9.46 turns on solo-cache automatically — expected ~8-11 s saving per warm CI job.

## Test plan
- [ ] CI green on this PR (build, integration-test, lint, unit-test).
- [ ] Spot-check a warm run's setup-soldr step for the solo-cache hit log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)