### PR TITLE
ci: bump setup-soldr v0.9.47 -> v0.9.48 (cache-eviction age floor fix)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.47
+      - uses: zackees/setup-soldr@v0.9.48
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.47
+      - uses: zackees/setup-soldr@v0.9.48
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.47
+      - uses: zackees/setup-soldr@v0.9.48
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.47
+      - uses: zackees/setup-soldr@v0.9.48
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Picks up setup-soldr#352/#353 — cache-eviction-policy age floor fix. This repo doesn't enable the policy, so no behavior change.