### PR TITLE
release: v2.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.9"
+version = "2.0.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.9"
+version = "2.0.10"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps workspace package version from **2.0.9 -> 2.0.10**.

Once this lands on main, [`Auto Release`](./.github/workflows/auto-release.yml) will:
1. Detect the new version is not on PyPI
2. Build wheels + native binaries on all six (linux/windows/macOS x86/arm) targets
3. Create and push the `v2.0.10` git tag
4. Publish to PyPI
5. Create a signed GitHub release with zipped binaries

## Notable changes since v2.0.9

- #145 — split four >=40 kB source files into focused modules (no behavior change)
- #146 — bump `setup-soldr` to v0.9.62 in `linux-x86-dwarf-smoke.yml`
- Other setup-soldr bumps from v0.9.56 -> v0.9.62 across CI

## Test plan

- [x] `soldr cargo check -p fastled-cli` -> clean
- [x] `pytest tests/unit/test_python_api.py::test_python_version_matches_cargo_workspace_version` -> pass
- [ ] CI on this PR
- [ ] Auto Release workflow on main after merge