### PR TITLE
fix: add FASTLED_FRONTEND_DIR env var for wheel builds

### DIFF
--- a/crates/fastled-cli/src/frontend.rs
+++ b/crates/fastled-cli/src/frontend.rs
@@ -32,6 +32,15 @@ fn workspace_root() -> PathBuf {
 /// Walk up from `CARGO_MANIFEST_DIR` looking for the workspace's
 /// `src/fastled/frontend` directory.
 fn default_source_dir() -> Result<PathBuf> {
+    // Check for FASTLED_FRONTEND_DIR environment variable first.
+    if let Ok(path) = std::env::var("FASTLED_FRONTEND_DIR") {
+        let candidate = PathBuf::from(&path);
+        if candidate.is_dir() {
+            return Ok(candidate);
+        }
+        anyhow::bail!("FASTLED_FRONTEND_DIR={} is not a directory", path);
+    }
+
     let candidate = workspace_root()
         .join("src")
         .join("fastled")
@@ -49,7 +58,8 @@ fn default_source_dir() -> Result<PathBuf> {
         current = dir.parent().map(Path::to_path_buf);
     }
     anyhow::bail!(
-        "could not locate src/fastled/frontend relative to CARGO_MANIFEST_DIR={}",
+        "could not locate src/fastled/frontend relative to CARGO_MANIFEST_DIR={}. \
+         Set FASTLED_FRONTEND_DIR to the path containing the frontend assets.",
         env!("CARGO_MANIFEST_DIR")
     )
 }

--- a/src/fastled/_rust_cli.py
+++ b/src/fastled/_rust_cli.py
@@ -79,6 +79,12 @@ def invoke_rust_fastled_cli(argv: list[str] | None = None) -> int:
     env = os.environ.copy()
     env.setdefault("FASTLED_PYTHON_EXECUTABLE", sys.executable)
 
+    # Set FASTLED_FRONTEND_DIR to the bundled frontend if not already set.
+    if "FASTLED_FRONTEND_DIR" not in env:
+        frontend_dir = Path(__file__).resolve().parent / "frontend"
+        if frontend_dir.is_dir():
+            env["FASTLED_FRONTEND_DIR"] = str(frontend_dir)
+
     cli = find_rust_fastled_cli()
     if cli is not None:
         return subprocess.run([str(cli), *args], check=False, env=env).returncode


### PR DESCRIPTION
Allow overriding the frontend source directory via FASTLED_FRONTEND_DIR environment variable. The Python shim sets this to the bundled frontend path when running from a wheel, so the Rust CLI can locate frontend assets that aren't relative to CARGO_MANIFEST_DIR.

Also improves the error message to mention the env var as a resolution step.

Authored by: Qwen-3.6-35B-A3B-MTP-GGUF:Q8_K_XL