### PR TITLE
release: v2.0.11 with viewer fix #157 + viewer URL regression gate

### DIFF
--- a/crates/fastled-cli/src/viewer.rs
+++ b/crates/fastled-cli/src/viewer.rs
@@ -346,7 +346,18 @@ fn spawn_hidden_viewer(binary: &Path, url: &str) -> Result<ViewerProcess> {
 /// viewer/WebView2 process tree is torn down too.
 ///
 /// Returns a process handle whose lifetime controls the viewer lifetime.
+///
+/// Fails loudly when `url` is not an http(s) URL. The viewer must always be
+/// pointed at the embedded HTTP server (which serves the loading page and
+/// reloads on build completion); pointing it at a directory or `fastled://`
+/// path regresses to a dead "Not Found" page (issues #151/#160).
 pub fn launch_tauri_viewer(url: &str) -> Result<ViewerProcess> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        anyhow::bail!(
+            "viewer must be launched with an http(s) URL pointing at the FastLED server, got: {url}"
+        );
+    }
+
     let binary =
         find_tauri_viewer().context("fastled binary not found; cannot launch Tauri viewer")?;
 
@@ -518,6 +529,24 @@ mod tests {
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
         assert_eq!(args, vec!["--internal-viewer", "http://127.0.0.1:8089"]);
+    }
+
+    #[test]
+    fn test_launch_tauri_viewer_rejects_directory_path() {
+        // Regression gate for #151/#160: the viewer must never be pointed at
+        // a filesystem path; it must load the FastLED HTTP server URL.
+        match launch_tauri_viewer("examples/TwinkleFox/fastled_js") {
+            Ok(_) => panic!("directory path must be rejected"),
+            Err(err) => assert!(err.to_string().contains("http(s) URL"), "got: {err}"),
+        }
+    }
+
+    #[test]
+    fn test_launch_tauri_viewer_rejects_fastled_protocol() {
+        match launch_tauri_viewer("fastled://localhost/index.html") {
+            Ok(_) => panic!("fastled:// protocol must be rejected"),
+            Err(err) => assert!(err.to_string().contains("http(s) URL"), "got: {err}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bump workspace version 2.0.10 -> 2.0.11 so the auto-release workflow ships the first release containing #157 (Tauri viewer pointed at the HTTP server instead of disk). v2.0.10 installs show a permanent "Not Found" viewer window (#151).
- Add a fail-loud http(s) URL guard in `launch_tauri_viewer` plus regression tests rejecting directory paths and `fastled://` URLs, so the viewer wiring can't silently regress to disk-backed serving again.

Closes #160
Refs #151

## Test plan
- [x] `soldr cargo test --workspace` — 137 passed (includes 2 new viewer regression tests)
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] After merge: auto-release publishes v2.0.11; verify `pip install fastled==2.0.11` + `fastled` shows the loading page then the sketch

🤖 Generated with [Claude Code](https://claude.com/claude-code)