### PR TITLE
feat: live colored compile log streaming in browser loading page

### DIFF
--- a/crates/fastled-cli/src/build.rs
+++ b/crates/fastled-cli/src/build.rs
@@ -3,4 +3,4 @@
 //! The Rust CLI owns the build backend directly. Python remains a compatibility
 //! API layer and is not part of the primary compile path.
 
-pub use crate::wasm_build::{run_build, BuildMode, BuildRequest, BuildResult};
+pub use crate::wasm_build::{run_build, run_build_streaming, BuildMode, BuildRequest, BuildResult};

--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, RwLock};
 use crate::build;
 use crate::cli::{requested_init_ref, validate_init_ref_flags, Cli};
 use crate::compile_stream::{
-    ensure_compile_prerequisites, purge_fastled_cache, run_native_compile_streaming,
-    selected_build_mode, send_sse, write_build_status,
+    ensure_compile_prerequisites, purge_fastled_cache, report_build_outcome,
+    run_native_compile_streaming, selected_build_mode, send_sse, write_build_status,
 };
 use crate::debug_symbols;
 use crate::dwarf_smoke::run_dwarf_source_smoke;
@@ -96,20 +96,7 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
 
         let success =
             run_native_compile_streaming(cli, &sketch_dir, cli.purge, &tx, &debug_symbols);
-
-        if success {
-            write_build_status(&output_dir, "success", "Done");
-            send_sse(
-                &tx,
-                r#"{"type":"status","status":"success","message":"Done"}"#,
-            );
-        } else {
-            write_build_status(&output_dir, "error", "Compilation failed");
-            send_sse(
-                &tx,
-                r#"{"type":"status","status":"error","message":"Compilation failed"}"#,
-            );
-        }
+        report_build_outcome(&output_dir, &tx, success);
 
         // --- Watch mode ---------------------------------------------------------
         println!("\nWill recompile on sketch changes or space bar press.");
@@ -147,20 +134,10 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
 
                 let success =
                     run_native_compile_streaming(cli, &sketch_dir, false, &tx, &debug_symbols);
-                if success {
+                if report_build_outcome(&output_dir, &tx, success) {
                     println!("Recompilation successful!");
-                    write_build_status(&output_dir, "success", "Done");
-                    send_sse(
-                        &tx,
-                        r#"{"type":"status","status":"success","message":"Done"}"#,
-                    );
                 } else {
                     eprintln!("Recompilation failed.");
-                    write_build_status(&output_dir, "error", "Compilation failed");
-                    send_sse(
-                        &tx,
-                        r#"{"type":"status","status":"error","message":"Compilation failed"}"#,
-                    );
                 }
             }
         }

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -173,6 +173,41 @@ pub(crate) fn emit_build_result_logs(
     }
 }
 
+/// Publish the build outcome to polling (`build-status.json`) and SSE
+/// clients. `success` is only reported when the build claims success *and*
+/// `index.html` actually exists on disk — the loading page reloads on
+/// `success`, and reloading without artifacts would wipe the error log (#153).
+/// Returns the effective success that was reported.
+pub(crate) fn report_build_outcome(
+    output_dir: &Path,
+    tx: &tokio::sync::broadcast::Sender<String>,
+    build_ok: bool,
+) -> bool {
+    let index_exists = output_dir.join("index.html").is_file();
+    if build_ok && index_exists {
+        write_build_status(output_dir, "success", "Done");
+        send_sse(
+            tx,
+            r#"{"type":"status","status":"success","message":"Done"}"#,
+        );
+        return true;
+    }
+    let message = if build_ok {
+        "Build completed but no index.html was produced"
+    } else {
+        "Compilation failed"
+    };
+    write_build_status(output_dir, "error", message);
+    send_sse(
+        tx,
+        &format!(
+            r#"{{"type":"status","status":"error","message":"{}"}}"#,
+            json_escape(message)
+        ),
+    );
+    false
+}
+
 /// Run the native build path and mirror its output to the terminal + SSE.
 pub(crate) fn run_native_compile_streaming(
     cli: &Cli,
@@ -193,7 +228,8 @@ pub(crate) fn run_native_compile_streaming(
         force_clean,
     };
 
-    match build::run_build(&request) {
+    let log = |line: &str, stream: &str| emit_build_log(tx, line, stream);
+    match build::run_build_streaming(&request, &log) {
         Ok(result) => {
             emit_build_result_logs(&result, tx);
             if result.success {
@@ -233,5 +269,43 @@ pub(crate) fn update_debug_symbol_resolver(
         ));
     if let Ok(mut guard) = handle.write() {
         *guard = Some(resolver);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_status(dir: &Path) -> String {
+        std::fs::read_to_string(dir.join("build-status.json")).unwrap()
+    }
+
+    #[test]
+    fn report_build_outcome_success_requires_index_html() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(8);
+
+        assert!(!report_build_outcome(dir.path(), &tx, true));
+        assert!(read_status(dir.path()).contains("\"error\""));
+        let event = rx.try_recv().unwrap();
+        assert!(event.contains("\"status\":\"error\""), "got: {event}");
+
+        std::fs::write(dir.path().join("index.html"), "<html></html>").unwrap();
+        assert!(report_build_outcome(dir.path(), &tx, true));
+        assert!(read_status(dir.path()).contains("\"success\""));
+        let event = rx.try_recv().unwrap();
+        assert!(event.contains("\"status\":\"success\""), "got: {event}");
+    }
+
+    #[test]
+    fn report_build_outcome_failure_is_error_even_with_stale_index() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<html></html>").unwrap();
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(8);
+
+        assert!(!report_build_outcome(dir.path(), &tx, false));
+        assert!(read_status(dir.path()).contains("\"error\""));
+        let event = rx.try_recv().unwrap();
+        assert!(event.contains("Compilation failed"), "got: {event}");
     }
 }

--- a/crates/fastled-cli/src/server.rs
+++ b/crates/fastled-cli/src/server.rs
@@ -59,6 +59,9 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
          overflow-y: auto; font-size: 0.85em; color: #aaa;
          white-space: pre-wrap; text-align: left; line-height: 1.4;
          padding: 8px; background: #1a1a1a; border-radius: 4px; }
+  #log div { min-height: 1.2em; }
+  #log .warn { color: #ffd54f; }
+  #log .err { color: #ef5350; }
 </style>
 <script>
   // Instant-launch flow (#148):
@@ -76,6 +79,11 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
     const header = document.getElementById('header');
     let buildStart = Date.now();
     let elapsedTimer = null;
+    // Auto-scroll follows the log tail unless the user scrolled up to read.
+    let userScrolled = false;
+    log.addEventListener('scroll', () => {
+      userScrolled = log.scrollTop + log.clientHeight < log.scrollHeight - 10;
+    });
 
     function startTimer() {
       stopTimer();
@@ -92,6 +100,7 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
       spinner.classList.remove('error');
       status.textContent = message || 'Compiling...';
       log.textContent = '';
+      userScrolled = false;
       startTimer();
     }
     function setError(message) {
@@ -99,10 +108,28 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
       spinner.classList.add('error');
       status.textContent = message || 'Compilation failed';
       stopTimer();
+      // Jump to the first diagnostic: emcc errors are usually followed by
+      // long noise, so the bottom of the log is the wrong place to land.
+      const firstErr = log.querySelector('.err');
+      if (firstErr) {
+        log.scrollTop = Math.max(0, firstErr.offsetTop - log.offsetTop - 8);
+      }
     }
-    function appendLog(line) {
-      log.textContent += line + '\n';
-      log.scrollTop = log.scrollHeight;
+    function classifyLine(line, stream) {
+      const l = line.toLowerCase();
+      if (l.includes('error:') || l.includes('fatal error') ||
+          l.includes('undefined symbol') ||
+          (stream === 'stderr' && l.includes('failed'))) { return 'err'; }
+      if (l.includes('warning:')) { return 'warn'; }
+      return '';
+    }
+    function appendLog(line, stream) {
+      const div = document.createElement('div');
+      div.textContent = line;
+      const cls = classifyLine(line, stream || 'stdout');
+      if (cls) { div.className = cls; }
+      log.appendChild(div);
+      if (!userScrolled) { log.scrollTop = log.scrollHeight; }
     }
 
     startTimer();
@@ -129,7 +156,7 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
         try {
           const d = JSON.parse(e.data);
           if (d.type === 'log') {
-            appendLog(d.line);
+            appendLog(d.line, d.stream);
           } else if (d.type === 'status') {
             handleStatus(d.status, d.message);
             if (d.status === 'success') { es.close(); }
@@ -697,6 +724,37 @@ mod tests {
         assert!(
             body.contains("/build-stream"),
             "loading page should connect to /build-stream"
+        );
+    }
+
+    /// Live compile log UX (#153): the loading page must classify and color
+    /// warning/error lines, follow the log tail, and never show a fake
+    /// progress bar (build step counts are unknowable).
+    #[test]
+    fn loading_page_colors_log_lines_and_has_no_progress_bar() {
+        assert!(
+            LOADING_PAGE.contains("classifyLine"),
+            "loading page must classify log lines"
+        );
+        assert!(
+            LOADING_PAGE.contains("warning:") && LOADING_PAGE.contains(".warn"),
+            "warnings must get the yellow .warn style"
+        );
+        assert!(
+            LOADING_PAGE.contains("error:") && LOADING_PAGE.contains(".err"),
+            "errors must get the red .err style"
+        );
+        assert!(
+            LOADING_PAGE.contains("spinner"),
+            "indeterminate spinner is the only activity indicator"
+        );
+        assert!(
+            !LOADING_PAGE.contains("<progress"),
+            "no progress bar: build step counts are unknowable"
+        );
+        assert!(
+            LOADING_PAGE.contains("userScrolled"),
+            "auto-scroll must pause when the user scrolls up"
         );
     }
 

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -6,14 +6,27 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use crate::{archive, debug_symbols, frontend, install};
+
+/// Receives one build-output line at a time. The second argument is the
+/// originating stream: `"stdout"` or `"stderr"`. Called on the build thread.
+pub type LogSink<'a> = &'a (dyn Fn(&str, &str) + 'a);
+
+fn stdio_log(line: &str, stream: &str) {
+    if stream == "stderr" {
+        eprintln!("{line}");
+    } else {
+        println!("{line}");
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuildMode {
@@ -178,6 +191,9 @@ fn build_env(tools: &ToolPaths) -> Vec<(String, String)> {
             tools.python.display().to_string(),
         ),
         ("EMCC_SKIP_SANITY_CHECK".to_string(), "1".to_string()),
+        // Build tools are Python-driven; without this their stdout is
+        // block-buffered when piped, which would defeat live log streaming.
+        ("PYTHONUNBUFFERED".to_string(), "1".to_string()),
     ];
     if cfg!(windows) {
         // Match the host's logical core count so emscripten's parallel
@@ -201,10 +217,56 @@ fn command_with_env(program: impl AsRef<Path>, tools: &ToolPaths) -> Command {
     command
 }
 
-fn run_status(mut command: Command, label: &str) -> Result<()> {
-    let status = command
-        .status()
-        .with_context(|| format!("launch {label}"))?;
+fn spawn_line_reader<R: std::io::Read + Send + 'static>(
+    reader: R,
+    stream: &'static str,
+    tx: std::sync::mpsc::Sender<(String, &'static str)>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(reader);
+        let mut buf = Vec::new();
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    while matches!(buf.last(), Some(b'\n' | b'\r')) {
+                        buf.pop();
+                    }
+                    if tx
+                        .send((String::from_utf8_lossy(&buf).into_owned(), stream))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Run a build tool with piped stdout/stderr, forwarding each output line to
+/// `log` as it arrives so callers can mirror it to the terminal and the
+/// browser SSE stream in real time (#153).
+fn run_status(mut command: Command, label: &str, log: LogSink) -> Result<()> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn().with_context(|| format!("launch {label}"))?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut readers = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        readers.push(spawn_line_reader(stdout, "stdout", tx.clone()));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        readers.push(spawn_line_reader(stderr, "stderr", tx.clone()));
+    }
+    drop(tx);
+    for (line, stream) in rx {
+        log(&line, stream);
+    }
+    for reader in readers {
+        let _ = reader.join();
+    }
+    let status = child.wait().with_context(|| format!("wait for {label}"))?;
     if !status.success() {
         bail!("{label} failed with {status}");
     }
@@ -524,6 +586,7 @@ fn ensure_meson_configured(
     build_dir: &Path,
     mode: BuildMode,
     force: bool,
+    log: LogSink,
 ) -> Result<()> {
     let marker = build_dir.join(".src_file_list_hash");
     let current_hash = compute_source_file_hash(fastled_dir)?;
@@ -550,8 +613,11 @@ fn ensure_meson_configured(
     for (key, value) in build_env(tools) {
         command.env(key, value);
     }
-    println!("[WASM] Configuring meson (mode: {})...", mode.as_str());
-    run_status(command, "meson setup")?;
+    log(
+        &format!("[WASM] Configuring meson (mode: {})...", mode.as_str()),
+        "stdout",
+    );
+    run_status(command, "meson setup", log)?;
     fs::write(marker, current_hash)?;
     Ok(())
 }
@@ -564,7 +630,12 @@ fn library_archive(build_dir: &Path) -> PathBuf {
         .join("libfastled.a")
 }
 
-fn build_library(fastled_dir: &Path, tools: &ToolPaths, build_dir: &Path) -> Result<bool> {
+fn build_library(
+    fastled_dir: &Path,
+    tools: &ToolPaths,
+    build_dir: &Path,
+    log: LogSink,
+) -> Result<bool> {
     let archive = library_archive(build_dir);
     let fingerprint_path = build_dir.join("library_src_fingerprint");
     let current = compute_source_file_hash(fastled_dir)?;
@@ -575,7 +646,7 @@ fn build_library(fastled_dir: &Path, tools: &ToolPaths, build_dir: &Path) -> Res
             .trim()
             == current
     {
-        println!("[WASM] Library up-to-date");
+        log("[WASM] Library up-to-date", "stdout");
         return Ok(false);
     }
     if archive.exists() {
@@ -590,10 +661,10 @@ fn build_library(fastled_dir: &Path, tools: &ToolPaths, build_dir: &Path) -> Res
     for (key, value) in build_env(tools) {
         command.env(key, value);
     }
-    println!("[WASM] Building libfastled.a...");
-    run_status(command, "meson compile fastled")?;
+    log("[WASM] Building libfastled.a...", "stdout");
+    run_status(command, "meson compile fastled", log)?;
     fs::write(fingerprint_path, current)?;
-    println!("[WASM] Library build successful");
+    log("[WASM] Library build successful", "stdout");
     Ok(true)
 }
 
@@ -655,6 +726,7 @@ fn build_sketch_pch(
     mode: BuildMode,
     emsdk_root: Option<&Path>,
     lib_was_rebuilt: bool,
+    log: LogSink,
 ) -> Result<Option<PathBuf>> {
     let pcm = build_dir.join("wasm_pch.h.pcm");
     let pch_o = build_dir.join("pch_codegen.o");
@@ -706,13 +778,13 @@ fn build_sketch_pch(
     ));
     args.extend(["-Xclang".to_string(), "-fmodules-codegen".to_string()]);
 
-    println!("[WASM] Building sketch header unit (.pcm)...");
+    log("[WASM] Building sketch header unit (.pcm)...", "stdout");
     let mut command = command_with_env(&tools.python, tools);
     command
         .current_dir(fastled_dir)
         .arg(&tools.emcc)
         .args(&args);
-    run_status(command, "emcc header unit")?;
+    run_status(command, "emcc header unit", log)?;
 
     let mut command = command_with_env(&tools.python, tools);
     command
@@ -723,7 +795,7 @@ fn build_sketch_pch(
         .args(["-o"])
         .arg(&pch_o)
         .args(["-O0", "-g0"]);
-    if run_status(command, "emcc header unit companion").is_ok() {
+    if run_status(command, "emcc header unit companion", log).is_ok() {
         let archive = library_archive(build_dir);
         if archive.is_file() && tools.emar.is_file() {
             let mut command = command_with_env(&tools.python, tools);
@@ -733,7 +805,7 @@ fn build_sketch_pch(
                 .arg("r")
                 .arg(&archive)
                 .arg(&pch_o);
-            let _ = run_status(command, "emar pch companion");
+            let _ = run_status(command, "emar pch companion", log);
         }
     }
 
@@ -741,6 +813,7 @@ fn build_sketch_pch(
     Ok(Some(pcm))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compile_sketch(
     tools: &ToolPaths,
     wrapper: &Path,
@@ -749,6 +822,7 @@ fn compile_sketch(
     example_dir: &Path,
     mode: BuildMode,
     dwarf_roots: &DwarfPathRoots,
+    log: LogSink,
 ) -> Result<PathBuf> {
     let fastled_dir = &dwarf_roots.fastled_dir;
     let object = sketch_cache_dir.join("sketch.o");
@@ -770,7 +844,7 @@ fn compile_sketch(
                 .filter_map(|metadata| metadata.modified().ok())
                 .all(|mtime| mtime <= object_mtime)
         {
-            println!("[WASM] Sketch is up-to-date");
+            log("[WASM] Sketch is up-to-date", "stdout");
             return Ok(object);
         }
     }
@@ -798,17 +872,21 @@ fn compile_sketch(
         args.push(format!("-fmodule-file={}", pcm.display()));
     }
 
-    println!("[WASM] Compiling sketch: {}", wrapper.display());
+    log(
+        &format!("[WASM] Compiling sketch: {}", wrapper.display()),
+        "stdout",
+    );
     let mut command = command_with_env(&tools.python, tools);
     command
         .current_dir(fastled_dir)
         .arg(&tools.empp)
         .args(&args);
-    run_status(command, "em++ sketch compile")?;
+    run_status(command, "em++ sketch compile", log)?;
     fs::write(flags_hash_path, current_flags_hash)?;
     Ok(object)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn link_wasm(
     fastled_dir: &Path,
     tools: &ToolPaths,
@@ -817,6 +895,7 @@ fn link_wasm(
     sketch_cache_dir: &Path,
     output_js: &Path,
     mode: BuildMode,
+    log: LogSink,
 ) -> Result<()> {
     let archive = library_archive(build_dir);
     let cached_js = sketch_cache_dir.join("fastled.js");
@@ -838,7 +917,7 @@ fn link_wasm(
                 .all(|mtime| mtime <= output_mtime)
         {
             copy_linked_output(sketch_cache_dir, output_js)?;
-            println!("[WASM] Link output up-to-date");
+            log("[WASM] Link output up-to-date", "stdout");
             return Ok(());
         }
     }
@@ -876,8 +955,8 @@ fn link_wasm(
     ];
     args.extend(link_flags);
 
-    println!("[WASM] Linking final WASM module...");
-    run_em_link_with_retries(fastled_dir, tools, &args)?;
+    log("[WASM] Linking final WASM module...", "stdout");
+    run_em_link_with_retries(fastled_dir, tools, &args, log)?;
     fs::write(flags_hash_path, current_flags_hash)?;
     copy_linked_output(sketch_cache_dir, output_js)?;
     Ok(())
@@ -890,19 +969,27 @@ fn link_wasm(
 /// Because each completed library is cached to disk, retrying advances the
 /// build by one library each time. A small retry loop lets the link
 /// converge without exposing the upstream flakiness to users. See #116.
-fn run_em_link_with_retries(fastled_dir: &Path, tools: &ToolPaths, args: &[String]) -> Result<()> {
+fn run_em_link_with_retries(
+    fastled_dir: &Path,
+    tools: &ToolPaths,
+    args: &[String],
+    log: LogSink,
+) -> Result<()> {
     let max_attempts = if cfg!(windows) { 6 } else { 1 };
     let mut last_err: Option<anyhow::Error> = None;
     for attempt in 1..=max_attempts {
         let mut command = command_with_env(&tools.python, tools);
         command.current_dir(fastled_dir).arg(&tools.empp).args(args);
-        match run_status(command, "em++ wasm link") {
+        match run_status(command, "em++ wasm link", log) {
             Ok(()) => return Ok(()),
             Err(err) => {
                 if attempt < max_attempts {
-                    println!(
-                        "[WASM] em++ link attempt {attempt}/{max_attempts} failed; \
-                         retrying (sysroot libs cache progressively): {err:#}"
+                    log(
+                        &format!(
+                            "[WASM] em++ link attempt {attempt}/{max_attempts} failed; \
+                             retrying (sysroot libs cache progressively): {err:#}"
+                        ),
+                        "stdout",
                     );
                 }
                 last_err = Some(err);
@@ -1038,7 +1125,14 @@ fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Run the build, streaming all tool output to stdout/stderr.
 pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
+    run_build_streaming(request, &stdio_log)
+}
+
+/// Run the build, forwarding every output line (tool stdout/stderr plus
+/// `[WASM]` progress markers) to `log` as it is produced.
+pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<BuildResult> {
     let wall_start = std::time::Instant::now();
     let output_dir = mode_output_dir(&request.sketch_dir);
     if request.force_clean && output_dir.exists() {
@@ -1074,8 +1168,9 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
             &build_dir,
             request.build_mode,
             request.force_clean,
+            log,
         )?;
-        let lib_rebuilt = build_library(&fastled_dir, &tools, &build_dir)?;
+        let lib_rebuilt = build_library(&fastled_dir, &tools, &build_dir, log)?;
         let _ = build_sketch_pch(
             &fastled_dir,
             &tools,
@@ -1083,6 +1178,7 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
             request.build_mode,
             emsdk_root.as_deref(),
             lib_rebuilt,
+            log,
         );
         let sketch_cache = sketch_cache_dir(&example_dir);
         let wrapper = create_wrapper(&example_dir, &example_name, &sketch_cache)?;
@@ -1099,6 +1195,7 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
             &example_dir,
             request.build_mode,
             &sketch_dwarf_roots,
+            log,
         )?;
         let output_js = output_dir.join("fastled.js");
         link_wasm(
@@ -1109,6 +1206,7 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
             &sketch_cache,
             &output_js,
             request.build_mode,
+            log,
         )?;
         frontend::copy_frontend_to_output(&output_dir, None)?;
         generate_manifest(&example_dir, &output_dir)?;
@@ -1149,6 +1247,65 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn shell_command(script: &str) -> Command {
+        if cfg!(windows) {
+            let mut command = Command::new("cmd");
+            command.args(["/C", script]);
+            command
+        } else {
+            let mut command = Command::new("sh");
+            command.args(["-c", script]);
+            command
+        }
+    }
+
+    fn collect_run_status_lines(script: &str) -> (Result<()>, Vec<(String, String)>) {
+        let lines = std::cell::RefCell::new(Vec::new());
+        let log = |line: &str, stream: &str| {
+            lines
+                .borrow_mut()
+                .push((line.to_string(), stream.to_string()));
+        };
+        let result = run_status(shell_command(script), "test command", &log);
+        (result, lines.into_inner())
+    }
+
+    #[test]
+    fn run_status_streams_stdout_and_stderr_lines() {
+        let script = if cfg!(windows) {
+            // No space before the redirect: cmd's echo would include it.
+            "echo out-line& echo err-line>&2"
+        } else {
+            "echo out-line; echo err-line >&2"
+        };
+        let (result, lines) = collect_run_status_lines(script);
+        result.unwrap();
+        assert!(
+            lines.contains(&("out-line".to_string(), "stdout".to_string())),
+            "missing stdout line, got: {lines:?}"
+        );
+        assert!(
+            lines.contains(&("err-line".to_string(), "stderr".to_string())),
+            "missing stderr line, got: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn run_status_reports_failure_but_still_streams_output() {
+        let script = if cfg!(windows) {
+            "echo doomed& exit 3"
+        } else {
+            "echo doomed; exit 3"
+        };
+        let (result, lines) = collect_run_status_lines(script);
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("test command failed"), "got: {err}");
+        assert!(
+            lines.contains(&("doomed".to_string(), "stdout".to_string())),
+            "output before failure must still stream, got: {lines:?}"
+        );
+    }
 
     fn write_build_flags(fastled_dir: &Path, source: &str) {
         let compiler_dir = fastled_dir.join("src/platforms/wasm/compiler");


### PR DESCRIPTION
Closes #153

## Summary
- Build subprocesses (meson, emcc/em++, emar) now run with piped stdout/stderr; every line is forwarded through a new `LogSink` to the terminal **and** the SSE `/build-stream` channel as it is produced — previously they inherited stdio and the browser only got a one-line summary after the build returned. `PYTHONUNBUFFERED=1` keeps the Python-driven tools line-buffered. `[WASM]` progress markers go through the same sink.
- Loading page log panel renders per-line `<div>`s (textContent — no HTML injection): `warning:` lines in yellow, `error:`/`fatal error`/`undefined symbol`/stderr-failure lines in red. Auto-scroll follows the tail unless the user scrolls up; on failure it jumps to the first diagnostic. The spinner remains the only activity indicator (no progress bar — step counts are unknowable).
- Fatal-error handling: `success` is only published (SSE + `build-status.json`) when `index.html` actually exists on disk, so an error can never reload the page into a blank view; the SSE connection stays open after an error, and a later fixed rebuild recovers to the sketch in the same session.

## Test plan
- [x] `soldr cargo test --workspace` — 136 tests pass (4 new: piped `run_status` streaming + failure, `report_build_outcome` index-gating, loading-page classification/no-progress-bar markers)
- [x] `bash lint` — fmt and clippy clean (dylint step fails identically on `main`: pre-existing `dylint_driver` build break, unrelated)
- [x] E2E with the release binary and a sketch containing an injected `use of undeclared identifier` error (fresh `fastled_js/`): 48 log lines streamed live over `/build-stream` during the build, compiler error line delivered with `"stream":"stderr"`, `build-status.json` and SSE report `error`, `/` keeps serving the loading page (no index.html, no reload)
- [x] E2E recovery: removing the bad line triggered the watcher; SSE showed `compiling` → `success`, `index.html` was produced, and `/` served the real sketch — same CLI session, no restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)