### PR TITLE
ci: bump setup-soldr v0.9.49 -> v0.9.50

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.49` to `v0.9.50`.

## What's in v0.9.50
Graduated age floor for `cache-eviction-policy` (closes setup-soldr#356).

v0.9.48's fixed 6h age floor became a no-op under heavy CI load. Observed on zccache MSRV at 13.63 GB usage where ALL 171 evictable entries were < 6h old — eviction deleted zero, leaving GitHub's non-deterministic LRU in charge of foundation entries.

New tier table:

| Overshoot (usage − trigger) | Floor (protect-foundations) | Floor (aggressive) |
|---|---|---|
| ≤ 1 GB        | 6h (baseline, #352 fix preserved)   | 2h |
| 1–3 GB        | 2h                                  | 2h |
| > 3 GB        | 0.5h (danger zone)                  | 0.5h |

Post-step log now emits `graduated age floor active — overshoot=X GB, floor=Y h` when the tier kicks in. No action-input changes; pure logic improvement that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green
- [ ] Post-step log shows `deleted N entries` (N ≥ 1) when usage > +3 GB over trigger
