### PR TITLE
ci: bump setup-soldr v0.9.60 -> v0.9.61

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           cat rust-toolchain.ci.toml
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.60
+      - uses: zackees/setup-soldr@v0.9.61
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.60` to `v0.9.61`.

## What's in v0.9.61 — perf win
Cache-eviction now sorts evictable entries by size descending (biggest first) instead of age ascending. Same byte-target reached with ~10× fewer API calls.

Production observation on zccache (v0.9.60 cascade run):
- 304 entries deleted to free 1.33 GB
- 70% were <1 MB sccache shards (~100 MB total)
- 3% were >100 MB entries (~1 GB total)

Combined with v0.9.60's parallel deletes, cache-eviction wall-clock should drop from ~12s to ~1-2s per CI cycle.

## Test plan
- [ ] CI green
- [ ] Post-step eviction log shows ~10 deletions (instead of ~300) when over-budget
