### PR TITLE
chore: source Python version from Cargo

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check if version needs release
         id: version_check
         run: |
-          VERSION=$(grep '^__version__' src/fastled/__version__.py | sed 's/.*"\(.*\)"/\1/')
+          VERSION=$(python -c 'import tomllib; from pathlib import Path; manifest = tomllib.loads(Path("Cargo.toml").read_text(encoding="utf-8")); print(manifest["workspace"]["package"]["version"])')
           echo "current=$VERSION" >> $GITHUB_OUTPUT
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/fastled/$VERSION/json")
           if [ "$STATUS" = "200" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel>=0.43"]
+requires = ["setuptools>=69", "wheel>=0.43", "tomli>=2; python_version < '3.11'"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
@@ -19,7 +19,7 @@ dev = [
 
 [project]
 name = "fastled"
-version = "2.0.9"
+dynamic = ["version"]
 readme = "README.md"
 description = "FastLED Wasm Compiler"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,15 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 from setuptools import Distribution, setup
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parent
 PACKAGE_BIN_DIR = ROOT / "src" / "fastled" / "bin"
@@ -19,6 +25,19 @@ def _cargo_command() -> list[str]:
     if soldr:
         return [soldr, "cargo"]
     raise RuntimeError("soldr was not found; cannot build bundled fastled")
+
+
+def _workspace_package_version() -> str:
+    cargo_toml = ROOT / "Cargo.toml"
+    with cargo_toml.open("rb") as handle:
+        manifest: dict[str, Any] = tomllib.load(handle)
+    try:
+        version = manifest["workspace"]["package"]["version"]
+    except KeyError as exc:
+        raise RuntimeError("Cargo.toml is missing workspace.package.version") from exc
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("Cargo.toml workspace.package.version must be a string")
+    return version
 
 
 def _candidate_binaries() -> list[Path]:
@@ -87,6 +106,7 @@ class bdist_wheel(_bdist_wheel):
 
 
 setup(
+    version=_workspace_package_version(),
     distclass=BinaryDistribution,
     cmdclass={
         "bdist_wheel": bdist_wheel,

--- a/src/fastled/__version__.py
+++ b/src/fastled/__version__.py
@@ -1,2 +1,41 @@
-# Version is read directly from this file by the GitHub Actions release workflow.
-__version__ = "2.0.9"
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _workspace_package_version() -> str | None:
+    for parent in Path(__file__).resolve().parents:
+        cargo_toml = parent / "Cargo.toml"
+        if cargo_toml.is_file():
+            return _read_workspace_package_version(cargo_toml)
+    return None
+
+
+def _read_workspace_package_version(cargo_toml: Path) -> str | None:
+    in_workspace_package = False
+    version_pattern = re.compile(r'^version\s*=\s*"([^"]+)"')
+    for raw_line in cargo_toml.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            in_workspace_package = line == "[workspace.package]"
+            continue
+        if in_workspace_package:
+            match = version_pattern.match(line)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _installed_or_source_version() -> str:
+    source_version = _workspace_package_version()
+    if source_version:
+        return source_version
+    try:
+        return version("fastled")
+    except PackageNotFoundError:
+        raise
+
+
+__version__ = _installed_or_source_version()

--- a/tests/unit/test_python_api.py
+++ b/tests/unit/test_python_api.py
@@ -1,4 +1,6 @@
 import importlib.util
+import re
+from pathlib import Path
 
 import fastled
 
@@ -7,6 +9,27 @@ def test_python_package_is_cli_only() -> None:
     assert fastled.__version__
     assert fastled.__all__ == ["__version__"]
     assert not hasattr(fastled, "BuildService")
+
+
+def test_python_version_matches_cargo_workspace_version() -> None:
+    cargo_toml = Path(__file__).resolve().parents[2] / "Cargo.toml"
+    in_workspace_package = False
+    cargo_version = None
+    version_pattern = re.compile(r'^version\s*=\s*"([^"]+)"')
+    for raw_line in cargo_toml.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            in_workspace_package = line == "[workspace.package]"
+            continue
+        if in_workspace_package:
+            match = version_pattern.match(line)
+            if not match:
+                continue
+            cargo_version = match.group(1)
+            break
+
+    assert cargo_version
+    assert fastled.__version__ == cargo_version
 
 
 def test_native_extension_is_not_packaged() -> None:


### PR DESCRIPTION
Closes #99.

Summary:
- Reads the Python package version from `Cargo.toml` workspace metadata during builds.
- Makes `fastled.__version__` resolve from the source tree when available and from installed package metadata in wheels.
- Updates the auto-release workflow to use the Cargo workspace version instead of parsing `src/fastled/__version__.py`.

Validation:
- `uv run pytest tests/unit/test_python_api.py -v`
- `uv run ruff check setup.py src/fastled/__version__.py tests/unit/test_python_api.py`
- `uv run python setup.py --version`
- `git diff --check`