### PR TITLE
ci: bump setup-soldr v0.9.46 → v0.9.47

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.46
+      - uses: zackees/setup-soldr@v0.9.47
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.46
+      - uses: zackees/setup-soldr@v0.9.47
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.46
+      - uses: zackees/setup-soldr@v0.9.47
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.46
+      - uses: zackees/setup-soldr@v0.9.47
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` pin from `v0.9.46` to `v0.9.47` across `.github/workflows/`.
- Picks up setup-soldr#347/#348 — new `cache-eviction-policy` input (defaults to disabled; behavior unchanged for this repo).

## Test plan
- [ ] CI green on all workflows (`_build`, `_integration-test`, `_lint`, `_unit-test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)