### PR TITLE
fix(build): pip install . auto-rebuilds the bundled native binary via soldr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,38 +55,55 @@ def _candidate_binaries() -> list[Path]:
             ]
         )
     candidates.append(ROOT / "target" / "release" / EXE_NAME)
-    cargo_home = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo"))
-    candidates.append(cargo_home / "bin" / EXE_NAME)
     return candidates
 
 
-def _copy_first_available_binary() -> bool:
+def _copy_newest_available_binary() -> bool:
     PACKAGE_BIN_DIR.mkdir(parents=True, exist_ok=True)
     dest = PACKAGE_BIN_DIR / EXE_NAME
-    for candidate in _candidate_binaries():
-        if candidate.is_file():
-            shutil.copy2(candidate, dest)
-            return True
-    return False
+    existing = [candidate for candidate in _candidate_binaries() if candidate.is_file()]
+    if not existing:
+        return False
+    newest = max(existing, key=lambda path: path.stat().st_mtime)
+    shutil.copy2(newest, dest)
+    return True
+
+
+def _newest_rust_source_mtime() -> float:
+    newest = 0.0
+    for path in (ROOT / "Cargo.toml", ROOT / "Cargo.lock"):
+        if path.is_file():
+            newest = max(newest, path.stat().st_mtime)
+    for path in (ROOT / "crates").rglob("*"):
+        if path.is_file():
+            newest = max(newest, path.stat().st_mtime)
+    return newest
 
 
 def ensure_bundled_fastled_binary() -> None:
     dest = PACKAGE_BIN_DIR / EXE_NAME
-    if dest.is_file():
-        return
-
-    if _copy_first_available_binary():
-        return
 
     if not (ROOT / "Cargo.toml").is_file():
-        raise RuntimeError("Cargo.toml was not found; cannot build bundled fastled")
+        if dest.is_file():
+            return
+        raise RuntimeError(
+            "Cargo.toml was not found and no staged fastled binary exists; "
+            "cannot build bundled fastled"
+        )
+
+    # A staged binary at least as new as every Rust source is current. This
+    # covers CI, which cross-compiles and stages the exe immediately before
+    # building the wheel. Anything older is stale and must be rebuilt so
+    # `pip install .` always bundles a binary matching the checkout.
+    if dest.is_file() and dest.stat().st_mtime >= _newest_rust_source_mtime():
+        return
 
     command = [*_cargo_command(), "build", "--release", "--bin", "fastled"]
     target = os.environ.get("FASTLED_RUST_TARGET")
     if target:
         command.extend(["--target", target])
     subprocess.check_call(command, cwd=ROOT)
-    if not _copy_first_available_binary():
+    if not _copy_newest_available_binary():
         raise RuntimeError("built fastled binary was not found")
 
 
@@ -101,7 +118,7 @@ class bdist_wheel(_bdist_wheel):
         super().run()
 
     def get_tag(self) -> tuple[str, str, str]:
-        _python, _abi, platform = super().get_tag()
+        *_, platform = super().get_tag()
         return "py3", "none", platform
 
 


### PR DESCRIPTION
## Summary
- `pip install .` previously bundled whatever exe was already sitting in `src/fastled/bin/` — `ensure_bundled_fastled_binary` returned early if the file existed, regardless of age. That's how a June 7 (pre-#157) viewer binary shipped from a June 11 fresh install (refs #151/#160).
- Now the staged exe is trusted only when its mtime is >= every Rust source (`Cargo.toml`, `Cargo.lock`, `crates/**`). Stale or missing -> `soldr cargo build --release --bin fastled` (soldr/zccache makes the rebuild cheap), then the newest built candidate is staged.
- Dropped the `~/.cargo/bin/fastled` fallback (could bundle an unrelated binstall-installed binary) and switched candidate selection from first-match to newest-by-mtime.
- CI release wheels unaffected: `_build.yml` stages a freshly cross-compiled exe immediately before `bdist_wheel`, so the freshness check passes and no host rebuild occurs.

## Test plan
- [x] Fresh worktree (no staged exe): `pip wheel . --no-deps` triggers the soldr build; resulting binary rejects `--internal-viewer not-a-url` (post-#157 behavior confirmed)
- [x] Up-to-date exe: second `pip wheel .` skips the rebuild (~12s total)
- [x] Backdated exe (June 7): `pip wheel .` rebuilds and restores a fresh binary
- [x] `ruff` / `black` / `isort` clean on setup.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)