### PR TITLE
feat(cli): add no-app and dynamic link modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Useful flags:
 | Flag | Description |
 |------|-------------|
 | `--just-compile` | Compile and exit without opening a browser or watching files |
+| `--no-app` | Emit the JavaScript API/WASM artifacts without the default `index.js` application |
+| `--link-mode <static|dynamic>` | Static linking is the default; dynamic mode emits and load-links `sketch.wasm` |
 | `--debug` | Build with debug-friendly compiler settings |
 | `--quick` | Default build mode |
 | `--release` | Optimized build (~1/3 smaller binary) |
@@ -91,7 +93,7 @@ If you launch `fastled` inside the FastLED repo with `--fastled-path`, changes t
 
 ### Big Data in `/data` Directory
 
-Large files (e.g. video) in a sketch's `data/` directory are handled specially to avoid round-tripping blobs. The WASM compiler generates a `files.json` manifest for an emulated SD card system mounted at `/data/`. Files named `*.json`, `*.csv`, `*.txt` are injected before `setup()` runs; all others are streamed asynchronously at runtime.
+Large files (e.g. video) in a sketch's `data/` directory are handled specially to avoid round-tripping blobs. The WASM compiler generates a `sketch_assets.json` manifest for an emulated SD card system mounted at `/data/`. Files named `*.json`, `*.csv`, `*.txt` are injected before `setup()` runs; all others are streamed asynchronously at runtime. The loader accepts legacy `files.json` output when running an older generated sketch.
 
 For an example see `examples/SdCard` in the FastLED repo.
 

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -1,4 +1,14 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+
+/// How the sketch code is linked into the generated WASM program.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub(crate) enum LinkMode {
+    /// Statically link the sketch into fastled.wasm.
+    #[default]
+    Static,
+    /// Emit sketch.wasm as an Emscripten side module loaded by fastled.js.
+    Dynamic,
+}
 
 /// FastLED WASM compilation CLI.
 ///
@@ -31,6 +41,15 @@ pub(crate) struct Cli {
     /// Just compile; skip opening the browser and watching for changes.
     #[arg(long)]
     pub(crate) just_compile: bool,
+
+    /// Omit the default index.js application and emit only the JavaScript API
+    /// plus its WASM/runtime artifacts.
+    #[arg(long)]
+    pub(crate) no_app: bool,
+
+    /// Select static linking (the default) or Emscripten side-module linking.
+    #[arg(long, value_enum, default_value_t = LinkMode::Static)]
+    pub(crate) link_mode: LinkMode,
 
     /// Enable profiling of the C++ build system used for WASM compilation.
     #[arg(long)]
@@ -150,5 +169,24 @@ mod tests {
         assert!(!cli.clangd);
         let cli = Cli::parse_from(["fastled", "--clangd", "sketch"]);
         assert!(cli.clangd);
+    }
+
+    #[test]
+    fn api_and_dynamic_linking_flags_parse_together() {
+        let cli = Cli::parse_from([
+            "fastled",
+            "sketch",
+            "--no-app",
+            "--link-mode=dynamic",
+        ]);
+        assert!(cli.no_app);
+        assert_eq!(cli.link_mode, LinkMode::Dynamic);
+    }
+
+    #[test]
+    fn static_linking_is_the_default() {
+        let cli = Cli::parse_from(["fastled", "sketch"]);
+        assert!(!cli.no_app);
+        assert_eq!(cli.link_mode, LinkMode::Static);
     }
 }

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -173,12 +173,7 @@ mod tests {
 
     #[test]
     fn api_and_dynamic_linking_flags_parse_together() {
-        let cli = Cli::parse_from([
-            "fastled",
-            "sketch",
-            "--no-app",
-            "--link-mode=dynamic",
-        ]);
+        let cli = Cli::parse_from(["fastled", "sketch", "--no-app", "--link-mode=dynamic"]);
         assert!(cli.no_app);
         assert_eq!(cli.link_mode, LinkMode::Dynamic);
     }

--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -36,7 +36,7 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
     // Ensure the emscripten + esbuild toolchains are installed before invoking
     // the native Rust build backend. The backend consumes the Rust-installed
     // directories via these environment variables.
-    if let Err(message) = ensure_compile_prerequisites() {
+    if let Err(message) = ensure_compile_prerequisites(true) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
     }
@@ -96,7 +96,7 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
 
         let success =
             run_native_compile_streaming(cli, &sketch_dir, cli.purge, &tx, &debug_symbols);
-        report_build_outcome(&output_dir, &tx, success);
+        report_build_outcome(&output_dir, &tx, success, !cli.no_app);
 
         // --- Watch mode ---------------------------------------------------------
         println!("\nWill recompile on sketch changes or space bar press.");
@@ -143,7 +143,7 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
 
                 let success =
                     run_native_compile_streaming(cli, &sketch_dir, false, &tx, &debug_symbols);
-                if report_build_outcome(&output_dir, &tx, success) {
+                if report_build_outcome(&output_dir, &tx, success, !cli.no_app) {
                     println!("Recompilation successful!");
                 } else {
                     eprintln!("Recompilation failed.");
@@ -284,7 +284,7 @@ pub(crate) fn run_native_init(cli: &Cli, example: Option<&str>) -> ExitCode {
 }
 
 pub(crate) fn run_native_just_compile(cli: &Cli, dir: &str) -> ExitCode {
-    if let Err(message) = ensure_compile_prerequisites() {
+    if let Err(message) = ensure_compile_prerequisites(!cli.no_app) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
     }
@@ -300,6 +300,8 @@ pub(crate) fn run_native_just_compile(cli: &Cli, dir: &str) -> ExitCode {
         fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
         force_clean: cli.purge,
         emit_clangd: cli.clangd,
+        no_app: cli.no_app,
+        link_mode: cli.link_mode,
     };
 
     let result = match build::run_build(&request) {
@@ -416,7 +418,7 @@ pub(crate) fn run_internal_dwarf_smoke(cli: &Cli) -> ExitCode {
         eprintln!("fastled: --internal-dwarf-smoke must be run with --debug");
         return ExitCode::FAILURE;
     }
-    if let Err(message) = ensure_compile_prerequisites() {
+    if let Err(message) = ensure_compile_prerequisites(true) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
     }
@@ -431,6 +433,8 @@ pub(crate) fn run_internal_dwarf_smoke(cli: &Cli) -> ExitCode {
         fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
         force_clean: cli.purge,
         emit_clangd: cli.clangd,
+        no_app: false,
+        link_mode: crate::cli::LinkMode::Static,
     };
     let result = match build::run_build(&request) {
         Ok(result) => result,

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -6,7 +6,7 @@ use crate::debug_symbols;
 use crate::install;
 use crate::server;
 
-pub(crate) fn ensure_compile_prerequisites() -> Result<(), String> {
+pub(crate) fn ensure_compile_prerequisites(include_app: bool) -> Result<(), String> {
     match install::ensure_emscripten_installed() {
         Ok(install_dir) => {
             std::env::set_var("FASTLED_EMSCRIPTEN_DIR", &install_dir);
@@ -26,12 +26,14 @@ pub(crate) fn ensure_compile_prerequisites() -> Result<(), String> {
             return Err(format!("emscripten toolchain install failed: {e:#}"));
         }
     }
-    match install::ensure_esbuild_installed() {
-        Ok(esbuild_path) => {
-            std::env::set_var("FASTLED_ESBUILD_PATH", &esbuild_path);
-        }
-        Err(e) => {
-            return Err(format!("esbuild install failed: {e:#}"));
+    if include_app {
+        match install::ensure_esbuild_installed() {
+            Ok(esbuild_path) => {
+                std::env::set_var("FASTLED_ESBUILD_PATH", &esbuild_path);
+            }
+            Err(e) => {
+                return Err(format!("esbuild install failed: {e:#}"));
+            }
         }
     }
     Ok(())
@@ -182,9 +184,10 @@ pub(crate) fn report_build_outcome(
     output_dir: &Path,
     tx: &tokio::sync::broadcast::Sender<String>,
     build_ok: bool,
+    app_required: bool,
 ) -> bool {
     let index_exists = output_dir.join("index.html").is_file();
-    if build_ok && index_exists {
+    if build_ok && (!app_required || index_exists) {
         write_build_status(output_dir, "success", "Done");
         send_sse(
             tx,
@@ -192,7 +195,7 @@ pub(crate) fn report_build_outcome(
         );
         return true;
     }
-    let message = if build_ok {
+    let message = if build_ok && app_required {
         "Build completed but no index.html was produced"
     } else {
         "Compilation failed"
@@ -227,6 +230,8 @@ pub(crate) fn run_native_compile_streaming(
         fastled_path: cli.fastled_path.as_ref().map(PathBuf::from),
         force_clean,
         emit_clangd: cli.clangd,
+        no_app: cli.no_app,
+        link_mode: cli.link_mode,
     };
 
     let log = |line: &str, stream: &str| emit_build_log(tx, line, stream);
@@ -286,13 +291,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(8);
 
-        assert!(!report_build_outcome(dir.path(), &tx, true));
+        assert!(!report_build_outcome(dir.path(), &tx, true, true));
         assert!(read_status(dir.path()).contains("\"error\""));
         let event = rx.try_recv().unwrap();
         assert!(event.contains("\"status\":\"error\""), "got: {event}");
 
         std::fs::write(dir.path().join("index.html"), "<html></html>").unwrap();
-        assert!(report_build_outcome(dir.path(), &tx, true));
+        assert!(report_build_outcome(dir.path(), &tx, true, true));
         assert!(read_status(dir.path()).contains("\"success\""));
         let event = rx.try_recv().unwrap();
         assert!(event.contains("\"status\":\"success\""), "got: {event}");
@@ -304,9 +309,20 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), "<html></html>").unwrap();
         let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(8);
 
-        assert!(!report_build_outcome(dir.path(), &tx, false));
+        assert!(!report_build_outcome(dir.path(), &tx, false, true));
         assert!(read_status(dir.path()).contains("\"error\""));
         let event = rx.try_recv().unwrap();
         assert!(event.contains("Compilation failed"), "got: {event}");
+    }
+
+    #[test]
+    fn report_build_outcome_allows_success_without_app() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(8);
+
+        assert!(report_build_outcome(dir.path(), &tx, true, false));
+        assert!(read_status(dir.path()).contains("\"success\""));
+        let event = rx.try_recv().unwrap();
+        assert!(event.contains("\"status\":\"success\""), "got: {event}");
     }
 }

--- a/crates/fastled-cli/src/frontend.rs
+++ b/crates/fastled-cli/src/frontend.rs
@@ -233,7 +233,13 @@ fn build_dist(source_dir: &Path) -> Result<PathBuf> {
     let marker = dist_dir.join(".esbuild_marker");
     let source_mtime = get_source_mtime(source_dir)?;
 
-    if dist_dir.exists() && marker.exists() {
+    if dist_dir.exists()
+        && marker.exists()
+        // The application entry artifact was renamed from app.js to index.js.
+        // Force one rebuild when an older cached dist is present.
+        && dist_dir.join("index.js").is_file()
+        && !dist_dir.join("app.js").exists()
+    {
         if let Ok(text) = fs::read_to_string(&marker) {
             if let Ok(value) = text.trim().parse::<f64>() {
                 if value >= source_mtime {
@@ -252,7 +258,7 @@ fn build_dist(source_dir: &Path) -> Result<PathBuf> {
     let esbuild = resolve_esbuild()?;
 
     let app_ts = source_dir.join("app.ts");
-    let app_out = dist_dir.join("app.js");
+    let app_out = dist_dir.join("index.js");
     run_esbuild(
         &esbuild,
         source_dir,
@@ -291,7 +297,7 @@ fn build_dist(source_dir: &Path) -> Result<PathBuf> {
     let index_src = source_dir.join("index.html");
     let index_html = fs::read_to_string(&index_src)
         .with_context(|| format!("read {}", index_src.display()))?
-        .replace("./app.ts", "./app.js");
+        .replace("./app.ts", "./index.js");
     fs::write(dist_dir.join("index.html"), index_html)
         .with_context(|| format!("write {}", dist_dir.join("index.html").display()))?;
 
@@ -362,6 +368,39 @@ pub fn copy_frontend_to_output(output_dir: &Path, source_dir: Option<&Path>) -> 
     Ok(())
 }
 
+/// Remove only the default application's generated files from an output
+/// directory. WASM, loader, debug, and sketch-asset artifacts are preserved.
+pub fn remove_app_from_output(output_dir: &Path) -> Result<()> {
+    for name in [
+        "index.js",
+        "index.js.map",
+        "app.js",
+        "app.js.map",
+        "index.html",
+        "index.css",
+        "fastled_background_worker.js",
+        "fastled_background_worker.js.map",
+        "audio_worklet_processor.js",
+        "emscripten.d.ts",
+        "types.d.ts",
+        "jsconfig.json",
+        ".esbuild_marker",
+        ".frontend_hash",
+    ] {
+        let path = output_dir.join(name);
+        if path.is_file() {
+            fs::remove_file(&path)
+                .with_context(|| format!("remove stale app artifact {}", path.display()))?;
+        }
+    }
+    let assets = output_dir.join("assets");
+    if assets.is_dir() {
+        fs::remove_dir_all(&assets)
+            .with_context(|| format!("remove stale app assets {}", assets.display()))?;
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -414,7 +453,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
         write(&root.join("app.ts"), b"// app");
-        write(&root.join("dist").join("app.js"), b"// built");
+        write(&root.join("dist").join("index.js"), b"// built");
         write(&root.join("modules").join("util.ts"), b"// util");
         write(&root.join("mydist").join("note.txt"), b"// kept");
 
@@ -450,7 +489,7 @@ mod tests {
         let source = workspace.path().join("frontend");
         let dist = source.join("dist");
         fs::create_dir_all(&dist).unwrap();
-        write(&dist.join("app.js"), b"// stub app");
+        write(&dist.join("index.js"), b"// stub app");
         write(&dist.join("index.html"), b"<!doctype html><title>t</title>");
         // Marker must satisfy `marker_value >= source_mtime` so build_dist is a
         // no-op. Use a value far in the future so any reasonable source mtime
@@ -459,17 +498,17 @@ mod tests {
 
         let output = TempDir::new().unwrap();
         copy_frontend_to_output(output.path(), Some(&source)).expect("first copy");
-        assert!(output.path().join("app.js").exists());
+        assert!(output.path().join("index.js").exists());
         let hash_after_first = fs::read_to_string(output.path().join(".frontend_hash")).unwrap();
 
         // Touch nothing; second call must be a no-op (marker matches).
-        let app_js_meta_before = fs::metadata(output.path().join("app.js"))
+        let app_js_meta_before = fs::metadata(output.path().join("index.js"))
             .unwrap()
             .modified()
             .unwrap();
         thread::sleep(Duration::from_millis(20));
         copy_frontend_to_output(output.path(), Some(&source)).expect("second copy");
-        let app_js_meta_after = fs::metadata(output.path().join("app.js"))
+        let app_js_meta_after = fs::metadata(output.path().join("index.js"))
             .unwrap()
             .modified()
             .unwrap();
@@ -483,5 +522,27 @@ mod tests {
             app_js_meta_before, app_js_meta_after,
             "files must not be re-copied when the hash marker already matches"
         );
+    }
+
+    #[test]
+    fn remove_app_from_output_preserves_runtime_and_assets_manifest() {
+        let output = TempDir::new().unwrap();
+        write(&output.path().join("index.js"), b"app");
+        write(&output.path().join("index.html"), b"html");
+        write(&output.path().join("index.css"), b"css");
+        write(&output.path().join("fastled.js"), b"loader");
+        write(&output.path().join("fastled.wasm"), b"wasm");
+        write(&output.path().join("sketch_assets.json"), b"[]");
+        write(&output.path().join("assets").join("font.ttf"), b"font");
+
+        remove_app_from_output(output.path()).expect("remove app artifacts");
+
+        assert!(!output.path().join("index.js").exists());
+        assert!(!output.path().join("index.html").exists());
+        assert!(!output.path().join("index.css").exists());
+        assert!(!output.path().join("assets").exists());
+        assert!(output.path().join("fastled.js").exists());
+        assert!(output.path().join("fastled.wasm").exists());
+        assert!(output.path().join("sketch_assets.json").exists());
     }
 }

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -134,7 +134,7 @@ pub fn run() -> ExitCode {
     //  - the user did NOT pass --just-compile
     //  - it's not a non-compile command (--init)
     if let Some(ref dir) = cli.directory {
-        if cli.just_compile && cli.init.is_none() {
+        if (cli.just_compile || cli.no_app) && cli.init.is_none() {
             return commands::run_native_just_compile(&cli, dir);
         }
         if !cli.just_compile && cli.init.is_none() {
@@ -198,6 +198,8 @@ mod tests {
             serve_dir: None,
             init: None,
             just_compile: false,
+            no_app: false,
+            link_mode: crate::cli::LinkMode::Static,
             profile: false,
             install: false,
             dry_run: false,

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -14,6 +14,7 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+use crate::cli::LinkMode;
 use crate::{archive, debug_symbols, frontend, install};
 
 /// Receives one build-output line at a time. The second argument is the
@@ -55,6 +56,8 @@ pub struct BuildRequest {
     /// Emit clangd/VS Code configuration into the sketch directory after a
     /// successful build. Off by default; opted in via `fastled --clangd`.
     pub emit_clangd: bool,
+    pub no_app: bool,
+    pub(crate) link_mode: LinkMode,
 }
 
 #[derive(Debug)]
@@ -276,6 +279,109 @@ fn run_status(mut command: Command, label: &str, log: LogSink) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn link_wasm_dynamic(
+    fastled_dir: &Path,
+    tools: &ToolPaths,
+    sketch_object: &Path,
+    build_dir: &Path,
+    sketch_cache_dir: &Path,
+    output_js: &Path,
+    mode: BuildMode,
+    log: LogSink,
+) -> Result<()> {
+    let archive = library_archive(build_dir);
+    let cached_js = sketch_cache_dir.join("fastled.js");
+    let cached_wasm = sketch_cache_dir.join("fastled.wasm");
+    let cached_sketch = sketch_cache_dir.join("sketch.wasm");
+    let link_flags = get_link_flags(fastled_dir, mode)?;
+    let mut hash_input = vec!["link-mode=dynamic".to_string()];
+    hash_input.extend(link_flags.iter().cloned());
+    hash_input.push("-sMAIN_MODULE=1".to_string());
+    hash_input.push("-sSIDE_MODULE=1".to_string());
+    let current_flags_hash = format!("{:x}", Sha256::digest(hash_input.join("\n").as_bytes()));
+    let flags_hash_path = sketch_cache_dir.join("link_flags.hash");
+    let output_mtime = cached_js.metadata().and_then(|metadata| metadata.modified()).ok();
+    let inputs_are_older = output_mtime.is_some_and(|output_mtime| {
+        [sketch_object, &archive]
+            .iter()
+            .filter_map(|path| path.metadata().ok())
+            .filter_map(|metadata| metadata.modified().ok())
+            .all(|mtime| mtime <= output_mtime)
+    });
+    if cached_js.is_file()
+        && cached_wasm.is_file()
+        && cached_sketch.is_file()
+        && fs::read_to_string(&flags_hash_path)
+            .unwrap_or_default()
+            .trim()
+            == current_flags_hash
+        && inputs_are_older
+    {
+        copy_linked_output(sketch_cache_dir, output_js)?;
+        log("[WASM] Dynamic link output up-to-date", "stdout");
+        return Ok(());
+    }
+
+    let include_flags = vec![
+        format!("-I{}", fastled_dir.join("src").display()),
+        format!(
+            "-I{}",
+            fastled_dir.join("src").join("platforms").join("wasm").display()
+        ),
+        format!(
+            "-I{}",
+            fastled_dir
+                .join("src")
+                .join("platforms")
+                .join("wasm")
+                .join("compiler")
+                .display()
+        ),
+    ];
+
+    log("[WASM] Linking sketch side module...", "stdout");
+    let mut side_args = vec![sketch_object.display().to_string()];
+    side_args.extend(include_flags.iter().cloned());
+    side_args.extend([
+        "-pthread".to_string(),
+        "-sSIDE_MODULE=1".to_string(),
+        "-o".to_string(),
+        cached_sketch.display().to_string(),
+    ]);
+    run_em_link_with_retries(fastled_dir, tools, &side_args, log)?;
+
+    let js_library = fastled_dir
+        .join("src")
+        .join("platforms")
+        .join("wasm")
+        .join("compiler")
+        .join("js_library.js");
+    let mut main_args = vec![archive.display().to_string(), cached_sketch.display().to_string()];
+    main_args.extend(include_flags);
+    main_args.extend([
+        format!("--js-library={}", js_library.display()),
+        "-sMAIN_MODULE=1".to_string(),
+        "-sAUTOLOAD_DYLIBS=1".to_string(),
+        "-o".to_string(),
+        cached_js.display().to_string(),
+    ]);
+    main_args.extend(link_flags);
+    // These dynamic-main requirements must come after the shared FastLED
+    // flags, whose static profile intentionally disables them.
+    main_args.extend([
+        "-sINCLUDE_FULL_LIBRARY=1".to_string(),
+        "-sFILESYSTEM=1".to_string(),
+        "-sAUTO_NATIVE_LIBRARIES=1".to_string(),
+    ]);
+
+    log("[WASM] Linking dynamic main WASM module...", "stdout");
+    run_em_link_with_retries(fastled_dir, tools, &main_args, log)?;
+    fs::write(flags_hash_path, current_flags_hash)?;
+    copy_linked_output(sketch_cache_dir, output_js)?;
+    Ok(())
+}
+
 /// Canonicalize and lexically normalize, stripping the Windows `\\?\`
 /// long-path prefix that breaks external tools (meson, Python, emcc).
 /// See `crate::path::canonicalize_normalized` for details.
@@ -304,10 +410,14 @@ fn mode_output_dir(sketch_dir: &Path) -> PathBuf {
     sketch_dir.join("fastled_js")
 }
 
-fn build_dir(fastled_dir: &Path, mode: BuildMode) -> PathBuf {
+fn build_dir(fastled_dir: &Path, mode: BuildMode, link_mode: LinkMode) -> PathBuf {
+    let suffix = match link_mode {
+        LinkMode::Static => String::new(),
+        LinkMode::Dynamic => "-dynamic".to_string(),
+    };
     fastled_dir
         .join(".build")
-        .join(format!("meson-wasm-{}", mode.as_str()))
+        .join(format!("meson-wasm-{}{}", mode.as_str(), suffix))
 }
 
 pub(crate) fn sketch_cache_dir(example_dir: &Path) -> PathBuf {
@@ -591,6 +701,7 @@ fn ensure_meson_configured(
     tools: &ToolPaths,
     build_dir: &Path,
     mode: BuildMode,
+    link_mode: LinkMode,
     force: bool,
     log: LogSink,
 ) -> Result<()> {
@@ -618,6 +729,10 @@ fn ensure_meson_configured(
         .arg(format!("-Dbuild_mode={}", mode.as_str()));
     for (key, value) in build_env(tools) {
         command.env(key, value);
+    }
+    if link_mode == LinkMode::Dynamic {
+        command.env("CFLAGS", "-fPIC");
+        command.env("CXXFLAGS", "-fPIC");
     }
     log(
         &format!("[WASM] Configuring meson (mode: {})...", mode.as_str()),
@@ -827,6 +942,7 @@ fn compile_sketch(
     sketch_cache_dir: &Path,
     example_dir: &Path,
     mode: BuildMode,
+    link_mode: LinkMode,
     dwarf_roots: &DwarfPathRoots,
     log: LogSink,
 ) -> Result<PathBuf> {
@@ -836,7 +952,9 @@ fn compile_sketch(
     let ino = sketch_ino_file(example_dir)?;
     let compile_flags = get_sketch_compile_flags(fastled_dir, mode, Some(dwarf_roots))?;
     let flags_hash_path = sketch_cache_dir.join("sketch_compile_flags.hash");
-    let current_flags_hash = format!("{:x}", Sha256::digest(compile_flags.join("\n").as_bytes()));
+    let mut hash_input = compile_flags.join("\n");
+    hash_input.push_str(&format!("\nlink-mode={link_mode:?}"));
+    let current_flags_hash = format!("{:x}", Sha256::digest(hash_input.as_bytes()));
     if object.is_file() {
         let object_mtime = object.metadata()?.modified()?;
         let inputs = [wrapper, &ino, &archive];
@@ -862,6 +980,9 @@ fn compile_sketch(
         object.display().to_string(),
     ];
     args.extend(compile_flags);
+    if link_mode == LinkMode::Dynamic {
+        args.push("-fPIC".to_string());
+    }
     args.push(format!("-I{}", fastled_dir.join("src").display()));
     args.push(format!(
         "-I{}",
@@ -901,11 +1022,31 @@ fn link_wasm(
     sketch_cache_dir: &Path,
     output_js: &Path,
     mode: BuildMode,
+    link_mode: LinkMode,
     log: LogSink,
 ) -> Result<()> {
+    if link_mode == LinkMode::Dynamic {
+        return link_wasm_dynamic(
+            fastled_dir,
+            tools,
+            sketch_object,
+            build_dir,
+            sketch_cache_dir,
+            output_js,
+            mode,
+            log,
+        );
+    }
     let archive = library_archive(build_dir);
     let cached_js = sketch_cache_dir.join("fastled.js");
     let cached_wasm = sketch_cache_dir.join("fastled.wasm");
+    // Static and dynamic modes share the sketch cache directory. Never let a
+    // side module from a previous dynamic build leak into static output.
+    let cached_sketch = sketch_cache_dir.join("sketch.wasm");
+    if cached_sketch.is_file() {
+        fs::remove_file(&cached_sketch)
+            .with_context(|| format!("remove stale {}", cached_sketch.display()))?;
+    }
     let link_flags = get_link_flags(fastled_dir, mode)?;
     let flags_hash_path = sketch_cache_dir.join("link_flags.hash");
     let current_flags_hash = format!("{:x}", Sha256::digest(link_flags.join("\n").as_bytes()));
@@ -1013,6 +1154,7 @@ fn copy_linked_output(sketch_cache_dir: &Path, output_js: &Path) -> Result<()> {
     for name in [
         "fastled.js",
         "fastled.wasm",
+        "sketch.wasm",
         "fastled.wasm.map",
         "fastled.js.map",
     ] {
@@ -1031,8 +1173,13 @@ fn copy_linked_output(sketch_cache_dir: &Path, output_js: &Path) -> Result<()> {
 fn generate_manifest(example_dir: &Path, output_dir: &Path) -> Result<()> {
     let mut files = Vec::<serde_json::Value>::new();
     collect_data_files(example_dir, example_dir, &mut files)?;
+    let legacy = output_dir.join("files.json");
+    if legacy.is_file() {
+        fs::remove_file(&legacy)
+            .with_context(|| format!("remove legacy asset manifest {}", legacy.display()))?;
+    }
     fs::write(
-        output_dir.join("files.json"),
+        output_dir.join("sketch_assets.json"),
         serde_json::to_string_pretty(&files)?,
     )?;
     Ok(())
@@ -1080,6 +1227,8 @@ pub(crate) fn resolve_fastled_dir_for_sketch(sketch_dir: &Path) -> Result<PathBu
         fastled_path: None,
         force_clean: false,
         emit_clangd: false,
+        no_app: false,
+        link_mode: LinkMode::Static,
     };
     let (fastled_dir, _cleanup) = resolve_fastled_dir(&request)?;
     Ok(normalize_path(&fastled_dir))
@@ -1174,21 +1323,27 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
     let sketch_start = std::time::Instant::now();
     let strategy = if output_dir.join("fastled.js").is_file()
         && output_dir.join("fastled.wasm").is_file()
+        && (request.link_mode == LinkMode::Static
+            || output_dir.join("sketch.wasm").is_file())
         && !request.force_clean
     {
-        "incremental"
+        match request.link_mode {
+            LinkMode::Static => "incremental-static",
+            LinkMode::Dynamic => "incremental-dynamic",
+        }
     } else {
         "cold"
     }
     .to_string();
 
     let build_result = (|| -> Result<()> {
-        let build_dir = build_dir(&fastled_dir, request.build_mode);
+        let build_dir = build_dir(&fastled_dir, request.build_mode, request.link_mode);
         ensure_meson_configured(
             &fastled_dir,
             &tools,
             &build_dir,
             request.build_mode,
+            request.link_mode,
             request.force_clean,
             log,
         )?;
@@ -1216,6 +1371,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &sketch_cache,
             &example_dir,
             request.build_mode,
+            request.link_mode,
             &sketch_dwarf_roots,
             log,
         )?;
@@ -1228,9 +1384,14 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &sketch_cache,
             &output_js,
             request.build_mode,
+            request.link_mode,
             log,
         )?;
-        frontend::copy_frontend_to_output(&output_dir, None)?;
+        if request.no_app {
+            frontend::remove_app_from_output(&output_dir)?;
+        } else {
+            frontend::copy_frontend_to_output(&output_dir, None)?;
+        }
         generate_manifest(&example_dir, &output_dir)?;
         let debug_config = debug_symbols::load_debug_symbol_config(
             example_dir.clone(),
@@ -1537,5 +1698,44 @@ link_flags = []
         fs::remove_file(cache.join("fastled.wasm.map")).unwrap();
         copy_linked_output(&cache, &output).unwrap();
         assert!(!output.parent().unwrap().join("fastled.wasm.map").exists());
+    }
+
+    #[test]
+    fn copy_linked_output_copies_dynamic_side_module_and_removes_it_when_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let output = tmp.path().join("out").join("fastled.js");
+        fs::create_dir_all(&cache).unwrap();
+        fs::create_dir_all(output.parent().unwrap()).unwrap();
+        fs::write(cache.join("fastled.js"), "js").unwrap();
+        fs::write(cache.join("fastled.wasm"), "wasm").unwrap();
+        fs::write(cache.join("sketch.wasm"), "side").unwrap();
+
+        copy_linked_output(&cache, &output).unwrap();
+        assert_eq!(
+            fs::read_to_string(output.parent().unwrap().join("sketch.wasm")).unwrap(),
+            "side"
+        );
+
+        fs::remove_file(cache.join("sketch.wasm")).unwrap();
+        copy_linked_output(&cache, &output).unwrap();
+        assert!(!output.parent().unwrap().join("sketch.wasm").exists());
+    }
+
+    #[test]
+    fn generate_manifest_uses_new_name_and_removes_legacy_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let example = tmp.path().join("Sketch");
+        let output = example.join("fastled_js");
+        fs::create_dir_all(example.join("data")).unwrap();
+        fs::create_dir_all(&output).unwrap();
+        fs::write(example.join("data").join("config.json"), "{}").unwrap();
+        fs::write(output.join("files.json"), "legacy").unwrap();
+
+        generate_manifest(&example, &output).unwrap();
+
+        assert!(!output.join("files.json").exists());
+        let manifest = fs::read_to_string(output.join("sketch_assets.json")).unwrap();
+        assert!(manifest.contains("config.json"));
     }
 }

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -301,7 +301,10 @@ fn link_wasm_dynamic(
     hash_input.push("-sSIDE_MODULE=1".to_string());
     let current_flags_hash = format!("{:x}", Sha256::digest(hash_input.join("\n").as_bytes()));
     let flags_hash_path = sketch_cache_dir.join("link_flags.hash");
-    let output_mtime = cached_js.metadata().and_then(|metadata| metadata.modified()).ok();
+    let output_mtime = cached_js
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok();
     let inputs_are_older = output_mtime.is_some_and(|output_mtime| {
         [sketch_object, &archive]
             .iter()
@@ -327,7 +330,11 @@ fn link_wasm_dynamic(
         format!("-I{}", fastled_dir.join("src").display()),
         format!(
             "-I{}",
-            fastled_dir.join("src").join("platforms").join("wasm").display()
+            fastled_dir
+                .join("src")
+                .join("platforms")
+                .join("wasm")
+                .display()
         ),
         format!(
             "-I{}",
@@ -357,7 +364,10 @@ fn link_wasm_dynamic(
         .join("wasm")
         .join("compiler")
         .join("js_library.js");
-    let mut main_args = vec![archive.display().to_string(), cached_sketch.display().to_string()];
+    let mut main_args = vec![
+        archive.display().to_string(),
+        cached_sketch.display().to_string(),
+    ];
     main_args.extend(include_flags);
     main_args.extend([
         format!("--js-library={}", js_library.display()),
@@ -1323,8 +1333,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
     let sketch_start = std::time::Instant::now();
     let strategy = if output_dir.join("fastled.js").is_file()
         && output_dir.join("fastled.wasm").is_file()
-        && (request.link_mode == LinkMode::Static
-            || output_dir.join("sketch.wasm").is_file())
+        && (request.link_mode == LinkMode::Static || output_dir.join("sketch.wasm").is_file())
         && !request.force_clean
     {
         match request.link_mode {

--- a/src/fastled/frontend/fastled_init.ts
+++ b/src/fastled/frontend/fastled_init.ts
@@ -356,7 +356,9 @@ export function onModuleLoaded(fastLedLoader) {
     const data = await response.json();
     return data;
   };
-  const filesJsonPromise = fetchJson('files.json');
+  // New builds call this manifest sketch_assets.json. Keep files.json as a
+  // fallback so previously generated sketches remain runnable.
+  const filesJsonPromise = fetchJson('sketch_assets.json').catch(() => fetchJson('files.json'));
   try {
     if (typeof fastLedLoader === 'function') {
       // Load the module
@@ -374,13 +376,13 @@ export function onModuleLoaded(fastLedLoader) {
           }
         };
 
-        // Wait for the files.json to load.
+        // Wait for the sketch asset manifest to load.
         let filesJson = null;
         try {
           filesJson = await filesJsonPromise;
           console.log('Files JSON:', filesJson);
         } catch (error) {
-          console.error('Error fetching files.json:', error);
+          console.error('Error fetching sketch asset manifest:', error);
           filesJson = {};
         }
         await __fastledLoadSetupLoop(instance, state.frameRate, filesJson);


### PR DESCRIPTION
## Summary\n- add --no-app to emit only the low-level JavaScript/WASM runtime outputs\n- add --link-mode=static|dynamic, with static as the default and Emscripten main/side-module output for dynamic mode\n- emit index.js for the app, sketch_assets.json for the manifest, and retain iles.json loading as a legacy fallback\n- clean stale app and side-module artifacts when switching modes\n\n## Verification\n- ash lint\n- soldr cargo test --workspace (159 CLI tests plus workspace tests)\n- exercised real static and dynamic --just-compile builds with and without the app\n\nRefs #184