### PR TITLE
ci: drop soldr v0.7.53 pin from _build.yml to unbreak Windows ARM Build

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -41,7 +41,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          version: 0.7.53
+          # No soldr version pin: v0.7.53 (zccache v1.11.20) breaks the
+          # aarch64-pc-windows-msvc cross-compile with silent rustc failures
+          # (see #158); the action default v0.7.51 is green here.
           # cache-preset: foundation expands to build-cache: true +
           # target-cache: false + cargo-registry-cache: false +
           # prebuild-deps: soldr-cook (setup-soldr v0.9.17+, #251).


### PR DESCRIPTION
Closes #158

## Summary
- "Windows ARM Build" (x86_64 host → `aarch64-pc-windows-msvc`) has failed since #150 pinned soldr v0.7.53 / zccache v1.11.20: upstream crates (reqwest, tauri, axum) fail with rustc exiting 1 and **zero diagnostics** under the zccache wrapper, plus `cook: failed with exit 101`. Green on every run before the pin; soldr v0.7.53 is the latest release, so no roll-forward exists.
- This reverts the pin in `_build.yml` only, restoring the setup-soldr default (v0.7.51). `_lint.yml`, `_unit-test.yml`, `_integration-test.yml`, and `linux-x86-dwarf-smoke.yml` keep v0.7.53, which passes there — preserving the zccache upgrade #150 wanted everywhere it works.
- Root cause belongs upstream in zackees/soldr (artifact-store / cross-target, likely related to soldr#704).

## Test plan
- [x] YAML parses
- [ ] "Windows ARM Build" check passes on this PR (the actual regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)