### PR TITLE
feat(cli): make clangd config emission opt-in via --clangd flag

### DIFF
--- a/crates/fastled-cli/src/clangd_config.rs
+++ b/crates/fastled-cli/src/clangd_config.rs
@@ -1,8 +1,9 @@
 //! Emit clangd / VS Code configuration for a sketch directory so that
 //! "Go to Definition" works for WASM sketches (Refs #177).
 //!
-//! After a successful WASM build (or via `fastled --write-clangd [DIR]`) the
-//! sketch directory receives:
+//! Generation is opt-in (Refs #179): after a successful WASM build run with
+//! `fastled --clangd`, or via the standalone `fastled --write-clangd [DIR]`,
+//! the sketch directory receives:
 //!
 //! - `compile_commands.json` — exact compile arguments (bundled clang++,
 //!   `--target=wasm32-unknown-emscripten`, `--sysroot`, includes, defines)

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -73,6 +73,12 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) purge: bool,
 
+    /// Also emit VS Code clangd configuration (compile_commands.json,
+    /// .clangd, .vscode/settings.json) into the sketch directory after a
+    /// successful compile.
+    #[arg(long)]
+    pub(crate) clangd: bool,
+
     /// Write VS Code clangd configuration (compile_commands.json,
     /// .clangd, .vscode/settings.json) for the sketch directory and exit.
     /// Defaults to the current directory when no DIR is given.
@@ -131,5 +137,18 @@ pub(crate) fn requested_init_ref(cli: &Cli) -> Option<&str> {
         // "latest release" default produced sketches that the build path
         // could not compile.
         Some("master")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clangd_emission_is_opt_in() {
+        let cli = Cli::parse_from(["fastled", "sketch"]);
+        assert!(!cli.clangd);
+        let cli = Cli::parse_from(["fastled", "--clangd", "sketch"]);
+        assert!(cli.clangd);
     }
 }

--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -299,6 +299,7 @@ pub(crate) fn run_native_just_compile(cli: &Cli, dir: &str) -> ExitCode {
         profile: cli.profile,
         fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
         force_clean: cli.purge,
+        emit_clangd: cli.clangd,
     };
 
     let result = match build::run_build(&request) {
@@ -429,6 +430,7 @@ pub(crate) fn run_internal_dwarf_smoke(cli: &Cli) -> ExitCode {
         profile: cli.profile,
         fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
         force_clean: cli.purge,
+        emit_clangd: cli.clangd,
     };
     let result = match build::run_build(&request) {
         Ok(result) => result,

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -226,6 +226,7 @@ pub(crate) fn run_native_compile_streaming(
         profile: cli.profile,
         fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
         force_clean,
+        emit_clangd: cli.clangd,
     };
 
     let log = |line: &str, stream: &str| emit_build_log(tx, line, stream);

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -208,6 +208,7 @@ mod tests {
             commit: None,
             fastled_path: None,
             purge: false,
+            clangd: false,
             write_clangd: None,
             internal_ensure_fastled_repo: None,
             internal_dwarf_smoke: false,

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -52,6 +52,9 @@ pub struct BuildRequest {
     pub profile: bool,
     pub fastled_path: Option<PathBuf>,
     pub force_clean: bool,
+    /// Emit clangd/VS Code configuration into the sketch directory after a
+    /// successful build. Off by default; opted in via `fastled --clangd`.
+    pub emit_clangd: bool,
 }
 
 #[derive(Debug)]
@@ -1076,6 +1079,7 @@ pub(crate) fn resolve_fastled_dir_for_sketch(sketch_dir: &Path) -> Result<PathBu
         profile: false,
         fastled_path: None,
         force_clean: false,
+        emit_clangd: false,
     };
     let (fastled_dir, _cleanup) = resolve_fastled_dir(&request)?;
     Ok(normalize_path(&fastled_dir))
@@ -1236,32 +1240,38 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
         debug_symbols::write_debug_symbol_manifest(&output_dir, &debug_config)?;
 
         // Emit clangd/VS Code configuration so "Go to Definition" works for
-        // the sketch in VS Code (Refs #177). Non-fatal: a config-write
-        // failure must never fail an otherwise successful build.
-        let clangd_result = (|| -> Result<()> {
-            let ino_file = sketch_ino_file(&example_dir)?;
-            let compile_flags = get_sketch_compile_flags(
-                &fastled_dir,
-                request.build_mode,
-                Some(&sketch_dwarf_roots),
-            )?;
-            crate::clangd_config::write_clangd_config(&crate::clangd_config::ClangdConfigInputs {
-                sketch_dir: crate::path::NormalizedPath::new(&example_dir),
-                fastled_dir: crate::path::NormalizedPath::new(&fastled_dir),
-                emsdk_install_dir: crate::path::NormalizedPath::new(&emscripten_install),
-                tools_emcc_path: crate::path::NormalizedPath::new(&tools.emcc),
-                tools_empp_path: crate::path::NormalizedPath::new(&tools.empp),
-                wrapper_source: crate::path::NormalizedPath::new(&wrapper),
-                ino_file: crate::path::NormalizedPath::new(ino_file),
-                compile_flags,
-                build_mode: request.build_mode,
-            })
-        })();
-        if let Err(err) = clangd_result {
-            log(
-                &format!("[WASM] warning: failed to write clangd config: {err:#}"),
-                "stderr",
-            );
+        // the sketch in VS Code (Refs #177). Opt-in via `--clangd` (Refs
+        // #179): writing IDE config into the user's project by default is
+        // too intrusive. Non-fatal: a config-write failure must never fail
+        // an otherwise successful build.
+        if request.emit_clangd {
+            let clangd_result = (|| -> Result<()> {
+                let ino_file = sketch_ino_file(&example_dir)?;
+                let compile_flags = get_sketch_compile_flags(
+                    &fastled_dir,
+                    request.build_mode,
+                    Some(&sketch_dwarf_roots),
+                )?;
+                crate::clangd_config::write_clangd_config(
+                    &crate::clangd_config::ClangdConfigInputs {
+                        sketch_dir: crate::path::NormalizedPath::new(&example_dir),
+                        fastled_dir: crate::path::NormalizedPath::new(&fastled_dir),
+                        emsdk_install_dir: crate::path::NormalizedPath::new(&emscripten_install),
+                        tools_emcc_path: crate::path::NormalizedPath::new(&tools.emcc),
+                        tools_empp_path: crate::path::NormalizedPath::new(&tools.empp),
+                        wrapper_source: crate::path::NormalizedPath::new(&wrapper),
+                        ino_file: crate::path::NormalizedPath::new(ino_file),
+                        compile_flags,
+                        build_mode: request.build_mode,
+                    },
+                )
+            })();
+            if let Err(err) = clangd_result {
+                log(
+                    &format!("[WASM] warning: failed to write clangd config: {err:#}"),
+                    "stderr",
+                );
+            }
         }
         Ok(())
     })();


### PR DESCRIPTION
## Summary
- Clangd/VS Code config (`compile_commands.json`, `.clangd`, `.vscode/settings.json`) is no longer written into the sketch directory on every successful compile (introduced in #178).
- New `--clangd` boolean flag opts in: `fastled --clangd <sketch_dir>` compiles and emits the config (still non-fatal on write failure).
- `--write-clangd[=DIR]` is unchanged as the standalone no-compile generator.
- `BuildRequest` gains `emit_clangd: bool`, threaded from the CLI through all build entry points.

Closes #179

## Test plan
- [x] `soldr cargo test --workspace` — all pass, including new `clangd_emission_is_opt_in` parse test
- [x] `bash lint` — clean
- [ ] Manual: `fastled <sketch>` leaves no clangd files; `fastled --clangd <sketch>` emits all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)