### PR TITLE
ci: pin soldr v0.7.53 (brings zccache v1.11.20)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          version: 0.7.53
           # cache-preset: foundation expands to build-cache: true +
           # target-cache: false + cargo-registry-cache: false +
           # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          version: 0.7.53
           # cache-preset: foundation expands to build-cache: true +
           # target-cache: false + cargo-registry-cache: false +
           # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          version: 0.7.53
           # cache-preset: foundation expands to build-cache: true +
           # target-cache: false + cargo-registry-cache: false +
           # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          version: 0.7.53
           # cache-preset: foundation expands to build-cache: true +
           # target-cache: false + cargo-registry-cache: false +
           # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).

--- a/.github/workflows/linux-x86-dwarf-smoke.yml
+++ b/.github/workflows/linux-x86-dwarf-smoke.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          version: 0.7.53
           cache-preset: foundation
           cache-key-suffix: ubuntu-24.04-dwarf-smoke
           linker: platform-default


### PR DESCRIPTION
## Summary

`setup-soldr@v0.9.62` currently defaults to **soldr v0.7.51 + zccache v1.11.8**. Latest soldr is **v0.7.53**, which bundles **zccache v1.11.20**. Adding an explicit \`version: 0.7.53\` input to all five workflow invocations so we get the upgrade now rather than waiting for setup-soldr to roll its default.

| Workflow | Change |
|---|---|
| \`_build.yml\` | + \`version: 0.7.53\` |
| \`_integration-test.yml\` | + \`version: 0.7.53\` |
| \`_lint.yml\` | + \`version: 0.7.53\` |
| \`_unit-test.yml\` | + \`version: 0.7.53\` |
| \`linux-x86-dwarf-smoke.yml\` | + \`version: 0.7.53\` |

## Test plan

- [ ] CI on this PR — all jobs must still pass on the new soldr/zccache pair