### PR TITLE
ci: bump setup-soldr v0.9.53 -> v0.9.55

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.53
+      - uses: zackees/setup-soldr@v0.9.55
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.53
+      - uses: zackees/setup-soldr@v0.9.55
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.53
+      - uses: zackees/setup-soldr@v0.9.55
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.53
+      - uses: zackees/setup-soldr@v0.9.55
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.53` to `v0.9.55`.

## What's in v0.9.54–v0.9.55
- **v0.9.54** — Extended per-layer split-timing (compress vs upload columns) to build-cache and cargo-registry (diagnostic).
- **v0.9.55** — **PERF**: setup-soldr now auto-derives `parentSha` from `git log -1 --format=%P HEAD` when `ACTION_PARENT_SHA` env var isn't set. This activates the cook-cache-delta, target-cache, and cargo-registry parent-SHA fallback restore keys that were previously inert (production observation: cook-cache-delta had 0% hit rate across 6 jobs in 3 runs). Closes setup-soldr#365.

## Test plan
- [ ] CI green
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears in the log (instead of `(no parent-fallback ...)`)
- [ ] Second commit after this lands: cook-cache-delta restore should HIT against this commit's saved entry (instead of MISS)
