### PR TITLE
ci: bump setup-soldr v0.9.48 -> v0.9.62 in linux-x86-dwarf-smoke

### DIFF
--- a/.github/workflows/linux-x86-dwarf-smoke.yml
+++ b/.github/workflows/linux-x86-dwarf-smoke.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python
         run: uv python install "$UV_PYTHON"
 
-      - uses: zackees/setup-soldr@v0.9.48
+      - uses: zackees/setup-soldr@v0.9.62
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

`linux-x86-dwarf-smoke.yml` was still pinned to `zackees/setup-soldr@v0.9.48` while the other four workflows (`_build`, `_integration-test`, `_lint`, `_unit-test`) had already been bumped to `v0.9.62` in 3f6dc42. This aligns the dwarf-smoke workflow with the rest.

`v0.9.62` is the latest tag in [`zackees/setup-soldr`](https://github.com/zackees/setup-soldr/tags) at time of writing (the GitHub-marked "latest release" is v0.9.48, but tags v0.9.49-v0.9.62 exist and are in use elsewhere in this repo).

## Test plan

- [ ] dwarf-smoke CI on this branch