### PR TITLE
ci: bump setup-soldr v0.9.55 -> v0.9.56

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.55` to `v0.9.56`.

## What's in v0.9.56
Fixes v0.9.55's parentSha derivation on shallow checkouts (the default `actions/checkout` config with `fetch-depth: 1`). Production observation on zccache MSRV (run 26799669322):
```
parent-sha: unexpected git output "\n"; leaving empty
cook: layered keys ... (no parent-fallback — parentSha unavailable, #365)
cook-cache-delta MISS
```

`git log -1 --format=%P HEAD` returns empty for grafted root commits on shallow clones. v0.9.56 adds a `git cat-file -p HEAD` fallback that parses the raw commit object — its `parent` header line is preserved even when the parent commit isn't fetched. This finally activates the cook-cache-delta / target-cache / cargo-registry parent-SHA fallback restore keys.

## Test plan
- [ ] CI green
- [ ] Log shows `parent-sha: derived <sha> from cat-file (#365, shallow-safe)`
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears
- [ ] Second commit after this lands: cook-cache-delta should HIT against this commit's saved entry
