### PR TITLE
fix(ci): publish jobs skipped when release builds reuse CI artifacts

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -279,7 +279,14 @@ jobs:
 
   publish-pypi:
     needs: [detect-version, create-tag]
-    if: needs.detect-version.outputs.should_release == 'true'
+    # Job-level success() (implied by a plain `if`) evaluates false when any
+    # transitive ancestor was skipped — and the build-* jobs are skipped
+    # whenever collect-artifacts reused CI artifacts, which silently skipped
+    # publishing on the v2.0.12 release. Gate explicitly on create-tag instead.
+    if: >-
+      !cancelled() &&
+      needs.detect-version.outputs.should_release == 'true' &&
+      needs.create-tag.result == 'success'
     runs-on: ubuntu-24.04
     environment:
       name: release
@@ -302,7 +309,11 @@ jobs:
 
   create-release:
     needs: [detect-version, create-tag]
-    if: needs.detect-version.outputs.should_release == 'true'
+    # Same skipped-ancestor gotcha as publish-pypi above.
+    if: >-
+      !cancelled() &&
+      needs.detect-version.outputs.should_release == 'true' &&
+      needs.create-tag.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- The v2.0.12 Auto Release run (27415484461) reused all six CI build artifacts as designed (#172), but `publish-pypi` and `create-release` were skipped: their plain `if:` implies job-level `success()`, which evaluates false when any transitive ancestor (the skipped `build-*` jobs) was skipped.
- Gate both jobs on `!cancelled() && should_release && needs.create-tag.result == 'success'`, the same pattern `create-tag` already uses.
- After merge, the push to main re-triggers Auto Release: 2.0.12 is still absent from PyPI, `create-tag` tolerates the existing tag, and the publish jobs will run.

Refs #170

## Test plan
- [x] `actionlint .github/workflows/auto-release.yml` passes
- [ ] CI green on this PR
- [ ] Post-merge Auto Release publishes v2.0.12 to PyPI and creates the GitHub release