### PR TITLE
feat(dwarf): bridge source maps to debug sources

### DIFF
--- a/.github/workflows/linux-x86-dwarf-smoke.yml
+++ b/.github/workflows/linux-x86-dwarf-smoke.yml
@@ -1,0 +1,64 @@
+name: Linux x86 DWARF Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  dwarf-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.11.9"
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
+
+      - uses: zackees/setup-soldr@v0.9.48
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          cache-preset: foundation
+          cache-key-suffix: ubuntu-24.04-dwarf-smoke
+          linker: platform-default
+          toolchain-file: rust-toolchain.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Sync Python deps
+        run: uv sync --group dev
+
+      - name: Build fastled CLI
+        run: soldr cargo build --release --bin fastled
+
+      - name: DWARF source smoke
+        run: |
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+          fastled_bin="$PWD/target/release/fastled"
+          sketch_dir="$workdir/Blink"
+          "$fastled_bin" --init Blink --branch master --no-interactive "$workdir"
+          "$fastled_bin" --internal-dwarf-smoke --debug --no-interactive "$sketch_dir"
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-logs-dwarf-smoke-ubuntu-24.04
+          path: logs/*
+          if-no-files-found: warn

--- a/crates/fastled-cli/src/debug_symbols.rs
+++ b/crates/fastled-cli/src/debug_symbols.rs
@@ -10,17 +10,19 @@
 //! This is the Rust port of the legacy Python `debug_symbols.py` module that
 //! used to back the Flask-based debug routes.
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_FASTLED_PREFIX: &str = "fastledsource";
 pub const DEFAULT_SKETCH_PREFIX: &str = "sketchsource";
 pub const DEFAULT_DWARF_PREFIX: &str = "dwarfsource";
+pub const DWARF_ROOTS_MANIFEST: &str = "dwarf-roots.json";
 
 /// Configurable DWARF path prefixes loaded from
 /// `<fastled-src>/platforms/wasm/compiler/build_flags.toml`.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DwarfPrefixConfig {
     #[serde(default = "default_fastled_prefix")]
     pub fastled_prefix: String,
@@ -28,6 +30,10 @@ pub struct DwarfPrefixConfig {
     pub sketch_prefix: String,
     #[serde(default = "default_dwarf_prefix")]
     pub dwarf_prefix: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_prefix_map_from: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_prefix_map_to: Option<String>,
 }
 
 fn default_fastled_prefix() -> String {
@@ -48,11 +54,13 @@ impl Default for DwarfPrefixConfig {
             fastled_prefix: default_fastled_prefix(),
             sketch_prefix: default_sketch_prefix(),
             dwarf_prefix: default_dwarf_prefix(),
+            file_prefix_map_from: None,
+            file_prefix_map_to: None,
         }
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DebugSymbolConfig {
     pub sketch_dir: PathBuf,
     pub fastled_dir: Option<PathBuf>,
@@ -86,7 +94,7 @@ impl DebugSymbolConfig {
 }
 
 fn canonicalize_or(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    crate::path::canonicalize_normalized(path).into_path_buf()
 }
 
 /// Load DWARF prefix overrides from
@@ -129,6 +137,47 @@ fn read_dwarf_prefixes(fastled_dir: &Path) -> Option<DwarfPrefixConfig> {
     parsed.dwarf
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct DebugSymbolManifest {
+    version: u32,
+    config: DebugSymbolConfig,
+}
+
+pub fn write_debug_symbol_manifest(
+    output_dir: &Path,
+    config: &DebugSymbolConfig,
+) -> Result<PathBuf> {
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("create {}", output_dir.display()))?;
+    let path = output_dir.join(DWARF_ROOTS_MANIFEST);
+    let manifest = DebugSymbolManifest {
+        version: 1,
+        config: config.clone(),
+    };
+    let json = serde_json::to_string_pretty(&manifest)?;
+    std::fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+    Ok(path)
+}
+
+pub fn read_debug_symbol_manifest(output_dir: &Path) -> Result<Option<DebugSymbolConfig>> {
+    let path = output_dir.join(DWARF_ROOTS_MANIFEST);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let json =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let manifest: DebugSymbolManifest =
+        serde_json::from_str(&json).with_context(|| format!("parse {}", path.display()))?;
+    if manifest.version != 1 {
+        anyhow::bail!(
+            "unsupported debug symbol manifest version {} in {}",
+            manifest.version,
+            path.display()
+        );
+    }
+    Ok(Some(manifest.config))
+}
+
 /// Resolves browser-issued DWARF paths to absolute file paths on disk.
 #[derive(Debug, Clone)]
 pub struct DebugSymbolResolver {
@@ -144,12 +193,18 @@ impl DebugSymbolResolver {
         &self.config
     }
 
-    fn known_prefixes(&self) -> [&str; 3] {
-        [
-            self.config.prefixes.fastled_prefix.as_str(),
-            self.config.prefixes.sketch_prefix.as_str(),
-            self.config.prefixes.dwarf_prefix.as_str(),
-        ]
+    fn known_prefixes(&self) -> Vec<String> {
+        let mut prefixes = vec![
+            self.config.prefixes.fastled_prefix.clone(),
+            self.config.prefixes.sketch_prefix.clone(),
+            self.config.prefixes.dwarf_prefix.clone(),
+        ];
+        for (prefix, _) in self.config.source_roots() {
+            if !prefixes.iter().any(|known| known == &prefix) {
+                prefixes.push(prefix);
+            }
+        }
+        prefixes
     }
 
     /// Strip leading garbage from a DWARF-issued path so that what remains
@@ -173,7 +228,7 @@ impl DebugSymbolResolver {
         let parts: Vec<&str> = normalized.split('/').filter(|p| !p.is_empty()).collect();
         let mut prefix_index: Option<usize> = None;
         for (idx, part) in parts.iter().enumerate() {
-            if prefixes.contains(part) {
+            if prefixes.iter().any(|prefix| prefix == part) {
                 prefix_index = Some(idx);
             }
         }
@@ -267,20 +322,7 @@ fn finalize_target(
 }
 
 fn lexically_normalize(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                out.pop();
-            }
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    if let Ok(canonical) = path.canonicalize() {
-        return canonical;
-    }
-    out
+    crate::path::canonicalize_normalized(path).into_path_buf()
 }
 
 fn is_within(path: &Path, root: &Path) -> bool {
@@ -445,5 +487,61 @@ dwarf_prefix = "fl_dwarf"
         assert_eq!(config.prefixes.fastled_prefix, "fl_src");
         assert_eq!(config.prefixes.sketch_prefix, "fl_sketch");
         assert_eq!(config.prefixes.dwarf_prefix, "fl_dwarf");
+    }
+
+    #[test]
+    fn debug_symbol_manifest_round_trips_config() {
+        let (tmp, sketch_dir, fastled_dir, emsdk_dir) = setup_dirs();
+        let output_dir = tmp.path().join("fastled_js");
+        let config = load_debug_symbol_config(
+            sketch_dir.clone(),
+            Some(fastled_dir.clone()),
+            Some(emsdk_dir.clone()),
+        );
+
+        let path = write_debug_symbol_manifest(&output_dir, &config).unwrap();
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some(DWARF_ROOTS_MANIFEST)
+        );
+
+        let loaded = read_debug_symbol_manifest(&output_dir)
+            .unwrap()
+            .expect("manifest should exist");
+        let resolver = DebugSymbolResolver::new(loaded);
+        let resolved = resolver.resolve("sketchsource/src/demo.ino", true).unwrap();
+        let expected =
+            crate::path::canonicalize_normalized(&sketch_dir.join("src").join("demo.ino"))
+                .into_path_buf();
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn direct_emsdk_prefix_resolves_from_source_roots() {
+        let (_tmp, sketch_dir, fastled_dir, emsdk_dir) = setup_dirs();
+        let resolver = DebugSymbolResolver::new(load_debug_symbol_config(
+            sketch_dir,
+            Some(fastled_dir),
+            Some(emsdk_dir),
+        ));
+
+        let emsdk = resolver
+            .resolve("emsdk/upstream/emscripten/cache.h", true)
+            .unwrap();
+        assert!(emsdk.ends_with("cache.h"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn source_roots_strip_windows_long_path_prefix() {
+        let config = DebugSymbolConfig {
+            sketch_dir: PathBuf::from(r"\\?\C:\tmp\sketch"),
+            fastled_dir: None,
+            emsdk_path: None,
+            prefixes: DwarfPrefixConfig::default(),
+        };
+
+        let roots = config.source_roots();
+        assert!(!roots[0].1.display().to_string().starts_with(r"\\?\"));
     }
 }

--- a/crates/fastled-cli/src/debug_symbols.rs
+++ b/crates/fastled-cli/src/debug_symbols.rs
@@ -360,7 +360,7 @@ pub fn guess_emsdk_path() -> Option<PathBuf> {
         return Some(PathBuf::from(emsdk));
     }
     if let Some(install_dir) = std::env::var_os("FASTLED_EMSCRIPTEN_DIR").map(PathBuf::from) {
-        return install_dir.parent().map(Path::to_path_buf);
+        return Some(install_dir);
     }
     None
 }

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -170,6 +170,48 @@ fn multipart_parts(version_info: &VersionInfo) -> Option<&[PartRef]> {
         .filter(|parts| !parts.is_empty())
 }
 
+#[cfg(unix)]
+fn ensure_bin_executables(install_dir: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin_dir = install_dir.join("bin");
+    if !bin_dir.is_dir() {
+        return Ok(());
+    }
+
+    let mut pending = vec![bin_dir];
+    while let Some(dir) = pending.pop() {
+        for entry in fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
+            let entry = entry.with_context(|| format!("read entry in {}", dir.display()))?;
+            let path = entry.path();
+            let metadata = fs::metadata(&path)
+                .with_context(|| format!("read metadata for {}", path.display()))?;
+            if metadata.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if !metadata.is_file() {
+                continue;
+            }
+
+            let mut permissions = metadata.permissions();
+            let mode = permissions.mode();
+            if mode & 0o111 == 0 {
+                permissions.set_mode(mode | 0o111);
+                fs::set_permissions(&path, permissions)
+                    .with_context(|| format!("set executable bit on {}", path.display()))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_bin_executables(_install_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
 /// Ensure the emscripten toolchain is installed at
 /// `~/.fastled/toolchains/emscripten/{platform}/{arch}/{version}/`.
 /// Returns the install directory path.
@@ -232,6 +274,7 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     }
     fs::create_dir_all(&staging)?;
     archive::extract_tar_zst(&archive_path, &staging)?;
+    ensure_bin_executables(&staging)?;
 
     fs::write(staging.join("done.txt"), "ok\n")?;
 
@@ -1224,6 +1267,27 @@ mod tests {
         let parts = multipart_parts(entry).expect("parts present");
         assert_eq!(parts.len(), 1);
         assert!(parts[0].href.ends_with(".part-aa"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_bin_executables_restores_unix_execute_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin");
+        let tool = bin_dir.join("llvm-ar");
+        fs::write(&tool, b"#!/bin/sh\n").expect("write tool");
+
+        let mut permissions = fs::metadata(&tool).expect("metadata").permissions();
+        permissions.set_mode(0o644);
+        fs::set_permissions(&tool, permissions).expect("clear executable bit");
+
+        ensure_bin_executables(temp.path()).expect("restore executable bits");
+
+        let mode = fs::metadata(&tool).expect("metadata").permissions().mode();
+        assert_ne!(mode & 0o111, 0);
     }
 
     /// Regression for issue #111: the win/x86_64 manifest publishes version

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -163,6 +163,13 @@ fn download_multipart(parts: &[PartRef], parts_dir: &Path, merged_path: &Path) -
     Ok(())
 }
 
+fn multipart_parts(version_info: &VersionInfo) -> Option<&[PartRef]> {
+    version_info
+        .parts
+        .as_deref()
+        .filter(|parts| !parts.is_empty())
+}
+
 /// Ensure the emscripten toolchain is installed at
 /// `~/.fastled/toolchains/emscripten/{platform}/{arch}/{version}/`.
 /// Returns the install directory path.
@@ -199,11 +206,12 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     let parts_subdir = cache_dir.join(format!("emscripten-{platform}-{arch}-{version}.parts"));
 
     if !archive_path.exists() {
-        let parts = version_info
-            .parts
-            .as_ref()
-            .with_context(|| format!("manifest version {version} has no parts"))?;
-        download_multipart(parts, &parts_subdir, &archive_path)?;
+        if let Some(parts) = multipart_parts(version_info) {
+            download_multipart(parts, &parts_subdir, &archive_path)?;
+        } else {
+            archive::download(&version_info.href, &archive_path)
+                .with_context(|| format!("download archive {}", version_info.href))?;
+        }
     }
 
     if !archive::verify_sha256(&archive_path, &version_info.sha256)? {
@@ -1205,6 +1213,7 @@ mod tests {
             "6af749f0d44927c7d4c93c9e407e195257ed690b8e3bd3a43d7a3f4badc52082"
         );
         assert!(entry.parts.is_none());
+        assert!(multipart_parts(entry).is_none());
     }
 
     #[test]
@@ -1212,7 +1221,7 @@ mod tests {
         let manifest: PlatformManifest = serde_json::from_str(LINUX_X86_64_MANIFEST_WITH_PARTS)
             .expect("parse linux/x86_64 manifest");
         let entry = manifest.versions.get("4.0.21").expect("entry for 4.0.21");
-        let parts = entry.parts.as_ref().expect("parts present");
+        let parts = multipart_parts(entry).expect("parts present");
         assert_eq!(parts.len(), 1);
         assert!(parts[0].href.ends_with(".part-aa"));
     }

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -975,16 +975,29 @@ fn serve_directory(dir: &str) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    let resolver = match debug_symbols::read_debug_symbol_manifest(&path) {
+        Ok(Some(config)) => Some(debug_symbols::DebugSymbolResolver::new(config)),
+        Ok(None) => None,
+        Err(err) => {
+            eprintln!(
+                "fastled: could not load {} from {}: {err:#}",
+                debug_symbols::DWARF_ROOTS_MANIFEST,
+                path.display()
+            );
+            None
+        }
+    };
+
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
-        let addr =
-            match server::start_server(path.clone(), 0, None, Arc::new(RwLock::new(None))).await {
-                Ok(a) => a,
-                Err(e) => {
-                    eprintln!("fastled: failed to start server: {e}");
-                    return ExitCode::FAILURE;
-                }
-            };
+        let debug_symbols: server::DebugSymbolHandle = Arc::new(RwLock::new(resolver));
+        let addr = match server::start_server(path.clone(), 0, None, debug_symbols).await {
+            Ok(a) => a,
+            Err(e) => {
+                eprintln!("fastled: failed to start server: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
 
         let url = format!("http://{addr}");
         println!("Serving {dir} at {url}");

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "512"]
 
+use anyhow::Context;
 use clap::Parser;
+use std::collections::BTreeSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -479,6 +481,11 @@ struct Cli {
     /// path so the Python side never has to do an HTTP download.
     #[arg(long, value_name = "REF", num_args = 0..=1, default_missing_value = "__latest__", hide = true)]
     internal_ensure_fastled_repo: Option<String>,
+
+    /// Internal CI plumbing: compile a debug sketch, start the source server
+    /// without the viewer, and verify every embedded debug source path.
+    #[arg(long, hide = true)]
+    internal_dwarf_smoke: bool,
 
     // Build mode (mutually exclusive).
     /// Build in debug mode.
@@ -1018,6 +1025,196 @@ fn serve_directory(dir: &str) -> ExitCode {
     })
 }
 
+fn run_internal_dwarf_smoke(cli: &Cli) -> ExitCode {
+    let Some(dir) = cli.directory.as_deref() else {
+        eprintln!("fastled: --internal-dwarf-smoke requires a sketch directory");
+        return ExitCode::FAILURE;
+    };
+    if selected_build_mode(cli) != build::BuildMode::Debug {
+        eprintln!("fastled: --internal-dwarf-smoke must be run with --debug");
+        return ExitCode::FAILURE;
+    }
+    if let Err(message) = ensure_compile_prerequisites() {
+        eprintln!("fastled: {message}");
+        return ExitCode::FAILURE;
+    }
+    if cli.purge {
+        purge_fastled_cache(cli.fastled_path.as_deref());
+    }
+
+    let request = build::BuildRequest {
+        sketch_dir: PathBuf::from(dir),
+        build_mode: build::BuildMode::Debug,
+        profile: cli.profile,
+        fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
+        force_clean: cli.purge,
+    };
+    let result = match build::run_build(&request) {
+        Ok(result) => result,
+        Err(err) => {
+            eprintln!("fastled: native compile path failed: {err:#}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if !result.success {
+        eprintln!("{}", result.output.trim_end());
+        eprintln!("\nCompilation failed.");
+        return ExitCode::FAILURE;
+    }
+
+    match run_dwarf_source_smoke(&result.output_dir) {
+        Ok(count) => {
+            println!(
+                "DWARF source smoke passed: resolved {count} embedded source paths via /dwarfsource"
+            );
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("fastled: DWARF source smoke failed: {err:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_dwarf_source_smoke(output_dir: &Path) -> anyhow::Result<usize> {
+    let config = debug_symbols::read_debug_symbol_manifest(output_dir)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing {} in {}",
+            debug_symbols::DWARF_ROOTS_MANIFEST,
+            output_dir.display()
+        )
+    })?;
+    let paths = collect_debug_source_paths(output_dir, &config)?;
+    if paths.is_empty() {
+        anyhow::bail!(
+            "no debug source paths found in {} or {}",
+            output_dir.join("fastled.wasm").display(),
+            output_dir.join("fastled.wasm.map").display()
+        );
+    }
+
+    let resolver = debug_symbols::DebugSymbolResolver::new(config);
+    let debug_symbols: server::DebugSymbolHandle = Arc::new(RwLock::new(Some(resolver)));
+    let output_dir = output_dir.to_path_buf();
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async move {
+        let addr = server::start_server(output_dir, 0, None, debug_symbols).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let client = reqwest::Client::new();
+        for path in &paths {
+            let resp = client
+                .post(format!("http://{addr}/dwarfsource"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(serde_json::json!({ "path": path }).to_string())
+                .send()
+                .await
+                .with_context(|| format!("POST /dwarfsource for {path}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("/dwarfsource rejected {path} with {status}: {body}");
+            }
+        }
+        Ok(paths.len())
+    })
+}
+
+fn collect_debug_source_paths(
+    output_dir: &Path,
+    config: &debug_symbols::DebugSymbolConfig,
+) -> anyhow::Result<BTreeSet<String>> {
+    let prefixes = debug_source_prefixes(config);
+    let mut paths = BTreeSet::new();
+
+    let wasm_path = output_dir.join("fastled.wasm");
+    let wasm =
+        std::fs::read(&wasm_path).with_context(|| format!("read {}", wasm_path.display()))?;
+    for candidate in extract_ascii_strings(&wasm) {
+        insert_debug_source_candidate(&mut paths, &prefixes, &candidate);
+    }
+
+    let source_map_path = output_dir.join("fastled.wasm.map");
+    if source_map_path.is_file() {
+        let json = std::fs::read_to_string(&source_map_path)
+            .with_context(|| format!("read {}", source_map_path.display()))?;
+        let parsed: serde_json::Value = serde_json::from_str(&json)
+            .with_context(|| format!("parse {}", source_map_path.display()))?;
+        if let Some(sources) = parsed.get("sources").and_then(serde_json::Value::as_array) {
+            for source in sources.iter().filter_map(serde_json::Value::as_str) {
+                insert_debug_source_candidate(&mut paths, &prefixes, source);
+            }
+        }
+    }
+
+    Ok(paths)
+}
+
+fn debug_source_prefixes(config: &debug_symbols::DebugSymbolConfig) -> Vec<String> {
+    let mut prefixes = Vec::new();
+    for prefix in [
+        config.prefixes.sketch_prefix.as_str(),
+        config.prefixes.fastled_prefix.as_str(),
+        config.prefixes.dwarf_prefix.as_str(),
+    ] {
+        push_debug_source_prefix(&mut prefixes, prefix);
+    }
+    for (prefix, _) in config.source_roots() {
+        push_debug_source_prefix(&mut prefixes, &prefix);
+    }
+    prefixes
+}
+
+fn push_debug_source_prefix(prefixes: &mut Vec<String>, prefix: &str) {
+    let mut normalized = prefix.trim_matches('/').replace('\\', "/");
+    if normalized.is_empty() {
+        return;
+    }
+    normalized.push('/');
+    if !prefixes.iter().any(|existing| existing == &normalized) {
+        prefixes.push(normalized);
+    }
+}
+
+fn insert_debug_source_candidate(
+    paths: &mut BTreeSet<String>,
+    prefixes: &[String],
+    candidate: &str,
+) {
+    let normalized = candidate
+        .trim()
+        .replace('\\', "/")
+        .trim_start_matches('/')
+        .to_string();
+    if normalized.is_empty() || normalized.split('/').any(|segment| segment == "..") {
+        return;
+    }
+    if prefixes
+        .iter()
+        .any(|prefix| normalized.starts_with(prefix) || normalized.contains(&format!("/{prefix}")))
+    {
+        paths.insert(normalized);
+    }
+}
+
+fn extract_ascii_strings(bytes: &[u8]) -> Vec<String> {
+    let mut strings = Vec::new();
+    let mut current = Vec::new();
+    for &byte in bytes {
+        if (0x20..=0x7e).contains(&byte) {
+            current.push(byte);
+        } else if current.len() >= 4 {
+            strings.push(String::from_utf8_lossy(&current).into_owned());
+            current.clear();
+        } else {
+            current.clear();
+        }
+    }
+    if current.len() >= 4 {
+        strings.push(String::from_utf8_lossy(&current).into_owned());
+    }
+    strings
+}
+
 /// Library entry point invoked by the `fastled` binary.
 pub fn run() -> ExitCode {
     let mut cli = Cli::parse();
@@ -1045,6 +1242,10 @@ pub fn run() -> ExitCode {
                 ExitCode::FAILURE
             }
         };
+    }
+
+    if cli.internal_dwarf_smoke {
+        return run_internal_dwarf_smoke(&cli);
     }
 
     // Handle --serve-dir natively with the Rust HTTP server (no Python needed).
@@ -1163,10 +1364,41 @@ mod tests {
             fastled_path: None,
             purge: false,
             internal_ensure_fastled_repo: None,
+            internal_dwarf_smoke: false,
             debug: false,
             quick: false,
             release: false,
         }
+    }
+
+    #[test]
+    fn collect_debug_source_paths_finds_wasm_and_source_map_entries() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let output_dir = temp.path().join("fastled_js");
+        fs::create_dir_all(&output_dir).unwrap();
+        fs::write(
+            output_dir.join("fastled.wasm"),
+            b"\0sketchsource/Blink.ino\0prefix/fastledsource/FastLED.h\0",
+        )
+        .unwrap();
+        fs::write(
+            output_dir.join("fastled.wasm.map"),
+            r#"{"version":3,"sources":["dwarfsource/emsdk/upstream/emscripten/cache.h","ignored.js"]}"#,
+        )
+        .unwrap();
+        let config = debug_symbols::DebugSymbolConfig {
+            sketch_dir: temp.path().join("Blink"),
+            fastled_dir: Some(temp.path().join("FastLED")),
+            emsdk_path: Some(temp.path().join("emsdk")),
+            prefixes: debug_symbols::DwarfPrefixConfig::default(),
+        };
+
+        let paths = collect_debug_source_paths(&output_dir, &config).unwrap();
+
+        assert!(paths.contains("sketchsource/Blink.ino"));
+        assert!(paths.contains("prefix/fastledsource/FastLED.h"));
+        assert!(paths.contains("dwarfsource/emsdk/upstream/emscripten/cache.h"));
+        assert!(!paths.contains("ignored.js"));
     }
 
     #[test]

--- a/crates/fastled-cli/src/server.rs
+++ b/crates/fastled-cli/src/server.rs
@@ -151,7 +151,11 @@ async fn serve_file(
     // Prevent directory traversal.
     let canonical = match file_path.canonicalize() {
         Ok(p) => p,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+        Err(_) => {
+            return serve_debug_source_url(&state, &path)
+                .await
+                .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+        }
     };
     let serve_canonical = match state.serve_dir.canonicalize() {
         Ok(p) => p,
@@ -166,7 +170,28 @@ async fn serve_file(
             let mime = mime_for_path(&path);
             (StatusCode::OK, [(header::CONTENT_TYPE, mime)], data).into_response()
         }
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Err(_) => serve_debug_source_url(&state, &path)
+            .await
+            .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response()),
+    }
+}
+
+async fn serve_debug_source_url(state: &AppState, request_path: &str) -> Option<Response> {
+    let resolver = state.debug_symbols.read().ok()?.clone()?;
+    match resolver.resolve(request_path, true) {
+        Ok(file) => match tokio::fs::read(&file).await {
+            Ok(bytes) => Some(
+                (
+                    StatusCode::OK,
+                    [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                    bytes,
+                )
+                    .into_response(),
+            ),
+            Err(_) => Some(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        },
+        Err(ResolveError::NotFound(_)) => Some(StatusCode::NOT_FOUND.into_response()),
+        Err(ResolveError::Invalid(_)) => None,
     }
 }
 
@@ -666,6 +691,77 @@ mod tests {
         assert!(roots
             .iter()
             .any(|r| r["prefix"].as_str() == Some("sketchsource")));
+    }
+
+    #[tokio::test]
+    async fn source_map_style_get_returns_resolved_file() {
+        use crate::debug_symbols::{load_debug_symbol_config, DebugSymbolResolver};
+
+        let dir = tempfile::tempdir().unwrap();
+        let serve_dir = dir.path().join("fastled_js");
+        let sketch_dir = dir.path().join("sketch");
+        fs::create_dir_all(sketch_dir.join("src")).unwrap();
+        fs::create_dir_all(&serve_dir).unwrap();
+        fs::write(sketch_dir.join("src").join("demo.ino"), "void loop() {}").unwrap();
+
+        let resolver = DebugSymbolResolver::new(load_debug_symbol_config(sketch_dir, None, None));
+        let handle: DebugSymbolHandle = Arc::new(RwLock::new(Some(resolver)));
+
+        let addr = start_server(serve_dir, 0, None, handle).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let resp = reqwest::get(format!("http://{addr}/sketchsource/src/demo.ino"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("text/plain"), "expected text/plain, got {ct}");
+        assert!(resp.text().await.unwrap().contains("void loop()"));
+
+        let resp = reqwest::get(format!(
+            "http://{addr}/.fastled/cache/fl/repo/sketchsource/src/demo.ino"
+        ))
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert!(resp.text().await.unwrap().contains("void loop()"));
+    }
+
+    #[tokio::test]
+    async fn source_map_get_works_from_debug_symbol_manifest() {
+        use crate::debug_symbols::{
+            load_debug_symbol_config, read_debug_symbol_manifest, write_debug_symbol_manifest,
+            DebugSymbolResolver,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let serve_dir = dir.path().join("fastled_js");
+        let sketch_dir = dir.path().join("sketch");
+        fs::create_dir_all(sketch_dir.join("src")).unwrap();
+        fs::create_dir_all(&serve_dir).unwrap();
+        fs::write(sketch_dir.join("src").join("demo.ino"), "void setup() {}").unwrap();
+
+        let config = load_debug_symbol_config(sketch_dir, None, None);
+        write_debug_symbol_manifest(&serve_dir, &config).unwrap();
+        let loaded = read_debug_symbol_manifest(&serve_dir)
+            .unwrap()
+            .expect("manifest should exist");
+        let handle: DebugSymbolHandle =
+            Arc::new(RwLock::new(Some(DebugSymbolResolver::new(loaded))));
+
+        let addr = start_server(serve_dir, 0, None, handle).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let resp = reqwest::get(format!("http://{addr}/sketchsource/src/demo.ino"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert!(resp.text().await.unwrap().contains("void setup()"));
     }
 
     #[tokio::test]

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -1051,10 +1051,7 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
     let tools = resolve_tool_paths(&emscripten_install)?;
     let (fastled_dir, _cleanup) = resolve_fastled_dir(request)?;
     let fastled_dir = normalize_path(&fastled_dir);
-    let emsdk_root = emscripten_install
-        .parent()
-        .map(Path::to_path_buf)
-        .or_else(|| Some(emscripten_install.clone()));
+    let emsdk_root = Some(emscripten_install.clone());
     let (example_name, example_dir, _is_in_tree) =
         resolve_example_name(&normalize_path(&request.sketch_dir), &fastled_dir);
 

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -13,7 +13,7 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-use crate::{archive, frontend, install};
+use crate::{archive, debug_symbols, frontend, install};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuildMode {
@@ -73,6 +73,7 @@ struct BuildFlagsToml {
     sketch: Option<FlagSection>,
     linking: Option<LinkingSection>,
     build_modes: Option<BTreeMap<String, ModeSection>>,
+    dwarf: Option<debug_symbols::DwarfPrefixConfig>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -97,6 +98,13 @@ struct ModeSection {
 #[derive(Debug, Default, Deserialize)]
 struct FlagList {
     flags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+struct DwarfPathRoots {
+    sketch_dir: Option<PathBuf>,
+    fastled_dir: PathBuf,
+    emsdk_root: Option<PathBuf>,
 }
 
 fn resolve_python_executable() -> PathBuf {
@@ -281,7 +289,11 @@ fn load_build_flags(fastled_dir: &Path) -> Result<BuildFlagsToml> {
     toml::from_str(&source).with_context(|| format!("parse {}", path.display()))
 }
 
-fn get_sketch_compile_flags(fastled_dir: &Path, mode: BuildMode) -> Result<Vec<String>> {
+fn get_sketch_compile_flags(
+    fastled_dir: &Path,
+    mode: BuildMode,
+    dwarf_roots: Option<&DwarfPathRoots>,
+) -> Result<Vec<String>> {
     let config = load_build_flags(fastled_dir)?;
     let mode_key = mode.as_str().to_string();
     let mode_config = config
@@ -304,6 +316,9 @@ fn get_sketch_compile_flags(fastled_dir: &Path, mode: BuildMode) -> Result<Vec<S
         } else {
             flags.extend(mode_config.flags.clone().unwrap_or_default());
         }
+    }
+    if mode == BuildMode::Debug {
+        append_dwarf_prefix_maps(&mut flags, config.dwarf.as_ref(), dwarf_roots);
     }
     Ok(flags)
 }
@@ -328,7 +343,76 @@ fn get_link_flags(fastled_dir: &Path, mode: BuildMode) -> Result<Vec<String>> {
     if let Some(mode_config) = mode_config {
         flags.extend(mode_config.link_flags.clone().unwrap_or_default());
     }
+    if mode == BuildMode::Debug
+        && !flags
+            .iter()
+            .any(|flag| flag == "-gsource-map" || flag.starts_with("-gsource-map="))
+    {
+        flags.push("-gsource-map".to_string());
+    }
     Ok(flags)
+}
+
+fn append_dwarf_prefix_maps(
+    flags: &mut Vec<String>,
+    config: Option<&debug_symbols::DwarfPrefixConfig>,
+    roots: Option<&DwarfPathRoots>,
+) {
+    let prefixes = config.cloned().unwrap_or_default();
+    if let Some(roots) = roots {
+        if let Some(sketch_dir) = &roots.sketch_dir {
+            push_file_prefix_map(flags, sketch_dir, &prefixes.sketch_prefix);
+        }
+        push_file_prefix_map(
+            flags,
+            &roots.fastled_dir.join("src"),
+            &prefixes.fastled_prefix,
+        );
+        if let Some(emsdk_root) = &roots.emsdk_root {
+            let emsdk_prefix = format!("{}/emsdk", prefixes.dwarf_prefix.trim_matches('/'));
+            push_file_prefix_map(flags, emsdk_root, &emsdk_prefix);
+        }
+        return;
+    }
+
+    if let (Some(from), Some(to)) = (
+        prefixes.file_prefix_map_from.as_ref(),
+        prefixes.file_prefix_map_to.as_ref(),
+    ) {
+        flags.push(format!(
+            "-ffile-prefix-map={}={}",
+            normalize_prefix_map_from(from),
+            normalize_prefix_map_to(to)
+        ));
+    }
+}
+
+fn push_file_prefix_map(flags: &mut Vec<String>, from: &Path, to: &str) {
+    flags.push(format!(
+        "-ffile-prefix-map={}={}",
+        normalize_prefix_map_path(from),
+        normalize_prefix_map_to(to)
+    ));
+}
+
+fn normalize_prefix_map_path(path: &Path) -> String {
+    let mut normalized = normalize_path(path).to_string_lossy().replace('\\', "/");
+    if !normalized.ends_with('/') {
+        normalized.push('/');
+    }
+    normalized
+}
+
+fn normalize_prefix_map_from(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn normalize_prefix_map_to(prefix: &str) -> String {
+    let mut normalized = prefix.trim_matches('/').replace('\\', "/");
+    if !normalized.ends_with('/') {
+        normalized.push('/');
+    }
+    normalized
 }
 
 fn hash_files(root: &Path, files: &[PathBuf]) -> Result<String> {
@@ -569,6 +653,7 @@ fn build_sketch_pch(
     tools: &ToolPaths,
     build_dir: &Path,
     mode: BuildMode,
+    emsdk_root: Option<&Path>,
     lib_was_rebuilt: bool,
 ) -> Result<Option<PathBuf>> {
     let pcm = build_dir.join("wasm_pch.h.pcm");
@@ -583,7 +668,13 @@ fn build_sketch_pch(
     if !header.is_file() {
         return Ok(None);
     }
-    let mut hash_input = get_sketch_compile_flags(fastled_dir, mode)?.join("\n");
+    let dwarf_roots = DwarfPathRoots {
+        sketch_dir: None,
+        fastled_dir: fastled_dir.to_path_buf(),
+        emsdk_root: emsdk_root.map(Path::to_path_buf),
+    };
+    let compile_flags = get_sketch_compile_flags(fastled_dir, mode, Some(&dwarf_roots))?;
+    let mut hash_input = compile_flags.join("\n");
     hash_input.push_str(&compute_source_file_hash(fastled_dir)?);
     let current_hash = format!("{:x}", Sha256::digest(hash_input.as_bytes()));
     if !lib_was_rebuilt
@@ -602,7 +693,7 @@ fn build_sketch_pch(
         "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST".to_string(),
         "-D_FILE_OFFSET_BITS=64".to_string(),
     ];
-    args.extend(get_sketch_compile_flags(fastled_dir, mode)?);
+    args.extend(compile_flags);
     args.push(format!("-I{}", fastled_dir.join("src").display()));
     args.push(format!(
         "-I{}",
@@ -651,25 +742,33 @@ fn build_sketch_pch(
 }
 
 fn compile_sketch(
-    fastled_dir: &Path,
     tools: &ToolPaths,
     wrapper: &Path,
     build_dir: &Path,
     sketch_cache_dir: &Path,
     example_dir: &Path,
     mode: BuildMode,
+    dwarf_roots: &DwarfPathRoots,
 ) -> Result<PathBuf> {
+    let fastled_dir = &dwarf_roots.fastled_dir;
     let object = sketch_cache_dir.join("sketch.o");
     let archive = library_archive(build_dir);
     let ino = sketch_ino_file(example_dir)?;
+    let compile_flags = get_sketch_compile_flags(fastled_dir, mode, Some(dwarf_roots))?;
+    let flags_hash_path = sketch_cache_dir.join("sketch_compile_flags.hash");
+    let current_flags_hash = format!("{:x}", Sha256::digest(compile_flags.join("\n").as_bytes()));
     if object.is_file() {
         let object_mtime = object.metadata()?.modified()?;
         let inputs = [wrapper, &ino, &archive];
-        if inputs
-            .iter()
-            .filter_map(|path| path.metadata().ok())
-            .filter_map(|metadata| metadata.modified().ok())
-            .all(|mtime| mtime <= object_mtime)
+        if fs::read_to_string(&flags_hash_path)
+            .unwrap_or_default()
+            .trim()
+            == current_flags_hash
+            && inputs
+                .iter()
+                .filter_map(|path| path.metadata().ok())
+                .filter_map(|metadata| metadata.modified().ok())
+                .all(|mtime| mtime <= object_mtime)
         {
             println!("[WASM] Sketch is up-to-date");
             return Ok(object);
@@ -682,7 +781,7 @@ fn compile_sketch(
         "-o".to_string(),
         object.display().to_string(),
     ];
-    args.extend(get_sketch_compile_flags(fastled_dir, mode)?);
+    args.extend(compile_flags);
     args.push(format!("-I{}", fastled_dir.join("src").display()));
     args.push(format!(
         "-I{}",
@@ -706,6 +805,7 @@ fn compile_sketch(
         .arg(&tools.empp)
         .args(&args);
     run_status(command, "em++ sketch compile")?;
+    fs::write(flags_hash_path, current_flags_hash)?;
     Ok(object)
 }
 
@@ -721,14 +821,21 @@ fn link_wasm(
     let archive = library_archive(build_dir);
     let cached_js = sketch_cache_dir.join("fastled.js");
     let cached_wasm = sketch_cache_dir.join("fastled.wasm");
+    let link_flags = get_link_flags(fastled_dir, mode)?;
+    let flags_hash_path = sketch_cache_dir.join("link_flags.hash");
+    let current_flags_hash = format!("{:x}", Sha256::digest(link_flags.join("\n").as_bytes()));
     if cached_js.is_file() && cached_wasm.is_file() {
         let output_mtime = cached_js.metadata()?.modified()?;
         let inputs = [sketch_object, &archive];
-        if inputs
-            .iter()
-            .filter_map(|path| path.metadata().ok())
-            .filter_map(|metadata| metadata.modified().ok())
-            .all(|mtime| mtime <= output_mtime)
+        if fs::read_to_string(&flags_hash_path)
+            .unwrap_or_default()
+            .trim()
+            == current_flags_hash
+            && inputs
+                .iter()
+                .filter_map(|path| path.metadata().ok())
+                .filter_map(|metadata| metadata.modified().ok())
+                .all(|mtime| mtime <= output_mtime)
         {
             copy_linked_output(sketch_cache_dir, output_js)?;
             println!("[WASM] Link output up-to-date");
@@ -767,10 +874,11 @@ fn link_wasm(
         "-o".to_string(),
         cached_js.display().to_string(),
     ];
-    args.extend(get_link_flags(fastled_dir, mode)?);
+    args.extend(link_flags);
 
     println!("[WASM] Linking final WASM module...");
     run_em_link_with_retries(fastled_dir, tools, &args)?;
+    fs::write(flags_hash_path, current_flags_hash)?;
     copy_linked_output(sketch_cache_dir, output_js)?;
     Ok(())
 }
@@ -782,19 +890,12 @@ fn link_wasm(
 /// Because each completed library is cached to disk, retrying advances the
 /// build by one library each time. A small retry loop lets the link
 /// converge without exposing the upstream flakiness to users. See #116.
-fn run_em_link_with_retries(
-    fastled_dir: &Path,
-    tools: &ToolPaths,
-    args: &[String],
-) -> Result<()> {
+fn run_em_link_with_retries(fastled_dir: &Path, tools: &ToolPaths, args: &[String]) -> Result<()> {
     let max_attempts = if cfg!(windows) { 6 } else { 1 };
     let mut last_err: Option<anyhow::Error> = None;
     for attempt in 1..=max_attempts {
         let mut command = command_with_env(&tools.python, tools);
-        command
-            .current_dir(fastled_dir)
-            .arg(&tools.empp)
-            .args(args);
+        command.current_dir(fastled_dir).arg(&tools.empp).args(args);
         match run_status(command, "em++ wasm link") {
             Ok(()) => return Ok(()),
             Err(err) => {
@@ -816,11 +917,19 @@ fn copy_linked_output(sketch_cache_dir: &Path, output_js: &Path) -> Result<()> {
         .parent()
         .ok_or_else(|| anyhow::anyhow!("output path has no parent: {}", output_js.display()))?;
     fs::create_dir_all(output_dir)?;
-    for name in ["fastled.js", "fastled.wasm"] {
+    for name in [
+        "fastled.js",
+        "fastled.wasm",
+        "fastled.wasm.map",
+        "fastled.js.map",
+    ] {
         let src = sketch_cache_dir.join(name);
+        let dst = output_dir.join(name);
         if src.is_file() {
-            fs::copy(&src, output_dir.join(name))
+            fs::copy(&src, &dst)
                 .with_context(|| format!("copy {} to {}", src.display(), output_dir.display()))?;
+        } else if dst.exists() {
+            fs::remove_file(&dst).with_context(|| format!("remove stale {}", dst.display()))?;
         }
     }
     Ok(())
@@ -975,18 +1084,24 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
             &tools,
             &build_dir,
             request.build_mode,
+            emsdk_root.as_deref(),
             lib_rebuilt,
         );
         let sketch_cache = sketch_cache_dir(&example_dir);
         let wrapper = create_wrapper(&example_dir, &example_name, &sketch_cache)?;
+        let sketch_dwarf_roots = DwarfPathRoots {
+            sketch_dir: Some(example_dir.clone()),
+            fastled_dir: fastled_dir.clone(),
+            emsdk_root: emsdk_root.clone(),
+        };
         let sketch_o = compile_sketch(
-            &fastled_dir,
             &tools,
             &wrapper,
             &build_dir,
             &sketch_cache,
             &example_dir,
             request.build_mode,
+            &sketch_dwarf_roots,
         )?;
         let output_js = output_dir.join("fastled.js");
         link_wasm(
@@ -1000,6 +1115,12 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
         )?;
         frontend::copy_frontend_to_output(&output_dir, None)?;
         generate_manifest(&example_dir, &output_dir)?;
+        let debug_config = debug_symbols::load_debug_symbol_config(
+            example_dir.clone(),
+            Some(fastled_dir.clone()),
+            emsdk_root.clone(),
+        );
+        debug_symbols::write_debug_symbol_manifest(&output_dir, &debug_config)?;
         Ok(())
     })();
 
@@ -1030,6 +1151,13 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+
+    fn write_build_flags(fastled_dir: &Path, source: &str) {
+        let compiler_dir = fastled_dir.join("src/platforms/wasm/compiler");
+        fs::create_dir_all(&compiler_dir).unwrap();
+        fs::write(compiler_dir.join("build_flags.toml"), source).unwrap();
+    }
 
     #[test]
     fn resolve_example_preserves_nested_names() {
@@ -1070,5 +1198,133 @@ mod tests {
         assert_eq!(BuildMode::Quick.as_str(), "quick");
         assert_eq!(BuildMode::Debug.as_str(), "debug");
         assert_eq!(BuildMode::Release.as_str(), "release");
+    }
+
+    #[test]
+    fn debug_compile_flags_include_dynamic_dwarf_prefix_maps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fastled_dir = tmp.path().join("FastLED");
+        let sketch_dir = tmp.path().join("Blink");
+        let emsdk_root = tmp.path().join("emsdk");
+        write_build_flags(
+            &fastled_dir,
+            r#"
+[all]
+defines = []
+compiler_flags = []
+
+[sketch]
+defines = []
+compiler_flags = []
+
+[build_modes.debug]
+flags = ["-g3"]
+
+[dwarf]
+fastled_prefix = "fastledsource"
+sketch_prefix = "sketchsource"
+dwarf_prefix = "dwarfsource"
+"#,
+        );
+        let roots = DwarfPathRoots {
+            sketch_dir: Some(sketch_dir.clone()),
+            fastled_dir: fastled_dir.clone(),
+            emsdk_root: Some(emsdk_root.clone()),
+        };
+
+        let flags = get_sketch_compile_flags(&fastled_dir, BuildMode::Debug, Some(&roots)).unwrap();
+
+        assert!(flags.contains(&format!(
+            "-ffile-prefix-map={}={}",
+            normalize_prefix_map_path(&sketch_dir),
+            "sketchsource/"
+        )));
+        assert!(flags.contains(&format!(
+            "-ffile-prefix-map={}={}",
+            normalize_prefix_map_path(&fastled_dir.join("src")),
+            "fastledsource/"
+        )));
+        assert!(flags.contains(&format!(
+            "-ffile-prefix-map={}={}",
+            normalize_prefix_map_path(&emsdk_root),
+            "dwarfsource/emsdk/"
+        )));
+    }
+
+    #[test]
+    fn quick_compile_flags_do_not_include_dwarf_prefix_maps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fastled_dir = tmp.path().join("FastLED");
+        write_build_flags(
+            &fastled_dir,
+            r#"
+[all]
+defines = []
+compiler_flags = []
+
+[sketch]
+defines = []
+compiler_flags = []
+
+[build_modes.quick]
+flags = ["-g0"]
+"#,
+        );
+        let roots = DwarfPathRoots {
+            sketch_dir: Some(tmp.path().join("Blink")),
+            fastled_dir: fastled_dir.clone(),
+            emsdk_root: None,
+        };
+
+        let flags = get_sketch_compile_flags(&fastled_dir, BuildMode::Quick, Some(&roots)).unwrap();
+
+        assert!(!flags
+            .iter()
+            .any(|flag| flag.starts_with("-ffile-prefix-map=")));
+    }
+
+    #[test]
+    fn debug_link_flags_emit_wasm_source_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fastled_dir = tmp.path().join("FastLED");
+        write_build_flags(
+            &fastled_dir,
+            r#"
+[linking.base]
+flags = ["-sWASM=1"]
+
+[linking.sketch]
+flags = []
+
+[build_modes.debug]
+link_flags = []
+"#,
+        );
+
+        let flags = get_link_flags(&fastled_dir, BuildMode::Debug).unwrap();
+
+        assert!(flags.contains(&"-gsource-map".to_string()));
+    }
+
+    #[test]
+    fn copy_linked_output_copies_and_removes_source_maps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let output = tmp.path().join("out").join("fastled.js");
+        fs::create_dir_all(&cache).unwrap();
+        fs::create_dir_all(output.parent().unwrap()).unwrap();
+        fs::write(cache.join("fastled.js"), "js").unwrap();
+        fs::write(cache.join("fastled.wasm"), "wasm").unwrap();
+        fs::write(cache.join("fastled.wasm.map"), "map").unwrap();
+
+        copy_linked_output(&cache, &output).unwrap();
+        assert_eq!(
+            fs::read_to_string(output.parent().unwrap().join("fastled.wasm.map")).unwrap(),
+            "map"
+        );
+
+        fs::remove_file(cache.join("fastled.wasm.map")).unwrap();
+        copy_linked_output(&cache, &output).unwrap();
+        assert!(!output.parent().unwrap().join("fastled.wasm.map").exists());
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     # emcc.py/em++.py/emar.py entry points directly.
     "meson>=1.4",
     "ninja>=1.11",
+    "typeguard>=4.4.4",
     "zcmds_win32; sys_platform == 'win32'",
 ]
 


### PR DESCRIPTION
## Summary

Refs #130, #129, #85.

This PR lands the fastled-wasm side of the browser DWARF/source bridge:

- generates debug-mode `-ffile-prefix-map` flags for sketch, FastLED, and emsdk roots using the `[dwarf]` prefixes from `build_flags.toml`
- keeps debug source maps enabled, copies `fastled.wasm.map` / `fastled.js.map` into `fastled_js/`, and removes stale maps when a later build does not produce them
- writes `fastled_js/dwarf-roots.json` after successful builds and lets `--serve-dir` rehydrate the guarded debug source resolver from it
- serves source-map URLs such as `sketchsource/Blink.ino`, FastLED prefix-map paths, emsdk paths, and browser-normalized variants through the existing `/dwarfsource` resolver
- adds a Linux x86 DWARF smoke workflow that builds debug Blink and verifies embedded wasm/source-map paths round-trip through `/dwarfsource`
- updates emscripten archive install handling for direct `href` manifests and restores executable bits after extraction

## Notes

This pairs with FastLED/FastLED#2675, which landed the FastLED-side wasm prefix-map support. I am not closing #130 from the PR alone; final issue closure still needs the browser null-deref acceptance check against the merged code.

## Test plan

- [x] `soldr cargo test -p fastled-cli debug_symbols`
- [x] `soldr cargo test -p fastled-cli wasm_build`
- [x] `soldr cargo test -p fastled-cli server`
- [x] `soldr cargo test -p fastled-cli`
- [x] `soldr --no-cache cargo test -p fastled-cli install::tests`
- [x] `bash lint`
- [x] `bash test`
- [x] local hidden smoke: `fastled --internal-dwarf-smoke --debug --no-interactive ./Blink` resolved 136 embedded source paths via `/dwarfsource`
- [x] PR #132 CI: all matrix checks passed, including `Linux x86 DWARF Smoke`