### PR TITLE
chore(release): bump version to 2.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.12"
+version = "2.0.13"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump workspace version 2.0.12 → 2.0.13 so Auto Release publishes a new PyPI/GitHub release on merge.

## Test plan
- [ ] CI green on this PR
- [ ] Post-merge Auto Release publishes v2.0.13 (artifact-reuse path, build-* jobs skipped)