### PR TITLE
chore(release): bump version to 2.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.11"
+version = "2.0.12"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump workspace version 2.0.11 -> 2.0.12 (Cargo.toml + Cargo.lock)
- On merge, Auto Release publishes v2.0.12 to PyPI and GitHub releases — first release exercising the #172 CI-artifact-reuse path (build-* jobs should be skipped, artifacts pulled from the merge commit's CI builds)

## Test plan
- [x] unit tests pass
- [ ] CI green
- [ ] Auto Release publishes v2.0.12 with reused artifacts