### PR TITLE
feat(cli): emit clangd/VS Code config for WASM sketches

### DIFF
--- a/crates/fastled-cli/src/clangd_config.rs
+++ b/crates/fastled-cli/src/clangd_config.rs
@@ -1,0 +1,602 @@
+//! Emit clangd / VS Code configuration for a sketch directory so that
+//! "Go to Definition" works for WASM sketches (Refs #177).
+//!
+//! After a successful WASM build (or via `fastled --write-clangd [DIR]`) the
+//! sketch directory receives:
+//!
+//! - `compile_commands.json` — exact compile arguments (bundled clang++,
+//!   `--target=wasm32-unknown-emscripten`, `--sysroot`, includes, defines)
+//!   for both the `.ino` and the generated wrapper `.cpp`.
+//! - `.clangd` — anchors the compilation database and adds fallback flags
+//!   for headers opened standalone.
+//! - `.vscode/settings.json` — points the clangd extension at the bundled
+//!   clang driver via `--query-driver` and disables the Microsoft C/C++
+//!   IntelliSense engine which fights clangd.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::json;
+
+use crate::install;
+use crate::path::NormalizedPath;
+use crate::wasm_build::BuildMode;
+
+/// Inputs required to emit the clangd configuration for one sketch.
+pub struct ClangdConfigInputs {
+    /// The sketch directory (where the three files are written).
+    pub sketch_dir: NormalizedPath,
+    /// FastLED checkout, e.g. `~/.fastled/cache/fastled-<ref>/`.
+    pub fastled_dir: NormalizedPath,
+    /// Emscripten install root, e.g.
+    /// `~/.fastled/toolchains/emscripten/<platform>/<arch>/<version>/`.
+    pub emsdk_install_dir: NormalizedPath,
+    /// Path to the emcc wrapper (informational; kept for parity with the
+    /// build's `ToolPaths`).
+    pub tools_emcc_path: NormalizedPath,
+    /// Path to the em++ wrapper (informational).
+    pub tools_empp_path: NormalizedPath,
+    /// The generated wrapper `.cpp` that is actually compiled.
+    pub wrapper_source: NormalizedPath,
+    /// The sketch `.ino` file, so clangd treats it as a translation unit.
+    pub ino_file: NormalizedPath,
+    /// Result of `get_sketch_compile_flags()` for the active build mode.
+    pub compile_flags: Vec<String>,
+    /// The active build mode.
+    pub build_mode: BuildMode,
+}
+
+/// Convert a path to an absolute, forward-slash string with no Windows
+/// `\\?\` long-path prefix. clangd accepts forward slashes on all platforms,
+/// and stale `\\?\` prefixes break clangd on Windows.
+fn display_path(path: &Path) -> String {
+    crate::path::canonicalize_normalized(path)
+        .into_path_buf()
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Path to the bundled clang++ binary inside the emscripten install.
+/// clangd parses `arguments[0]` to find builtin include dirs; the em++
+/// wrapper is a Python script, not a clang binary, so it cannot be used.
+fn bundled_clangxx(emsdk_install_dir: &Path) -> NormalizedPath {
+    let name = if cfg!(windows) {
+        "clang++.exe"
+    } else {
+        "clang++"
+    };
+    NormalizedPath::new(emsdk_install_dir.join("bin").join(name))
+}
+
+/// Parse `(major, minor)` from the emsdk install dir's version path
+/// component (e.g. `.../emscripten/win/x86_64/4.0.19` -> `(4, 0)`).
+fn emscripten_version(emsdk_install_dir: &Path) -> Option<(u32, u32)> {
+    let name = emsdk_install_dir.file_name()?.to_str()?;
+    let mut parts = name.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|m| m.parse().ok()).unwrap_or(0);
+    Some((major, minor))
+}
+
+/// Drop flags that clangd's clang does not understand or that are
+/// stale-prone for an index-only configuration:
+///
+/// - `-sFOO[=...]` emscripten linker-style settings (note: `-std=...`,
+///   `-shared` etc. have a lowercase letter after `-s` and are kept),
+/// - `-flto=...` / `-flto`,
+/// - `-fmodule-file=...` (PCM path is build-mode dependent and stale-prone),
+/// - `-Xclang` plus its argument,
+/// - `-fmodules-codegen`.
+fn filter_compile_flags(flags: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(flags.len());
+    let mut skip_next = false;
+    for flag in flags {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if flag == "-s" || flag == "-Xclang" {
+            skip_next = true;
+            continue;
+        }
+        let em_setting = flag
+            .strip_prefix("-s")
+            .and_then(|rest| rest.chars().next())
+            .is_some_and(|c| c.is_ascii_uppercase());
+        if em_setting
+            || flag == "-flto"
+            || flag.starts_with("-flto=")
+            || flag.starts_with("-fmodule-file=")
+            || flag == "-fmodules-codegen"
+        {
+            continue;
+        }
+        out.push(flag.clone());
+    }
+    out
+}
+
+struct ResolvedPaths {
+    sketch_dir: String,
+    fastled_dir: String,
+    clangxx: String,
+    sysroot: String,
+    libcxx_include: String,
+    sysroot_include: String,
+    system_include: String,
+    fastled_src: String,
+    fastled_wasm_compiler: String,
+}
+
+fn resolve_paths(inputs: &ClangdConfigInputs) -> ResolvedPaths {
+    let emsdk = crate::path::canonicalize_normalized(&inputs.emsdk_install_dir);
+    let fastled_dir = crate::path::canonicalize_normalized(&inputs.fastled_dir);
+    let sysroot = emsdk.join("emscripten").join("cache").join("sysroot");
+    ResolvedPaths {
+        sketch_dir: display_path(&inputs.sketch_dir),
+        fastled_dir: fastled_dir.to_string_lossy().replace('\\', "/"),
+        clangxx: bundled_clangxx(&emsdk).to_string_lossy().replace('\\', "/"),
+        sysroot: sysroot.to_string_lossy().replace('\\', "/"),
+        libcxx_include: sysroot
+            .join("include")
+            .join("c++")
+            .join("v1")
+            .to_string_lossy()
+            .replace('\\', "/"),
+        sysroot_include: sysroot.join("include").to_string_lossy().replace('\\', "/"),
+        system_include: emsdk
+            .join("emscripten")
+            .join("system")
+            .join("include")
+            .to_string_lossy()
+            .replace('\\', "/"),
+        fastled_src: fastled_dir.join("src").to_string_lossy().replace('\\', "/"),
+        fastled_wasm_compiler: fastled_dir
+            .join("src")
+            .join("platforms")
+            .join("wasm")
+            .join("compiler")
+            .to_string_lossy()
+            .replace('\\', "/"),
+    }
+}
+
+/// Build the `arguments` array of one `compile_commands.json` entry.
+fn compile_arguments(
+    inputs: &ClangdConfigInputs,
+    paths: &ResolvedPaths,
+    file: &str,
+    force_cpp: bool,
+) -> Vec<String> {
+    let mut args = vec![paths.clangxx.clone()];
+    if force_cpp {
+        // The `.ino` extension is unknown to clang; force C++.
+        args.push("-x".to_string());
+        args.push("c++".to_string());
+    }
+    args.extend([
+        "-c".to_string(),
+        file.to_string(),
+        "-o".to_string(),
+        format!("{}/.build/wasm/clangd_stub.o", paths.sketch_dir),
+        "--target=wasm32-unknown-emscripten".to_string(),
+        format!("--sysroot={}", paths.sysroot),
+        "-isystem".to_string(),
+        paths.libcxx_include.clone(),
+        "-isystem".to_string(),
+        paths.sysroot_include.clone(),
+        "-isystem".to_string(),
+        paths.system_include.clone(),
+        "-I".to_string(),
+        paths.fastled_src.clone(),
+        "-I".to_string(),
+        paths.fastled_wasm_compiler.clone(),
+        "-I".to_string(),
+        paths.sketch_dir.clone(),
+        "-D__EMSCRIPTEN__=1".to_string(),
+    ]);
+    if let Some((major, minor)) = emscripten_version(&inputs.emsdk_install_dir) {
+        args.push(format!("-D__EMSCRIPTEN_major__={major}"));
+        args.push(format!("-D__EMSCRIPTEN_minor__={minor}"));
+    }
+    args.extend(filter_compile_flags(&inputs.compile_flags));
+    args
+}
+
+fn write_compile_commands(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Result<()> {
+    let ino = display_path(&inputs.ino_file);
+    let wrapper = display_path(&inputs.wrapper_source);
+    // `directory` must be the FastLED checkout because the real build runs
+    // with `current_dir(fastled_dir)`.
+    let entries = json!([
+        {
+            "directory": paths.fastled_dir,
+            "file": ino,
+            "arguments": compile_arguments(inputs, paths, &ino, true),
+        },
+        {
+            "directory": paths.fastled_dir,
+            "file": wrapper,
+            "arguments": compile_arguments(inputs, paths, &wrapper, false),
+        },
+    ]);
+    install::write_json_file(&inputs.sketch_dir.join("compile_commands.json"), &entries)
+}
+
+fn write_clangd_file(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Result<()> {
+    let content = format!(
+        "# Generated by `fastled` (build mode: {mode}).\n\
+         # Real build driver: {empp} (emcc: {emcc})\n\
+         CompileFlags:\n\
+         \x20 CompilationDatabase: .\n\
+         \x20 Add:\n\
+         \x20   - --target=wasm32-unknown-emscripten\n\
+         \x20   - --sysroot={sysroot}\n\
+         \x20   - -isystem{libcxx}\n\
+         \x20   - -I{fastled_src}\n\
+         \x20   - -I{fastled_wasm_compiler}\n\
+         \x20   - -D__EMSCRIPTEN__=1\n\
+         \x20   - -DSKETCH_COMPILE=1\n\
+         \x20 Remove:\n\
+         \x20   - -fmodule-file=*\n\
+         \x20   - -fmodules-codegen\n\
+         \x20   - -Xclang\n",
+        mode = inputs.build_mode.as_str(),
+        empp = display_path(&inputs.tools_empp_path),
+        emcc = display_path(&inputs.tools_emcc_path),
+        sysroot = paths.sysroot,
+        libcxx = paths.libcxx_include,
+        fastled_src = paths.fastled_src,
+        fastled_wasm_compiler = paths.fastled_wasm_compiler,
+    );
+    let path = inputs.sketch_dir.join(".clangd");
+    std::fs::write(&path, content).with_context(|| format!("write {}", path.display()))
+}
+
+fn write_vscode_settings(paths: &ResolvedPaths, sketch_dir: &Path) -> Result<()> {
+    let settings_path = sketch_dir.join(".vscode").join("settings.json");
+    let mut settings = install::read_json_file(&settings_path, json!({}));
+    if !settings.is_object() {
+        settings = json!({});
+    }
+    let object = settings.as_object_mut().expect("settings.json root object");
+
+    object.insert(
+        "clangd.arguments".to_string(),
+        json!([
+            "--compile-commands-dir=${workspaceFolder}",
+            format!("--query-driver={}", paths.clangxx),
+            "--background-index",
+            "--header-insertion=never",
+            "--completion-style=detailed",
+            "--pch-storage=memory",
+        ]),
+    );
+    object.insert(
+        "clangd.fallbackFlags".to_string(),
+        json!([
+            "-std=c++20",
+            "--target=wasm32-unknown-emscripten",
+            format!("-I{}", paths.fastled_src),
+            format!("-I{}", paths.fastled_wasm_compiler),
+            format!("-isystem{}", paths.libcxx_include),
+            "-D__EMSCRIPTEN__=1",
+        ]),
+    );
+    object.insert("C_Cpp.intelliSenseEngine".to_string(), json!("disabled"));
+    object.insert("C_Cpp.autocomplete".to_string(), json!("disabled"));
+    object.insert("C_Cpp.errorSquiggles".to_string(), json!("disabled"));
+
+    let associations = object
+        .entry("files.associations")
+        .or_insert_with(|| json!({}));
+    if !associations.is_object() {
+        *associations = json!({});
+    }
+    associations
+        .as_object_mut()
+        .expect("files.associations object")
+        .insert("*.ino".to_string(), json!("cpp"));
+
+    install::write_json_file(&settings_path, &settings)
+}
+
+/// Write `compile_commands.json`, `.clangd`, and `.vscode/settings.json`
+/// into the sketch directory. All emitted paths are absolute, use forward
+/// slashes, and carry no Windows `\\?\` prefix.
+pub fn write_clangd_config(inputs: &ClangdConfigInputs) -> Result<()> {
+    let paths = resolve_paths(inputs);
+    write_compile_commands(inputs, &paths)?;
+    write_clangd_file(inputs, &paths)?;
+    write_vscode_settings(&paths, &inputs.sketch_dir)?;
+    Ok(())
+}
+
+/// Handler for `fastled --write-clangd[=DIR]`: regenerate the clangd
+/// configuration for a sketch directory without compiling. Ensures the
+/// emscripten toolchain and the FastLED repo are present (downloading them
+/// if necessary), materializes the wrapper `.cpp`, and writes the config.
+pub fn run_write_clangd(dir_arg: &str) -> Result<()> {
+    let sketch_dir = if dir_arg == "__cwd__" {
+        NormalizedPath::new(std::env::current_dir().context("resolve current directory")?)
+    } else {
+        NormalizedPath::new(dir_arg)
+    };
+    let sketch_dir = crate::path::canonicalize_normalized(&sketch_dir);
+    if !sketch_dir.is_dir() {
+        anyhow::bail!("sketch directory does not exist: {}", sketch_dir.display());
+    }
+    let ino_file = NormalizedPath::new(crate::wasm_build::sketch_ino_file(&sketch_dir)?);
+
+    let emsdk_install_dir = NormalizedPath::new(install::ensure_emscripten_installed()?);
+    let tools_emcc_path = emsdk_install_dir.join("emscripten").join("emcc.py");
+    let tools_empp_path = emsdk_install_dir.join("emscripten").join("em++.py");
+
+    let fastled_dir = NormalizedPath::new(crate::wasm_build::resolve_fastled_dir_for_sketch(
+        &sketch_dir,
+    )?);
+    let (example_name, example_dir, _is_in_tree) =
+        crate::wasm_build::resolve_example_name(&sketch_dir, &fastled_dir);
+    let example_dir = NormalizedPath::new(example_dir);
+    let sketch_cache = crate::wasm_build::sketch_cache_dir(&example_dir);
+    let wrapper_source = NormalizedPath::new(crate::wasm_build::create_wrapper(
+        &example_dir,
+        &example_name,
+        &sketch_cache,
+    )?);
+
+    let build_mode = BuildMode::Quick;
+    let compile_flags =
+        crate::wasm_build::get_sketch_compile_flags(&fastled_dir, build_mode, None)?;
+
+    write_clangd_config(&ClangdConfigInputs {
+        sketch_dir: example_dir.clone(),
+        fastled_dir,
+        emsdk_install_dir,
+        tools_emcc_path,
+        tools_empp_path,
+        wrapper_source,
+        ino_file,
+        compile_flags,
+        build_mode,
+    })?;
+
+    println!(
+        "Wrote clangd configuration (compile_commands.json, .clangd, .vscode/settings.json) to {}",
+        example_dir.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::fs;
+
+    fn stub_inputs(root: &Path) -> ClangdConfigInputs {
+        let sketch_dir = root.join("Blink");
+        let cache = sketch_dir.join(".build").join("wasm");
+        fs::create_dir_all(&cache).unwrap();
+        let ino_file = sketch_dir.join("Blink.ino");
+        fs::write(&ino_file, "void setup() {}\nvoid loop() {}\n").unwrap();
+        let wrapper_source = cache.join("Blink_wrapper.cpp");
+        fs::write(&wrapper_source, "// wrapper\n").unwrap();
+
+        let fastled_dir = root.join("fastled");
+        fs::create_dir_all(
+            fastled_dir
+                .join("src")
+                .join("platforms")
+                .join("wasm")
+                .join("compiler"),
+        )
+        .unwrap();
+
+        let emsdk = root.join("emsdk").join("4.0.19");
+        fs::create_dir_all(emsdk.join("bin")).unwrap();
+        let clang_name = if cfg!(windows) {
+            "clang++.exe"
+        } else {
+            "clang++"
+        };
+        fs::write(emsdk.join("bin").join(clang_name), "stub").unwrap();
+        fs::create_dir_all(
+            emsdk
+                .join("emscripten")
+                .join("cache")
+                .join("sysroot")
+                .join("include")
+                .join("c++")
+                .join("v1"),
+        )
+        .unwrap();
+        fs::create_dir_all(emsdk.join("emscripten").join("system").join("include")).unwrap();
+
+        ClangdConfigInputs {
+            sketch_dir: NormalizedPath::new(&sketch_dir),
+            fastled_dir: NormalizedPath::new(fastled_dir),
+            emsdk_install_dir: NormalizedPath::new(&emsdk),
+            tools_emcc_path: NormalizedPath::new(emsdk.join("emscripten").join("emcc.py")),
+            tools_empp_path: NormalizedPath::new(emsdk.join("emscripten").join("em++.py")),
+            wrapper_source: NormalizedPath::new(wrapper_source),
+            ino_file: NormalizedPath::new(ino_file),
+            compile_flags: vec![
+                "-DFASTLED_FORCE_NAMESPACE=1".to_string(),
+                "-DSKETCH_COMPILE=1".to_string(),
+                "-std=c++20".to_string(),
+                "-fno-exceptions".to_string(),
+                "-sALLOW_MEMORY_GROWTH=1".to_string(),
+                "-flto=thin".to_string(),
+                "-fmodule-file=/tmp/wasm_pch.h.pcm".to_string(),
+                "-Xclang".to_string(),
+                "-fmodules-codegen".to_string(),
+            ],
+            build_mode: BuildMode::Quick,
+        }
+    }
+
+    #[test]
+    fn filter_drops_em_settings_and_module_flags() {
+        let flags: Vec<String> = [
+            "-std=c++20",
+            "-sALLOW_MEMORY_GROWTH=1",
+            "-s",
+            "EXPORTED_FUNCTIONS=_main",
+            "-flto=thin",
+            "-flto",
+            "-fmodule-file=a.pcm",
+            "-Xclang",
+            "-fmodules-codegen",
+            "-shared",
+            "-DSKETCH_COMPILE=1",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            filter_compile_flags(&flags),
+            vec![
+                "-std=c++20".to_string(),
+                "-shared".to_string(),
+                "-DSKETCH_COMPILE=1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_emscripten_version_from_install_dir() {
+        assert_eq!(
+            emscripten_version(Path::new(
+                "/home/u/.fastled/toolchains/emscripten/x/y/4.0.19"
+            )),
+            Some((4, 0))
+        );
+        assert_eq!(emscripten_version(Path::new("/tmp/not-a-version")), None);
+    }
+
+    #[test]
+    fn writes_all_three_files_with_expected_contents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inputs = stub_inputs(tmp.path());
+
+        write_clangd_config(&inputs).unwrap();
+
+        // compile_commands.json
+        let cc_path = inputs.sketch_dir.join("compile_commands.json");
+        let cc_text = fs::read_to_string(&cc_path).unwrap();
+        assert!(!cc_text.contains("\\\\?\\"), "no \\\\?\\ prefixes allowed");
+        let cc: Value = serde_json::from_str(&cc_text).unwrap();
+        let entries = cc.as_array().expect("array");
+        assert_eq!(entries.len(), 2);
+
+        let clangxx = bundled_clangxx(&crate::path::canonicalize_normalized(
+            &inputs.emsdk_install_dir,
+        ));
+        assert!(clangxx.is_file(), "bundled clang++ must exist on disk");
+        for entry in entries {
+            let args: Vec<&str> = entry["arguments"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect();
+            assert_eq!(args[0], clangxx.to_string_lossy().replace('\\', "/"));
+            assert!(args.contains(&"--target=wasm32-unknown-emscripten"));
+            assert!(args.contains(&"-D__EMSCRIPTEN__=1"));
+            assert!(args.contains(&"-D__EMSCRIPTEN_major__=4"));
+            assert!(args
+                .iter()
+                .any(|a| a.starts_with("--sysroot=") && a.ends_with("emscripten/cache/sysroot")));
+            assert!(args.contains(&"-std=c++20"));
+            // em-only flags are filtered.
+            assert!(!args.contains(&"-sALLOW_MEMORY_GROWTH=1"));
+            assert!(!args.contains(&"-flto=thin"));
+            assert!(!args.iter().any(|a| a.starts_with("-fmodule-file=")));
+            assert!(!args.contains(&"-Xclang"));
+            // -I flags use the two-token form: ["-I", "<dir>"].
+            let include_dirs: Vec<&str> = args
+                .iter()
+                .enumerate()
+                .filter(|(_, a)| **a == "-I")
+                .map(|(i, _)| args[i + 1])
+                .collect();
+            assert!(include_dirs.iter().any(|d| d.ends_with("fastled/src")));
+            assert!(include_dirs
+                .iter()
+                .any(|d| d.ends_with("src/platforms/wasm/compiler")));
+            // directory is the FastLED checkout (build cwd).
+            let directory = entry["directory"].as_str().unwrap();
+            assert!(directory.ends_with("fastled"));
+            assert!(!directory.contains("\\\\?\\"));
+        }
+        // The .ino entry forces C++.
+        let ino_args: Vec<&str> = entries[0]["arguments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(entries[0]["file"].as_str().unwrap().ends_with("Blink.ino"));
+        assert_eq!(&ino_args[1..3], ["-x", "c++"]);
+
+        // .clangd
+        let clangd_text = fs::read_to_string(inputs.sketch_dir.join(".clangd")).unwrap();
+        assert!(clangd_text.contains("CompilationDatabase: ."));
+        assert!(clangd_text.contains("- --target=wasm32-unknown-emscripten"));
+        assert!(clangd_text.contains("- -D__EMSCRIPTEN__=1"));
+        assert!(clangd_text.contains("- -DSKETCH_COMPILE=1"));
+        assert!(clangd_text.contains("- -fmodule-file=*"));
+        assert!(!clangd_text.contains("\\\\?\\"));
+
+        // .vscode/settings.json
+        let settings_path = inputs.sketch_dir.join(".vscode").join("settings.json");
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let clangd_args: Vec<&str> = settings["clangd.arguments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(clangd_args.contains(&"--compile-commands-dir=${workspaceFolder}"));
+        assert!(clangd_args
+            .iter()
+            .any(|a| a.starts_with("--query-driver=") && a.contains("clang++")));
+        assert_eq!(settings["C_Cpp.intelliSenseEngine"], "disabled");
+        assert_eq!(settings["files.associations"]["*.ino"], "cpp");
+    }
+
+    #[test]
+    fn merges_existing_vscode_settings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inputs = stub_inputs(tmp.path());
+        let settings_path = inputs.sketch_dir.join(".vscode").join("settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(
+            &settings_path,
+            r#"{"editor.formatOnSave": true, "files.associations": {"*.h": "cpp"}}"#,
+        )
+        .unwrap();
+
+        write_clangd_config(&inputs).unwrap();
+
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(settings["editor.formatOnSave"], true);
+        assert_eq!(settings["files.associations"]["*.h"], "cpp");
+        assert_eq!(settings["files.associations"]["*.ino"], "cpp");
+        assert!(settings["clangd.arguments"].is_array());
+    }
+
+    #[test]
+    fn regenerating_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inputs = stub_inputs(tmp.path());
+        write_clangd_config(&inputs).unwrap();
+        let first = fs::read_to_string(inputs.sketch_dir.join("compile_commands.json")).unwrap();
+        write_clangd_config(&inputs).unwrap();
+        let second = fs::read_to_string(inputs.sketch_dir.join("compile_commands.json")).unwrap();
+        assert_eq!(first, second);
+    }
+}

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -73,6 +73,12 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) purge: bool,
 
+    /// Write VS Code clangd configuration (compile_commands.json,
+    /// .clangd, .vscode/settings.json) for the sketch directory and exit.
+    /// Defaults to the current directory when no DIR is given.
+    #[arg(long, value_name = "DIR", num_args = 0..=1, default_missing_value = "__cwd__")]
+    pub(crate) write_clangd: Option<String>,
+
     /// Internal plumbing flag: ensure the FastLED repo for the given ref
     /// (defaults to latest release) is downloaded and extracted, print the
     /// local path to stdout, and exit. Used by the Python `Api.project_init`

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -733,14 +733,14 @@ fn check_existing_arduino_content() -> bool {
     cwd.join("examples").exists() || has_ino_file(&cwd)
 }
 
-fn read_json_file(path: &Path, default: Value) -> Value {
+pub(crate) fn read_json_file(path: &Path, default: Value) -> Value {
     fs::read_to_string(path)
         .ok()
         .and_then(|text| serde_json::from_str::<Value>(&text).ok())
         .unwrap_or(default)
 }
 
-fn write_json_file(path: &Path, value: &Value) -> Result<()> {
+pub(crate) fn write_json_file(path: &Path, value: &Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 
 mod archive;
 mod build;
+mod clangd_config;
 mod cli;
 mod commands;
 mod compile_stream;
@@ -85,6 +86,17 @@ pub fn run() -> ExitCode {
                 return ExitCode::FAILURE;
             }
         }
+    }
+
+    // Regenerate VS Code clangd configuration for a sketch without building.
+    if let Some(ref dir) = cli.write_clangd {
+        return match clangd_config::run_write_clangd(dir) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(err) => {
+                eprintln!("fastled: failed to write clangd config: {err:#}");
+                ExitCode::FAILURE
+            }
+        };
     }
 
     if let Some(ref init_value) = cli.init {
@@ -196,6 +208,7 @@ mod tests {
             commit: None,
             fastled_path: None,
             purge: false,
+            write_clangd: None,
             internal_ensure_fastled_repo: None,
             internal_dwarf_smoke: false,
             internal_serve_dir_headless: None,

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -114,7 +114,7 @@ struct FlagList {
 }
 
 #[derive(Debug, Clone)]
-struct DwarfPathRoots {
+pub(crate) struct DwarfPathRoots {
     sketch_dir: Option<PathBuf>,
     fastled_dir: PathBuf,
     emsdk_root: Option<PathBuf>,
@@ -280,7 +280,10 @@ fn normalize_path(path: &Path) -> PathBuf {
     crate::path::canonicalize_normalized(path).into_path_buf()
 }
 
-fn resolve_example_name(sketch_dir: &Path, fastled_dir: &Path) -> (String, PathBuf, bool) {
+pub(crate) fn resolve_example_name(
+    sketch_dir: &Path,
+    fastled_dir: &Path,
+) -> (String, PathBuf, bool) {
     let examples_dir = fastled_dir.join("examples");
     if let Ok(relative) = sketch_dir.strip_prefix(&examples_dir) {
         let name = relative.to_string_lossy().replace('\\', "/");
@@ -304,11 +307,11 @@ fn build_dir(fastled_dir: &Path, mode: BuildMode) -> PathBuf {
         .join(format!("meson-wasm-{}", mode.as_str()))
 }
 
-fn sketch_cache_dir(example_dir: &Path) -> PathBuf {
+pub(crate) fn sketch_cache_dir(example_dir: &Path) -> PathBuf {
     example_dir.join(".build").join("wasm")
 }
 
-fn sketch_ino_file(example_dir: &Path) -> Result<PathBuf> {
+pub(crate) fn sketch_ino_file(example_dir: &Path) -> Result<PathBuf> {
     let sketch_name = example_dir
         .file_name()
         .and_then(|name| name.to_str())
@@ -351,7 +354,7 @@ fn load_build_flags(fastled_dir: &Path) -> Result<BuildFlagsToml> {
     toml::from_str(&source).with_context(|| format!("parse {}", path.display()))
 }
 
-fn get_sketch_compile_flags(
+pub(crate) fn get_sketch_compile_flags(
     fastled_dir: &Path,
     mode: BuildMode,
     dwarf_roots: Option<&DwarfPathRoots>,
@@ -668,7 +671,7 @@ fn build_library(
     Ok(true)
 }
 
-fn create_wrapper(
+pub(crate) fn create_wrapper(
     example_dir: &Path,
     example_name: &str,
     sketch_cache_dir: &Path,
@@ -1063,6 +1066,21 @@ fn collect_data_files(root: &Path, dir: &Path, out: &mut Vec<serde_json::Value>)
     Ok(())
 }
 
+/// Resolve the FastLED checkout for a sketch directory without a full
+/// `BuildRequest`. Used by `fastled --write-clangd` to mirror the build's
+/// FastLED-ref resolution (honours the `fastled.json` pin).
+pub(crate) fn resolve_fastled_dir_for_sketch(sketch_dir: &Path) -> Result<PathBuf> {
+    let request = BuildRequest {
+        sketch_dir: sketch_dir.to_path_buf(),
+        build_mode: BuildMode::Quick,
+        profile: false,
+        fastled_path: None,
+        force_clean: false,
+    };
+    let (fastled_dir, _cleanup) = resolve_fastled_dir(&request)?;
+    Ok(normalize_path(&fastled_dir))
+}
+
 fn resolve_fastled_dir(request: &BuildRequest) -> Result<(PathBuf, Option<PathBuf>)> {
     if let Some(path) = &request.fastled_path {
         return Ok((normalize_path(path), None));
@@ -1216,6 +1234,35 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             emsdk_root.clone(),
         );
         debug_symbols::write_debug_symbol_manifest(&output_dir, &debug_config)?;
+
+        // Emit clangd/VS Code configuration so "Go to Definition" works for
+        // the sketch in VS Code (Refs #177). Non-fatal: a config-write
+        // failure must never fail an otherwise successful build.
+        let clangd_result = (|| -> Result<()> {
+            let ino_file = sketch_ino_file(&example_dir)?;
+            let compile_flags = get_sketch_compile_flags(
+                &fastled_dir,
+                request.build_mode,
+                Some(&sketch_dwarf_roots),
+            )?;
+            crate::clangd_config::write_clangd_config(&crate::clangd_config::ClangdConfigInputs {
+                sketch_dir: crate::path::NormalizedPath::new(&example_dir),
+                fastled_dir: crate::path::NormalizedPath::new(&fastled_dir),
+                emsdk_install_dir: crate::path::NormalizedPath::new(&emscripten_install),
+                tools_emcc_path: crate::path::NormalizedPath::new(&tools.emcc),
+                tools_empp_path: crate::path::NormalizedPath::new(&tools.empp),
+                wrapper_source: crate::path::NormalizedPath::new(&wrapper),
+                ino_file: crate::path::NormalizedPath::new(ino_file),
+                compile_flags,
+                build_mode: request.build_mode,
+            })
+        })();
+        if let Err(err) = clangd_result {
+            log(
+                &format!("[WASM] warning: failed to write clangd config: {err:#}"),
+                "stderr",
+            );
+        }
         Ok(())
     })();
 


### PR DESCRIPTION
## Summary

Closes #177.

- New `crates/fastled-cli/src/clangd_config.rs` module that writes `compile_commands.json` (entries for both the `.ino` and the generated wrapper `.cpp`), `.clangd`, and `.vscode/settings.json` into the sketch directory, so the VS Code clangd extension resolves FastLED headers, emscripten sysroot headers, and libc++ ("Go to Definition" / "Find Usages" work).
- `compile_commands.json` uses the bundled `<emsdk>/bin/clang++[.exe]` as `arguments[0]`, adds `--target=wasm32-unknown-emscripten`, `--sysroot`, `-isystem` sysroot/libc++/system includes, `-D__EMSCRIPTEN__=1` (+ major/minor parsed from the toolchain version dir), and the real sketch compile flags with em-only flags filtered out (`-sFOO=...`, `-flto`, `-fmodule-file=...`, `-Xclang`, `-fmodules-codegen`).
- `.vscode/settings.json` is create-or-merged (existing keys preserved) and wires `clangd.arguments` with `--compile-commands-dir=${workspaceFolder}` and `--query-driver=<bundled clang++>`, disables the MS C/C++ IntelliSense engine, and maps `*.ino` to C++.
- Hooked at the tail of `run_build_streaming()` after a successful build; failures are non-fatal (warning via the log sink, build still succeeds).
- New `--write-clangd[=DIR]` flag regenerates all three files without compiling, reusing the build's FastLED-ref resolution (`fastled.json` pin) and wrapper generation.
- All paths are absolute, forward-slashed, and stripped of Windows `\?\` prefixes; the module uses `NormalizedPath` per the `ban_std_pathbuf` dylint.

## Tests run

- `soldr cargo test -p fastled-cli` — 155 tests pass, including 5 new `clangd_config` unit tests (file contents, flag filtering, settings merge, idempotency, version parsing, no `\?\` prefixes).
- `uv run pytest tests/unit/test_python_api.py` — 3 passed.
- `bash lint` — clean (clippy + dylint + rustfmt + Python linters).
- Manual smoke on Windows: `fastled --write-clangd <tempdir sketch>` against the real installed toolchain; verified `arguments[0]` is the existing bundled `clang++.exe`, target/sysroot/includes/defines present, valid JSON, `--query-driver` wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)