### PR TITLE
fix(lint): default RUSTUP_HOME for cargo-dylint 6.x driver check

### DIFF
--- a/lint
+++ b/lint
@@ -29,6 +29,10 @@ if [ -z "$RUSTUP_BIN" ]; then
   echo "Error: rustup is required for cargo-dylint's internal driver build" >&2
   exit 1
 fi
+# cargo-dylint 6.x's driver toolchain check requires RUSTUP_HOME to be set
+# explicitly; CI exports it but local shells typically rely on rustup's
+# implicit default and fail with "environment variable not found: RUSTUP_HOME".
+export RUSTUP_HOME="${RUSTUP_HOME:-$("$RUSTUP_BIN" show home)}"
 RUSTUP_BIN_DIR="$(dirname "$RUSTUP_BIN")"
 DYLINT_CARGO_SHIM_DIR="$(mktemp -d)"
 DYLINT_PREVIOUS_DEFAULT="$(rustup default 2>/dev/null | sed 's/ (default)$//')"


### PR DESCRIPTION
## Summary
- `bash lint` failed on local dev machines with `Error: environment variable not found: RUSTUP_HOME` once cargo-dylint 6.0.1 is installed (the version the lint script and CI require). CI exports RUSTUP_HOME; local shells usually rely on rustup's implicit default.
- Derive `RUSTUP_HOME` from `rustup show home` when unset, before invoking cargo-dylint.

## Test plan
- [x] `env -u RUSTUP_HOME bash lint` passes end-to-end on Windows (previously failed at the dylint step)
- [x] No behavior change when RUSTUP_HOME is already exported (CI path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)