### PR TITLE
ci: bump setup-soldr v0.9.48 -> v0.9.49

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.48
+      - uses: zackees/setup-soldr@v0.9.49
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.48
+      - uses: zackees/setup-soldr@v0.9.49
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.48
+      - uses: zackees/setup-soldr@v0.9.49
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.48
+      - uses: zackees/setup-soldr@v0.9.49
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.48` to `v0.9.49`.

## What's in v0.9.49
- `cache-eviction-policy: protect-foundations` thresholds raised from 9 GB / 8 GB to 9.5 GB / 9.0 GB.
- Reason: v0.9.48 was leaving ~2 GB of usable cache budget on the table. New thresholds keep 0.5 GB headroom under GitHub's 10 GB cap and fire eviction less eagerly while still beating GitHub's own non-deterministic LRU. The 6h age floor from v0.9.48 is unchanged.

No action input changes; this is a pure threshold tuning that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green (warm restore + post-step eviction logs)
- [ ] Post-step eviction log shows new thresholds (`evicting toward 9 GB` when usage > 9.5 GB) — or no eviction at all if usage stays under 9.5 GB
