### PR TITLE
ci: bump setup-soldr v0.9.56 -> v0.9.57

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.56` to `v0.9.57`.

## What's in v0.9.57 — major perf win
Adds `cook-base-v2-` to `FOUNDATION_PREFIXES` so setup-soldr's controlled eviction skips cook-cache-base entries. Closes setup-soldr#368.

Production evidence on zccache:
- 08:17 UTC: cook-cache-base HIT (key `cook-base-v2-linux-x64-glibc-rustc1.94.1-fnone-l92559307b22cc1be-soldrv0.7.51`)
- 08:38 UTC: same lockfile hash on child commit — base **MISS** (evicted in 21 minutes by our own graduated age floor)

Cost of MISS: ~200s of cold cargo cook per affected job. With this change, the same base survives across commits and CI cycles.

GitHub's own LRU continues evicting truly-stale cook-base entries (~7 days unused), so unbounded growth is bounded. Worst case ~7 platforms × 300 MB = ~2.1 GB foundation footprint.

## Test plan
- [ ] CI green
- [ ] Cook-cache-base HIT rate climbs to >50% on consecutive commits with same lockfile
- [ ] Post-step eviction log shows cook-base entries protected from self-eviction
