### PR TITLE
perf(cli): cache dynamic WASM runtime independently

### DIFF
--- a/.github/workflows/linux-x86-dwarf-smoke.yml
+++ b/.github/workflows/linux-x86-dwarf-smoke.yml
@@ -74,6 +74,27 @@ jobs:
           FASTLED_CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: node ci/runtime_stack_smoke.mjs
 
+      - name: Dynamic runtime and loader smoke
+        env:
+          FASTLED_CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: |
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+          fastled_bin="$PWD/target/release/fastled"
+          sketch_dir="$workdir/Blink"
+          "$fastled_bin" --init Blink --branch master --no-interactive "$workdir"
+          mkdir -p "$sketch_dir/data"
+          printf '{"dynamic":true}\n' > "$sketch_dir/data/config.json"
+
+          "$fastled_bin" --just-compile --quick --link-mode dynamic --no-interactive "$sketch_dir"
+          node ci/dynamic_runtime_smoke.mjs "$fastled_bin" "$sketch_dir/fastled_js"
+
+          mv "$sketch_dir/fastled_js/sketch_assets.json" "$sketch_dir/fastled_js/files.json"
+          node ci/dynamic_runtime_smoke.mjs "$fastled_bin" "$sketch_dir/fastled_js"
+
+          "$fastled_bin" --just-compile --quick --link-mode dynamic --no-app --no-interactive "$sketch_dir"
+          node ci/dynamic_runtime_smoke.mjs "$fastled_bin" "$sketch_dir/fastled_js" --no-app
+
       - name: Upload failure logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -116,6 +116,18 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "atk"
@@ -253,6 +265,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +315,16 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
 ]
 
 [[package]]
@@ -540,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +652,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1111,6 +1162,7 @@ dependencies = [
  "toml 0.8.2",
  "tower-http",
  "windows-sys 0.61.2",
+ "zccache-fingerprint",
  "zip",
  "zstd",
 ]
@@ -1605,6 +1657,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2509,6 +2574,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -4234,7 +4308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4245,7 +4319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5195,7 +5269,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6445,6 +6531,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "zccache-core"
+version = "1.1.8"
+source = "git+https://github.com/zackees/zccache?rev=7721650d587085de3dc5d4ca77399c7ee2fa4fff#7721650d587085de3dc5d4ca77399c7ee2fa4fff"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "zccache-fingerprint"
+version = "1.1.8"
+source = "git+https://github.com/zackees/zccache?rev=7721650d587085de3dc5d4ca77399c7ee2fa4fff#7721650d587085de3dc5d4ca77399c7ee2fa4fff"
+dependencies = [
+ "clap",
+ "fs2",
+ "globset",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "walkdir",
+ "zccache-hash",
+]
+
+[[package]]
+name = "zccache-hash"
+version = "1.1.8"
+source = "git+https://github.com/zackees/zccache?rev=7721650d587085de3dc5d4ca77399c7ee2fa4fff#7721650d587085de3dc5d4ca77399c7ee2fa4fff"
+dependencies = [
+ "blake3",
+ "memmap2",
+ "serde",
+ "zccache-core",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6547,7 +6671,7 @@ dependencies = [
  "aes",
  "arbitrary",
  "bzip2",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ toml = "0.8"
 tauri = { version = "2", features = ["devtools"] }
 tauri-build = { version = "2", features = [] }
 windows-sys = "0.61"
+# Last zccache-fingerprint revision compatible with this workspace's Rust 1.85 MSRV.
+zccache-fingerprint = { git = "https://github.com/zackees/zccache", rev = "7721650d587085de3dc5d4ca77399c7ee2fa4fff" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/ci/dynamic_runtime_smoke.mjs
+++ b/ci/dynamic_runtime_smoke.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SERVER_URL_RE = /http:\/\/127\.0\.0\.1:\d+/;
+
+async function main() {
+  const fastledBin = process.env.FASTLED_BIN || process.argv[2];
+  const outputDir = process.env.FASTLED_OUTPUT_DIR || process.argv[3];
+  const noApp = process.argv.includes("--no-app");
+  if (!fastledBin || !outputDir) {
+    throw new Error("usage: dynamic_runtime_smoke.mjs <fastled-bin> <fastled-output-dir>");
+  }
+  const expectedAssetManifest = noApp
+    ? undefined
+    : existsSync(path.join(outputDir, "sketch_assets.json"))
+      ? "sketch_assets.json"
+      : existsSync(path.join(outputDir, "files.json"))
+        ? "files.json"
+        : undefined;
+  if (!noApp && !expectedAssetManifest) {
+    throw new Error("app smoke requires sketch_assets.json or legacy files.json");
+  }
+
+  let profileDir;
+  let server;
+  let chrome;
+  let cdp;
+  let noAppHost;
+  try {
+    if (noApp) {
+      noAppHost = path.join(outputDir, "__dynamic_smoke.html");
+      await writeFile(noAppHost, `<!doctype html>
+<meta charset="utf-8">
+<script src="fastled.js"></script>
+<script>
+globalThis.__dynamicSmoke = { ready: false };
+fastled().then(() => { globalThis.__dynamicSmoke.ready = true; }).catch((error) => {
+  globalThis.__dynamicSmoke.error = String(error?.stack || error);
+  console.error("no-app FastLED startup failed", error);
+});
+</script>`, "utf8");
+    }
+    profileDir = await mkdtemp(path.join(os.tmpdir(), "fastled-dynamic-smoke-"));
+    const served = await startServer(fastledBin, outputDir);
+    server = served.child;
+    console.log(`Dynamic smoke server: ${served.url}`);
+    const port = await getFreePort();
+    chrome = launchChrome(findChrome(), port, profileDir);
+    const webSocketUrl = await waitFor(async () => {
+      const response = await fetch(`http://127.0.0.1:${port}/json/version`).catch(() => undefined);
+      return response?.ok ? (await response.json()).webSocketDebuggerUrl : undefined;
+    }, 30_000, "Chrome debugging endpoint");
+    cdp = await CdpConnection.connect(webSocketUrl);
+    console.log("Dynamic smoke connected to Chrome");
+
+    const sessionsByTarget = new Map();
+    const exceptions = [];
+    const errorLogs = [];
+    const allLogs = [];
+    const requests = [];
+    const responses = new Map();
+    cdp.onEvent((message) => {
+      if (message.method === "Target.attachedToTarget") {
+        const { sessionId, targetInfo } = message.params;
+        sessionsByTarget.set(targetInfo.targetId, sessionId);
+        instrument(cdp, sessionId, targetInfo.type).catch((error) => exceptions.push(error.message));
+      } else if (message.method === "Runtime.exceptionThrown") {
+        exceptions.push(message.params.exceptionDetails?.exception?.description || message.params.exceptionDetails?.text || "exception");
+      } else if (message.method === "Runtime.consoleAPICalled" && message.params.type === "error") {
+        const text = (message.params.args || []).map(formatRemoteObject).join(" ");
+        errorLogs.push(text);
+        allLogs.push(`error: ${text}`);
+      } else if (message.method === "Runtime.consoleAPICalled") {
+        allLogs.push(`${message.params.type}: ${(message.params.args || []).map(formatRemoteObject).join(" ")}`);
+      } else if (message.method === "Network.requestWillBeSent") {
+        requests.push(message.params.request.url);
+      } else if (message.method === "Network.responseReceived") {
+        responses.set(message.params.response.url, message.params.response.status);
+      }
+    });
+
+    await cdp.send("Target.setAutoAttach", {
+      autoAttach: true,
+      waitForDebuggerOnStart: false,
+      flatten: true,
+    });
+    const { targetId } = await cdp.send("Target.createTarget", { url: "about:blank" });
+    const pageSession = await waitFor(
+      () => sessionsByTarget.get(targetId),
+      30_000,
+      "page target attachment",
+    );
+    console.log("Dynamic smoke attached to page");
+    await cdp.send("Page.enable", {}, pageSession);
+    const pageUrl = noApp ? `${served.url}/__dynamic_smoke.html` : `${served.url}/?gfx=0`;
+    await cdp.send("Page.navigate", { url: pageUrl }, pageSession);
+
+    let lastState;
+    let state;
+    try {
+      state = await waitFor(async () => {
+        const result = await cdp.send("Runtime.evaluate", {
+          expression: noApp ? `(() => ({
+            readyState: document.readyState,
+            ready: !!globalThis.__dynamicSmoke?.ready,
+            error: globalThis.__dynamicSmoke?.error || "",
+          }))()` : `(() => ({
+            readyState: document.readyState,
+            hasController: !!globalThis.fastLEDController,
+            setupCompleted: !!globalThis.fastLEDController?.setupCompleted,
+            workerActive: !!globalThis.fastLEDWorkerManager?.isWorkerActive,
+            bodyText: document.body?.innerText?.slice(0, 500) || "",
+          }))()`,
+          returnByValue: true,
+        }, pageSession);
+        const value = result.result?.value;
+        lastState = value;
+        return noApp
+          ? (value?.ready ? value : undefined)
+          : (value?.setupCompleted && value?.workerActive ? value : undefined);
+      }, 30_000, "FastLED dynamic runtime startup");
+    } catch (error) {
+      error.message += `\nlast state: ${JSON.stringify(lastState)}`;
+      error.message += `\nexceptions: ${exceptions.join(" | ") || "(none)"}`;
+      error.message += `\nconsole errors: ${errorLogs.join(" | ") || "(none)"}`;
+      error.message += `\nconsole tail:\n${allLogs.slice(-100).join("\n")}`;
+      error.message += `\nrequests: ${requests.slice(-30).join(", ")}`;
+      throw error;
+    }
+
+    const sketchRequest = requests.find((url) => /\/sketch\.wasm(?:[?#]|$)/.test(url));
+    if (!sketchRequest) {
+      throw new Error(`browser did not request sketch.wasm; requests: ${requests.join(", ")}`);
+    }
+    if (expectedAssetManifest) {
+      const manifestResponse = [...responses.entries()].find(([url]) =>
+        url.endsWith(`/${expectedAssetManifest}`)
+      );
+      if (!manifestResponse || manifestResponse[1] !== 200) {
+        throw new Error(
+          `browser did not load ${expectedAssetManifest} successfully; responses: ${JSON.stringify([...responses])}`,
+        );
+      }
+    }
+    if (exceptions.length || errorLogs.length) {
+      throw new Error(
+        `browser errors after startup:\n${[...exceptions, ...errorLogs].join("\n")}`,
+      );
+    }
+    console.log(
+      noApp
+        ? "Dynamic no-app smoke passed: sketch.wasm loaded; FastLED factory resolved"
+        : `Dynamic runtime smoke passed: sketch.wasm loaded; setup=${state.setupCompleted}; worker=${state.workerActive}`,
+    );
+  } finally {
+    cdp?.close();
+    await stopChild(chrome);
+    await stopChild(server);
+    if (noAppHost) {
+      await unlink(noAppHost).catch(() => {});
+    }
+    if (profileDir) {
+      await rm(profileDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+        .catch(() => {});
+    }
+  }
+}
+
+async function instrument(cdp, sessionId, targetType) {
+  await cdp.send("Runtime.enable", {}, sessionId);
+  await cdp.send("Network.enable", {}, sessionId).catch(() => {});
+  if (targetType === "page" || targetType === "iframe") {
+    await cdp.send("Target.setAutoAttach", {
+      autoAttach: true,
+      waitForDebuggerOnStart: false,
+      flatten: true,
+    }, sessionId).catch(() => {});
+  }
+}
+
+async function startServer(fastledBin, outputDir) {
+  const child = spawn(fastledBin, ["--internal-serve-dir-headless", outputDir], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, FASTLED_MANAGED_RUNTIME: "1" },
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  try {
+    const url = await waitFor(() => stdout.match(SERVER_URL_RE)?.[0], 30_000, "server URL");
+    return { child, url };
+  } catch (error) {
+    await stopChild(child);
+    error.message += `\nserver stdout:\n${stdout}\nserver stderr:\n${stderr}`;
+    throw error;
+  }
+}
+
+function findChrome() {
+  const candidates = [
+    process.env.FASTLED_CHROME,
+    process.env.CHROME_BIN,
+    process.env.PROGRAMFILES && path.join(process.env.PROGRAMFILES, "Google/Chrome/Application/chrome.exe"),
+    process.env["PROGRAMFILES(X86)"] && path.join(process.env["PROGRAMFILES(X86)"], "Google/Chrome/Application/chrome.exe"),
+    "google-chrome-stable",
+    "google-chrome",
+    "chromium",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if ((candidate.includes(path.sep) || path.isAbsolute(candidate)) && !existsSync(candidate)) {
+      continue;
+    }
+    if (spawnSync(candidate, ["--version"], { stdio: "ignore" }).status === 0) {
+      return candidate;
+    }
+  }
+  throw new Error(`could not find Chrome; tried ${candidates.join(", ")}`);
+}
+
+function launchChrome(binary, port, profileDir) {
+  return spawn(binary, [
+    "--headless=new",
+    `--remote-debugging-port=${port}`,
+    "--remote-debugging-address=127.0.0.1",
+    "--no-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    `--user-data-dir=${path.join(profileDir, "chrome-profile")}`,
+    "about:blank",
+  ], { stdio: "ignore" });
+}
+
+class CdpConnection {
+  constructor(socket) {
+    this.socket = socket;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.listeners = new Set();
+    socket.addEventListener("message", (event) => this.handle(event.data));
+  }
+
+  static async connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+      socket.addEventListener("open", resolve, { once: true });
+      socket.addEventListener("error", () => reject(new Error("failed to connect to Chrome")), { once: true });
+    });
+    return new CdpConnection(socket);
+  }
+
+  send(method, params = {}, sessionId = undefined) {
+    const id = this.nextId++;
+    const message = { id, method, params };
+    if (sessionId) message.sessionId = sessionId;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP command timed out: ${method}`));
+      }, 15_000);
+      this.pending.set(id, {
+        resolve: (value) => { clearTimeout(timeout); resolve(value); },
+        reject: (error) => { clearTimeout(timeout); reject(error); },
+      });
+      this.socket.send(JSON.stringify(message));
+    });
+  }
+
+  onEvent(listener) {
+    this.listeners.add(listener);
+  }
+
+  handle(raw) {
+    const message = JSON.parse(typeof raw === "string" ? raw : Buffer.from(raw).toString("utf8"));
+    if (message.id) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) pending.reject(new Error(message.error.message));
+      else pending.resolve(message.result || {});
+      return;
+    }
+    for (const listener of this.listeners) listener(message);
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+function formatRemoteObject(object) {
+  if (Object.hasOwn(object || {}, "value")) return String(object.value);
+  return object?.description || object?.type || "";
+}
+
+async function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitFor(check, timeoutMs, label) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const value = await check();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function stopChild(child) {
+  if (!child || child.exitCode !== null) return;
+  if (process.platform === "win32" && child.pid) {
+    const killed = spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      timeout: 10_000,
+    });
+    if (killed.error?.code === "ETIMEDOUT") child.kill();
+    return;
+  }
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("close", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+main().catch((error) => {
+  console.error(`Dynamic runtime smoke failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -45,6 +45,7 @@ dirs = { workspace = true }
 toml = { workspace = true }
 tauri = { workspace = true, optional = true }
 tempfile = "3"
+zccache-fingerprint = { workspace = true }
 
 [build-dependencies]
 indexmap = { version = "1.9.3", features = ["std"] }

--- a/crates/fastled-cli/assets/dynamic_loader.js
+++ b/crates/fastled-cli/assets/dynamic_loader.js
@@ -1,0 +1,4 @@
+// The dynamic FastLED runtime is sketch-independent. Tell Emscripten to
+// fetch and load the separately linked sketch side module before startup.
+// This source is embedded into fastled.js via --pre-js.
+Module["dynamicLibraries"] = ["sketch.wasm"];

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -76,6 +76,16 @@ pub(crate) fn purge_fastled_cache(fastled_path: Option<&str>) {
                 if !name.starts_with("meson-wasm-") || !wasm_dir.is_dir() {
                     continue;
                 }
+                let runtime_cache = wasm_dir.join("dynamic-runtime-cache");
+                if runtime_cache.exists() {
+                    match std::fs::remove_dir_all(&runtime_cache) {
+                        Ok(()) => println!("Purged: {}", runtime_cache.display()),
+                        Err(err) => eprintln!(
+                            "fastled: failed to purge {}: {err}",
+                            runtime_cache.display()
+                        ),
+                    }
+                }
                 for stale in [
                     "wasm_ld_args.json",
                     "wasm_ld_args.key",

--- a/crates/fastled-cli/src/dynamic_cache.rs
+++ b/crates/fastled-cli/src/dynamic_cache.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+use crate::path::NormalizedPath;
 
 const CACHE_SCHEMA: u32 = 1;
 const METADATA_FILE: &str = "cache-metadata.json";
@@ -193,8 +195,8 @@ impl CacheLock {
     }
 }
 
-pub(crate) fn entry_path(cache_root: &Path, fingerprint: &str) -> PathBuf {
-    cache_root.join(fingerprint)
+pub(crate) fn entry_path(cache_root: &Path, fingerprint: &str) -> NormalizedPath {
+    NormalizedPath::new(cache_root.join(fingerprint))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -204,8 +206,8 @@ struct AttemptMetadata {
     message: Option<String>,
 }
 
-fn attempt_path(cache_root: &Path, fingerprint: &str) -> PathBuf {
-    cache_root.join(format!("{fingerprint}.attempt.json"))
+fn attempt_path(cache_root: &Path, fingerprint: &str) -> NormalizedPath {
+    NormalizedPath::new(cache_root.join(format!("{fingerprint}.attempt.json")))
 }
 
 pub(crate) fn previous_attempt(cache_root: &Path, fingerprint: &str) -> Option<String> {

--- a/crates/fastled-cli/src/dynamic_cache.rs
+++ b/crates/fastled-cli/src/dynamic_cache.rs
@@ -1,0 +1,390 @@
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const CACHE_SCHEMA: u32 = 1;
+const METADATA_FILE: &str = "cache-metadata.json";
+
+pub(crate) const DYNAMIC_LOADER_JS: &str = include_str!("../assets/dynamic_loader.js");
+
+/// Hash a selected source tree with zccache's content-authoritative scanner.
+/// Paths, file count, and bytes all participate, so additions, deletions, and
+/// same-size edits with restored mtimes cannot produce a false cache hit.
+pub(crate) fn fingerprint_tree(root: &Path, include: &[&str], exclude: &[&str]) -> Result<String> {
+    let files = zccache_fingerprint::walk_files_glob(root, include, exclude)
+        .with_context(|| format!("scan fingerprint inputs under {}", root.display()))?;
+    zccache_fingerprint::compute_aggregate_hash(&files)
+        .with_context(|| format!("hash fingerprint inputs under {}", root.display()))
+}
+
+pub(crate) fn fingerprint_values<'a>(values: impl IntoIterator<Item = &'a [u8]>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"fastled-wasm-dynamic-cache-v1\0");
+    for value in values {
+        hasher.update((value.len() as u64).to_le_bytes());
+        hasher.update(value);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ArtifactRecord {
+    bytes: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheMetadata {
+    schema: u32,
+    fingerprint: String,
+    artifacts: BTreeMap<String, ArtifactRecord>,
+}
+
+fn hash_file(path: &Path) -> Result<ArtifactRecord> {
+    let mut file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut bytes = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("read {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        bytes += read as u64;
+        hasher.update(&buffer[..read]);
+    }
+    Ok(ArtifactRecord {
+        bytes,
+        sha256: format!("{:x}", hasher.finalize()),
+    })
+}
+
+fn validate_artifact_shape(name: &str, path: &Path, bytes: u64) -> std::result::Result<(), String> {
+    if bytes == 0 {
+        return Err(format!("{name} is empty"));
+    }
+    if name.ends_with(".wasm") {
+        let mut header = [0_u8; 8];
+        File::open(path)
+            .and_then(|mut file| file.read_exact(&mut header))
+            .map_err(|err| format!("cannot read {name} header: {err}"))?;
+        if header[..4] != *b"\0asm" || header[4..] != [1, 0, 0, 0] {
+            return Err(format!(
+                "{name} has an invalid WebAssembly magic or version"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_entry(
+    entry: &Path,
+    fingerprint: &str,
+    required: &[&str],
+) -> std::result::Result<(), String> {
+    let metadata_path = entry.join(METADATA_FILE);
+    let source = fs::read_to_string(&metadata_path)
+        .map_err(|err| format!("cannot read {}: {err}", metadata_path.display()))?;
+    let metadata: CacheMetadata = serde_json::from_str(&source)
+        .map_err(|err| format!("invalid {}: {err}", metadata_path.display()))?;
+    if metadata.schema != CACHE_SCHEMA {
+        return Err(format!(
+            "cache schema mismatch: expected {CACHE_SCHEMA}, got {}",
+            metadata.schema
+        ));
+    }
+    if metadata.fingerprint != fingerprint {
+        return Err("cache fingerprint mismatch".to_string());
+    }
+    for name in required {
+        if !metadata.artifacts.contains_key(*name) {
+            return Err(format!("metadata is missing required artifact {name}"));
+        }
+    }
+    for (name, expected) in &metadata.artifacts {
+        let path = entry.join(name);
+        let actual = hash_file(&path).map_err(|err| err.to_string())?;
+        validate_artifact_shape(name, &path, actual.bytes)?;
+        if actual.bytes != expected.bytes || actual.sha256 != expected.sha256 {
+            return Err(format!("artifact digest mismatch for {name}"));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn write_metadata(staging: &Path, fingerprint: &str, artifacts: &[&str]) -> Result<()> {
+    let mut records = BTreeMap::new();
+    for name in artifacts {
+        let path = staging.join(name);
+        let record = hash_file(&path)?;
+        validate_artifact_shape(name, &path, record.bytes).map_err(anyhow::Error::msg)?;
+        records.insert((*name).to_string(), record);
+    }
+    let metadata = CacheMetadata {
+        schema: CACHE_SCHEMA,
+        fingerprint: fingerprint.to_string(),
+        artifacts: records,
+    };
+    fs::write(
+        staging.join(METADATA_FILE),
+        serde_json::to_vec_pretty(&metadata)?,
+    )
+    .with_context(|| format!("write cache metadata under {}", staging.display()))?;
+    Ok(())
+}
+
+/// Publish a fully validated staging directory by one same-filesystem rename.
+/// A key is never observable as successful until every artifact and its
+/// metadata are complete.
+pub(crate) fn publish_staging(staging: tempfile::TempDir, target: &Path) -> Result<()> {
+    let staging_path = staging.keep();
+    if target.exists() {
+        fs::remove_dir_all(target)
+            .with_context(|| format!("remove invalid cache entry {}", target.display()))?;
+    }
+    if let Err(error) = fs::rename(&staging_path, target) {
+        fs::remove_dir_all(&staging_path).ok();
+        return Err(error).with_context(|| {
+            format!(
+                "publish cache entry {} to {}",
+                staging_path.display(),
+                target.display()
+            )
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn staging_dir(cache_root: &Path, prefix: &str) -> Result<tempfile::TempDir> {
+    fs::create_dir_all(cache_root)
+        .with_context(|| format!("create cache root {}", cache_root.display()))?;
+    tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in(cache_root)
+        .with_context(|| format!("create staging directory in {}", cache_root.display()))
+}
+
+pub(crate) struct CacheLock {
+    _file: File,
+}
+
+impl CacheLock {
+    pub(crate) fn acquire(cache_root: &Path, fingerprint: &str) -> Result<Self> {
+        fs::create_dir_all(cache_root)
+            .with_context(|| format!("create cache root {}", cache_root.display()))?;
+        let path = cache_root.join(format!("{fingerprint}.lock"));
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("open cache lock {}", path.display()))?;
+        fs2::FileExt::lock_exclusive(&file)
+            .with_context(|| format!("lock cache key {fingerprint}"))?;
+        Ok(Self { _file: file })
+    }
+}
+
+pub(crate) fn entry_path(cache_root: &Path, fingerprint: &str) -> PathBuf {
+    cache_root.join(fingerprint)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AttemptMetadata {
+    status: String,
+    phase: String,
+    message: Option<String>,
+}
+
+fn attempt_path(cache_root: &Path, fingerprint: &str) -> PathBuf {
+    cache_root.join(format!("{fingerprint}.attempt.json"))
+}
+
+pub(crate) fn previous_attempt(cache_root: &Path, fingerprint: &str) -> Option<String> {
+    let path = attempt_path(cache_root, fingerprint);
+    let source = fs::read_to_string(path).ok()?;
+    let attempt: AttemptMetadata = serde_json::from_str(&source).ok()?;
+    Some(match attempt.message {
+        Some(message) => format!("{} {}: {message}", attempt.status, attempt.phase),
+        None => format!("{} {}", attempt.status, attempt.phase),
+    })
+}
+
+pub(crate) fn mark_pending(cache_root: &Path, fingerprint: &str, phase: &str) -> Result<()> {
+    write_attempt(cache_root, fingerprint, "pending", phase, None)
+}
+
+pub(crate) fn mark_failure(
+    cache_root: &Path,
+    fingerprint: &str,
+    phase: &str,
+    error: &anyhow::Error,
+) -> Result<()> {
+    write_attempt(
+        cache_root,
+        fingerprint,
+        "failure",
+        phase,
+        Some(format!("{error:#}")),
+    )
+}
+
+fn write_attempt(
+    cache_root: &Path,
+    fingerprint: &str,
+    status: &str,
+    phase: &str,
+    message: Option<String>,
+) -> Result<()> {
+    fs::create_dir_all(cache_root)?;
+    let attempt = AttemptMetadata {
+        status: status.to_string(),
+        phase: phase.to_string(),
+        message,
+    };
+    fs::write(
+        attempt_path(cache_root, fingerprint),
+        serde_json::to_vec_pretty(&attempt)?,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn clear_attempt(cache_root: &Path, fingerprint: &str) -> Result<()> {
+    let path = attempt_path(cache_root, fingerprint);
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    fn wasm_bytes(payload: &[u8]) -> Vec<u8> {
+        let mut bytes = b"\0asm\x01\0\0\0".to_vec();
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    #[test]
+    fn fingerprint_detects_same_size_edit_even_with_unchanged_mtime() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("sketch.ino");
+        fs::write(&source, "aaaa").unwrap();
+        let original_mtime = source.metadata().unwrap().modified().unwrap();
+        let first = fingerprint_tree(temp.path(), &["**/*.ino"], &[]).unwrap();
+
+        fs::write(&source, "bbbb").unwrap();
+        let file = OpenOptions::new().write(true).open(&source).unwrap();
+        file.set_modified(original_mtime).unwrap();
+        let second = fingerprint_tree(temp.path(), &["**/*.ino"], &[]).unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn fingerprint_detects_source_deletion() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("a.cpp"), "a").unwrap();
+        fs::write(temp.path().join("b.cpp"), "b").unwrap();
+        let first = fingerprint_tree(temp.path(), &["**/*.cpp"], &[]).unwrap();
+        fs::remove_file(temp.path().join("b.cpp")).unwrap();
+        let second = fingerprint_tree(temp.path(), &["**/*.cpp"], &[]).unwrap();
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn validation_rejects_missing_empty_truncated_and_corrupt_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let entry = temp.path().join("entry");
+        fs::create_dir(&entry).unwrap();
+        fs::write(entry.join("fastled.js"), "js").unwrap();
+        fs::write(entry.join("fastled.wasm"), wasm_bytes(b"runtime")).unwrap();
+        write_metadata(&entry, "key", &["fastled.js", "fastled.wasm"]).unwrap();
+        assert!(validate_entry(&entry, "key", &["fastled.js", "fastled.wasm"]).is_ok());
+
+        fs::remove_file(entry.join("fastled.js")).unwrap();
+        assert!(validate_entry(&entry, "key", &["fastled.js", "fastled.wasm"]).is_err());
+        fs::write(entry.join("fastled.js"), "").unwrap();
+        assert!(validate_entry(&entry, "key", &["fastled.js", "fastled.wasm"]).is_err());
+        fs::write(entry.join("fastled.js"), "js").unwrap();
+        fs::write(entry.join("fastled.wasm"), b"\0asm").unwrap();
+        assert!(validate_entry(&entry, "key", &["fastled.js", "fastled.wasm"]).is_err());
+        fs::write(entry.join(METADATA_FILE), "not-json").unwrap();
+        assert!(validate_entry(&entry, "key", &["fastled.js", "fastled.wasm"]).is_err());
+
+        fs::write(entry.join("fastled.wasm"), b"\0asm\x02\0\0\0").unwrap();
+        assert!(write_metadata(&entry, "key", &["fastled.js", "fastled.wasm"]).is_err());
+    }
+
+    #[test]
+    fn cache_lock_serializes_same_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let barrier = Arc::new(Barrier::new(2));
+        let other_barrier = Arc::clone(&barrier);
+        let handle = std::thread::spawn(move || {
+            let _lock = CacheLock::acquire(&root, "same-key").unwrap();
+            other_barrier.wait();
+            std::thread::sleep(Duration::from_millis(150));
+        });
+        barrier.wait();
+        let started = std::time::Instant::now();
+        let _lock = CacheLock::acquire(temp.path(), "same-key").unwrap();
+        assert!(started.elapsed() >= Duration::from_millis(100));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn atomic_publish_replaces_invalid_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("cache");
+        fs::create_dir(&root).unwrap();
+        let target = root.join("key");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("broken"), "old").unwrap();
+
+        let staging = staging_dir(&root, ".staging-").unwrap();
+        fs::write(staging.path().join("sketch.wasm"), wasm_bytes(b"side")).unwrap();
+        write_metadata(staging.path(), "key", &["sketch.wasm"]).unwrap();
+        publish_staging(staging, &target).unwrap();
+
+        assert!(validate_entry(&target, "key", &["sketch.wasm"]).is_ok());
+        assert!(!target.join("broken").exists());
+    }
+
+    #[test]
+    fn attempt_state_records_pending_failure_and_clears_after_success() {
+        let temp = tempfile::tempdir().unwrap();
+        mark_pending(temp.path(), "key", "main-link").unwrap();
+        assert_eq!(
+            previous_attempt(temp.path(), "key").as_deref(),
+            Some("pending main-link")
+        );
+
+        mark_failure(
+            temp.path(),
+            "key",
+            "main-link",
+            &anyhow::anyhow!("link failed"),
+        )
+        .unwrap();
+        assert!(previous_attempt(temp.path(), "key")
+            .unwrap()
+            .contains("failure main-link: link failed"));
+
+        clear_attempt(temp.path(), "key").unwrap();
+        assert!(previous_attempt(temp.path(), "key").is_none());
+    }
+}

--- a/crates/fastled-cli/src/dynamic_cache_matrix_tests.rs
+++ b/crates/fastled-cli/src/dynamic_cache_matrix_tests.rs
@@ -1,0 +1,560 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+
+use crate::dynamic_cache;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct Invocations {
+    library_build: usize,
+    main_link: usize,
+    sketch_compile: usize,
+    side_link: usize,
+    app_build: usize,
+    asset_manifest: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OutputHashes {
+    runtime_js: String,
+    runtime_wasm: String,
+    sketch_wasm: String,
+}
+
+struct FakeRepository {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    fastled: PathBuf,
+    app: PathBuf,
+    mode: String,
+    toolchain: String,
+    abi: String,
+    no_app: bool,
+}
+
+impl FakeRepository {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let fastled = root.join("FastLED");
+        write(&fastled.join("src/core.cpp"), "core-v1");
+        write(&fastled.join("src/core.h"), "header-v1");
+        write(
+            &fastled.join("src/platforms/wasm/compiler/build_flags.toml"),
+            "flags-v1",
+        );
+        write(
+            &fastled.join("src/platforms/wasm/compiler/js_library.js"),
+            "js-library-v1",
+        );
+        write(&fastled.join("meson.build"), "meson-v1");
+        write(&fastled.join("ci/meson/wasm/meson.build"), "wasm-meson-v1");
+
+        for (name, source) in [("SketchA", "setup-a"), ("SketchB", "setup-b")] {
+            let sketch = root.join(name);
+            write(&sketch.join(format!("{name}.ino")), source);
+            write(&sketch.join("include/config.h"), "config-v1");
+            write(&sketch.join("data/config.json"), "{\"asset\":1}");
+        }
+        let app = root.join("app");
+        write(&app.join("index.ts"), "app-v1");
+
+        Self {
+            _temp: temp,
+            root,
+            fastled,
+            app,
+            mode: "quick".to_string(),
+            toolchain: "emscripten-4.0.19".to_string(),
+            abi: "MAIN_MODULE=1;SIDE_MODULE=1;WASM_BIGINT=0".to_string(),
+            no_app: false,
+        }
+    }
+
+    fn sketch(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    fn runtime_root(&self) -> PathBuf {
+        self.fastled
+            .join(".build")
+            .join("fake-dynamic-runtime-cache")
+    }
+
+    fn runtime_fingerprint(&self) -> String {
+        let source = dynamic_cache::fingerprint_tree(
+            &self.fastled,
+            &[
+                "src/**/*.cpp",
+                "src/**/*.h",
+                "src/**/*.toml",
+                "src/**/*.js",
+                "meson.build",
+                "ci/meson/wasm/meson.build",
+            ],
+            &[".build/**"],
+        )
+        .unwrap();
+        dynamic_cache::fingerprint_values([
+            source.as_bytes(),
+            self.mode.as_bytes(),
+            self.toolchain.as_bytes(),
+            self.abi.as_bytes(),
+            b"schema=1",
+        ])
+    }
+
+    fn library_fingerprint(&self) -> String {
+        let source = dynamic_cache::fingerprint_tree(
+            &self.fastled,
+            &[
+                "src/**/*.cpp",
+                "src/**/*.h",
+                "src/**/*.toml",
+                "meson.build",
+                "ci/meson/wasm/meson.build",
+            ],
+            &[".build/**"],
+        )
+        .unwrap();
+        dynamic_cache::fingerprint_values([
+            source.as_bytes(),
+            self.mode.as_bytes(),
+            self.toolchain.as_bytes(),
+        ])
+    }
+
+    fn sketch_fingerprint(&self, name: &str, runtime: &str) -> String {
+        let sketch = self.sketch(name);
+        let source = dynamic_cache::fingerprint_tree(
+            &sketch,
+            &["**/*.ino", "**/*.cpp", "**/*.c", "**/*.h", "**/*.hpp"],
+            &[".build/**", "fastled_js/**", "data/**"],
+        )
+        .unwrap();
+        dynamic_cache::fingerprint_values([
+            source.as_bytes(),
+            runtime.as_bytes(),
+            self.mode.as_bytes(),
+            self.toolchain.as_bytes(),
+            self.abi.as_bytes(),
+            b"generated-wrapper-v1",
+        ])
+    }
+
+    fn run(&self, name: &str) -> (Invocations, OutputHashes) {
+        let mut calls = Invocations::default();
+        let runtime_fingerprint = self.runtime_fingerprint();
+        let library_fingerprint = self.library_fingerprint();
+        let library_marker = self
+            .fastled
+            .join(".build")
+            .join(format!("fake-library-{}", self.mode));
+        if fs::read_to_string(&library_marker).unwrap_or_default() != library_fingerprint {
+            calls.library_build += 1;
+            write(&library_marker, &library_fingerprint);
+        }
+        let runtime_root = self.runtime_root();
+        let runtime_entry = dynamic_cache::entry_path(&runtime_root, &runtime_fingerprint);
+        let _runtime_lock =
+            dynamic_cache::CacheLock::acquire(&runtime_root, &runtime_fingerprint).unwrap();
+        if dynamic_cache::validate_entry(
+            &runtime_entry,
+            &runtime_fingerprint,
+            &["fastled.js", "fastled.wasm"],
+        )
+        .is_err()
+        {
+            calls.main_link += 1;
+            let staging = dynamic_cache::staging_dir(&runtime_root, ".fake-runtime-").unwrap();
+            write(
+                &staging.path().join("fastled.js"),
+                &format!("fake loader {runtime_fingerprint}"),
+            );
+            write_wasm(
+                &staging.path().join("fastled.wasm"),
+                runtime_fingerprint.as_bytes(),
+            );
+            dynamic_cache::write_metadata(
+                staging.path(),
+                &runtime_fingerprint,
+                &["fastled.js", "fastled.wasm"],
+            )
+            .unwrap();
+            dynamic_cache::publish_staging(staging, &runtime_entry).unwrap();
+        }
+        drop(_runtime_lock);
+
+        let sketch_fingerprint = self.sketch_fingerprint(name, &runtime_fingerprint);
+        let sketch_root = self.sketch(name).join(".build/fake-sketch-cache");
+        let object_entry =
+            dynamic_cache::entry_path(&sketch_root.join("objects"), &sketch_fingerprint);
+        if dynamic_cache::validate_entry(&object_entry, &sketch_fingerprint, &["sketch.o"]).is_err()
+        {
+            calls.sketch_compile += 1;
+            publish_fake(
+                &sketch_root.join("objects"),
+                &sketch_fingerprint,
+                "sketch.o",
+                sketch_fingerprint.as_bytes(),
+                false,
+            );
+        }
+
+        let side_entry = dynamic_cache::entry_path(&sketch_root.join("sides"), &sketch_fingerprint);
+        if dynamic_cache::validate_entry(&side_entry, &sketch_fingerprint, &["sketch.wasm"])
+            .is_err()
+        {
+            calls.side_link += 1;
+            publish_fake(
+                &sketch_root.join("sides"),
+                &sketch_fingerprint,
+                "sketch.wasm",
+                sketch_fingerprint.as_bytes(),
+                true,
+            );
+        }
+
+        let output = self.sketch(name).join("fastled_js");
+        fs::create_dir_all(&output).unwrap();
+        fs::copy(runtime_entry.join("fastled.js"), output.join("fastled.js")).unwrap();
+        fs::copy(
+            runtime_entry.join("fastled.wasm"),
+            output.join("fastled.wasm"),
+        )
+        .unwrap();
+        fs::copy(side_entry.join("sketch.wasm"), output.join("sketch.wasm")).unwrap();
+
+        let app_fingerprint = dynamic_cache::fingerprint_tree(&self.app, &[], &[]).unwrap();
+        let desired_app = format!("{app_fingerprint}:no-app={}", self.no_app);
+        let app_marker = output.join(".fake-app-fingerprint");
+        if fs::read_to_string(&app_marker).unwrap_or_default() != desired_app {
+            calls.app_build += 1;
+            write(&app_marker, &desired_app);
+        }
+
+        let assets = self.sketch(name).join("data");
+        let asset_fingerprint = dynamic_cache::fingerprint_tree(&assets, &[], &[]).unwrap();
+        let asset_marker = output.join(".fake-asset-fingerprint");
+        if fs::read_to_string(&asset_marker).unwrap_or_default() != asset_fingerprint {
+            calls.asset_manifest += 1;
+            write(&asset_marker, &asset_fingerprint);
+        }
+
+        (
+            calls,
+            OutputHashes {
+                runtime_js: digest(&output.join("fastled.js")),
+                runtime_wasm: digest(&output.join("fastled.wasm")),
+                sketch_wasm: digest(&output.join("sketch.wasm")),
+            },
+        )
+    }
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn write_wasm(path: &Path, payload: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let mut bytes = b"\0asm\x01\0\0\0".to_vec();
+    bytes.extend_from_slice(payload);
+    fs::write(path, bytes).unwrap();
+}
+
+fn publish_fake(root: &Path, fingerprint: &str, name: &str, payload: &[u8], wasm: bool) {
+    let staging = dynamic_cache::staging_dir(root, ".fake-").unwrap();
+    if wasm {
+        write_wasm(&staging.path().join(name), payload);
+    } else {
+        fs::write(staging.path().join(name), payload).unwrap();
+    }
+    dynamic_cache::write_metadata(staging.path(), fingerprint, &[name]).unwrap();
+    dynamic_cache::publish_staging(staging, &dynamic_cache::entry_path(root, fingerprint)).unwrap();
+}
+
+fn digest(path: &Path) -> String {
+    format!("{:x}", Sha256::digest(fs::read(path).unwrap()))
+}
+
+fn assert_runtime_rebuild(calls: Invocations) {
+    assert_eq!(calls.library_build, 1, "library build count: {calls:?}");
+    assert_eq!(calls.main_link, 1, "main link count: {calls:?}");
+    assert_eq!(calls.sketch_compile, 1, "sketch compile count: {calls:?}");
+    assert_eq!(calls.side_link, 1, "side link count: {calls:?}");
+}
+
+#[test]
+fn cold_noop_and_sketch_only_transitions_use_minimal_commands() {
+    let repo = FakeRepository::new();
+    let (cold, original) = repo.run("SketchA");
+    assert_runtime_rebuild(cold);
+    assert_eq!(cold.app_build, 1);
+    assert_eq!(cold.asset_manifest, 1);
+
+    let (noop, unchanged) = repo.run("SketchA");
+    assert_eq!(noop, Invocations::default());
+    assert_eq!(unchanged, original);
+
+    write(&repo.sketch("SketchA").join("SketchA.ino"), "setup-a-v2");
+    let (edited, changed) = repo.run("SketchA");
+    assert_eq!(edited.library_build, 0);
+    assert_eq!(edited.main_link, 0);
+    assert_eq!(edited.sketch_compile, 1);
+    assert_eq!(edited.side_link, 1);
+    assert_eq!(changed.runtime_js, original.runtime_js);
+    assert_eq!(changed.runtime_wasm, original.runtime_wasm);
+    assert_ne!(changed.sketch_wasm, original.sketch_wasm);
+}
+
+#[test]
+fn every_runtime_input_class_rebuilds_runtime_and_sketch() {
+    let mutations: Vec<(Box<dyn Fn(&mut FakeRepository)>, bool)> = vec![
+        (
+            Box::new(|repo| write(&repo.fastled.join("src/core.cpp"), "core-v2")),
+            true,
+        ),
+        (
+            Box::new(|repo| write(&repo.fastled.join("src/core.h"), "header-v2")),
+            true,
+        ),
+        (
+            Box::new(|repo| write(&repo.fastled.join("src/new.cpp"), "new-source")),
+            true,
+        ),
+        (
+            Box::new(|repo| fs::remove_file(repo.fastled.join("src/core.cpp")).unwrap()),
+            true,
+        ),
+        (
+            Box::new(|repo| {
+                fs::rename(
+                    repo.fastled.join("src/core.cpp"),
+                    repo.fastled.join("src/renamed.cpp"),
+                )
+                .unwrap()
+            }),
+            true,
+        ),
+        (
+            Box::new(|repo| {
+                write(
+                    &repo
+                        .fastled
+                        .join("src/platforms/wasm/compiler/build_flags.toml"),
+                    "flags-v2",
+                )
+            }),
+            true,
+        ),
+        (
+            Box::new(|repo| {
+                write(
+                    &repo
+                        .fastled
+                        .join("src/platforms/wasm/compiler/js_library.js"),
+                    "js-library-v2",
+                )
+            }),
+            false,
+        ),
+        (
+            Box::new(|repo| repo.toolchain = "emscripten-4.0.20".to_string()),
+            true,
+        ),
+        (
+            Box::new(|repo| repo.abi = "MAIN_MODULE=1;SIDE_MODULE=1;WASM_BIGINT=1".to_string()),
+            false,
+        ),
+        (Box::new(|repo| repo.mode = "debug".to_string()), true),
+        (Box::new(|repo| repo.mode = "release".to_string()), true),
+    ];
+
+    for (mutate, library_rebuild) in mutations {
+        let mut repo = FakeRepository::new();
+        repo.run("SketchA");
+        mutate(&mut repo);
+        let (calls, _) = repo.run("SketchA");
+        assert_eq!(
+            calls.library_build,
+            usize::from(library_rebuild),
+            "{calls:?}"
+        );
+        assert_eq!(calls.main_link, 1, "{calls:?}");
+        assert_eq!(calls.sketch_compile, 1, "{calls:?}");
+        assert_eq!(calls.side_link, 1, "{calls:?}");
+    }
+}
+
+#[test]
+fn app_assets_no_app_and_second_sketch_do_not_relink_runtime() {
+    let mut repo = FakeRepository::new();
+    let (_, baseline) = repo.run("SketchA");
+
+    write(&repo.app.join("index.ts"), "app-v2");
+    let (app, app_hashes) = repo.run("SketchA");
+    assert_eq!(app.app_build, 1);
+    assert_eq!(app.main_link + app.sketch_compile + app.side_link, 0);
+    assert_eq!(app_hashes, baseline);
+
+    write(
+        &repo.sketch("SketchA").join("data/config.json"),
+        "{\"asset\":2}",
+    );
+    let (assets, asset_hashes) = repo.run("SketchA");
+    assert_eq!(assets.asset_manifest, 1);
+    assert_eq!(
+        assets.main_link + assets.sketch_compile + assets.side_link,
+        0
+    );
+    assert_eq!(asset_hashes, baseline);
+
+    repo.no_app = true;
+    let (no_app, no_app_hashes) = repo.run("SketchA");
+    assert_eq!(no_app.app_build, 1);
+    assert_eq!(
+        no_app.main_link + no_app.sketch_compile + no_app.side_link,
+        0
+    );
+    assert_eq!(no_app_hashes, baseline);
+
+    let (second, second_hashes) = repo.run("SketchB");
+    assert_eq!(second.library_build, 0);
+    assert_eq!(second.main_link, 0);
+    assert_eq!(second.sketch_compile, 1);
+    assert_eq!(second.side_link, 1);
+    assert_eq!(second_hashes.runtime_js, baseline.runtime_js);
+    assert_eq!(second_hashes.runtime_wasm, baseline.runtime_wasm);
+}
+
+#[test]
+fn touch_is_ignored_but_same_size_preserved_mtime_edit_rebuilds() {
+    let repo = FakeRepository::new();
+    repo.run("SketchA");
+    let source = repo.sketch("SketchA").join("SketchA.ino");
+    let original_mtime = source.metadata().unwrap().modified().unwrap();
+
+    let file = fs::OpenOptions::new().write(true).open(&source).unwrap();
+    file.set_modified(std::time::SystemTime::now()).unwrap();
+    assert_eq!(repo.run("SketchA").0, Invocations::default());
+
+    write(&source, "changed");
+    assert_eq!(fs::metadata(&source).unwrap().len(), "setup-a".len() as u64);
+    let file = fs::OpenOptions::new().write(true).open(&source).unwrap();
+    file.set_modified(original_mtime).unwrap();
+    let (calls, _) = repo.run("SketchA");
+    assert_eq!(calls.main_link, 0);
+    assert_eq!(calls.sketch_compile, 1);
+    assert_eq!(calls.side_link, 1);
+}
+
+#[test]
+fn corrupt_runtime_and_side_artifacts_rebuild_smallest_safe_unit() {
+    let repo = FakeRepository::new();
+    repo.run("SketchA");
+    let runtime = repo.runtime_fingerprint();
+    let runtime_entry = dynamic_cache::entry_path(&repo.runtime_root(), &runtime);
+    fs::write(runtime_entry.join("cache-metadata.json"), "broken").unwrap();
+    let (runtime_calls, _) = repo.run("SketchA");
+    assert_eq!(runtime_calls.library_build, 0);
+    assert_eq!(runtime_calls.main_link, 1);
+    assert_eq!(runtime_calls.sketch_compile, 0);
+    assert_eq!(runtime_calls.side_link, 0);
+
+    fs::write(runtime_entry.join("fastled.wasm"), b"\0asm\x01").unwrap();
+    let (truncated_runtime, _) = repo.run("SketchA");
+    assert_eq!(truncated_runtime.main_link, 1);
+    assert_eq!(truncated_runtime.side_link, 0);
+
+    let sketch = repo.sketch_fingerprint("SketchA", &runtime);
+    let side_entry = dynamic_cache::entry_path(
+        &repo
+            .sketch("SketchA")
+            .join(".build/fake-sketch-cache/sides"),
+        &sketch,
+    );
+    fs::remove_file(side_entry.join("sketch.wasm")).unwrap();
+    let (missing_side, _) = repo.run("SketchA");
+    assert_eq!(missing_side.main_link, 0);
+    assert_eq!(missing_side.sketch_compile, 0);
+    assert_eq!(missing_side.side_link, 1);
+
+    fs::write(side_entry.join("sketch.wasm"), b"\0asm\x01").unwrap();
+    let (truncated_side, _) = repo.run("SketchA");
+    assert_eq!(truncated_side.main_link, 0);
+    assert_eq!(truncated_side.sketch_compile, 0);
+    assert_eq!(truncated_side.side_link, 1);
+}
+
+#[test]
+fn interrupted_new_key_preserves_old_entry_and_concurrent_build_links_once() -> Result<()> {
+    let mut repo = FakeRepository::new();
+    repo.run("SketchA");
+    let old_fingerprint = repo.runtime_fingerprint();
+    let old_entry = dynamic_cache::entry_path(&repo.runtime_root(), &old_fingerprint);
+    let old_hash = digest(&old_entry.join("fastled.wasm"));
+
+    repo.toolchain = "interrupted-toolchain".to_string();
+    let new_fingerprint = repo.runtime_fingerprint();
+    dynamic_cache::mark_pending(&repo.runtime_root(), &new_fingerprint, "main-link")?;
+    let partial = dynamic_cache::staging_dir(&repo.runtime_root(), ".interrupted-")?;
+    write_wasm(&partial.path().join("fastled.wasm"), b"partial");
+    std::mem::forget(partial);
+    assert_eq!(digest(&old_entry.join("fastled.wasm")), old_hash);
+    assert!(dynamic_cache::validate_entry(
+        &dynamic_cache::entry_path(&repo.runtime_root(), &new_fingerprint),
+        &new_fingerprint,
+        &["fastled.js", "fastled.wasm"],
+    )
+    .is_err());
+
+    let concurrent_root = repo.root.join("concurrent-runtime");
+    let fingerprint = "shared-key".to_string();
+    let links = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
+    for _ in 0..2 {
+        let root = concurrent_root.clone();
+        let key = fingerprint.clone();
+        let links = Arc::clone(&links);
+        handles.push(std::thread::spawn(move || {
+            let _lock = dynamic_cache::CacheLock::acquire(&root, &key).unwrap();
+            let entry = dynamic_cache::entry_path(&root, &key);
+            if dynamic_cache::validate_entry(&entry, &key, &["fastled.js", "fastled.wasm"]).is_err()
+            {
+                links.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let staging = dynamic_cache::staging_dir(&root, ".concurrent-").unwrap();
+                write(&staging.path().join("fastled.js"), "loader");
+                write_wasm(&staging.path().join("fastled.wasm"), b"runtime");
+                dynamic_cache::write_metadata(
+                    staging.path(),
+                    &key,
+                    &["fastled.js", "fastled.wasm"],
+                )
+                .unwrap();
+                dynamic_cache::publish_staging(staging, &entry).unwrap();
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    assert_eq!(links.load(Ordering::SeqCst), 1);
+    assert!(dynamic_cache::validate_entry(
+        &dynamic_cache::entry_path(&concurrent_root, &fingerprint),
+        &fingerprint,
+        &["fastled.js", "fastled.wasm"],
+    )
+    .is_ok());
+    Ok(())
+}

--- a/crates/fastled-cli/src/dynamic_cache_matrix_tests.rs
+++ b/crates/fastled-cli/src/dynamic_cache_matrix_tests.rs
@@ -319,7 +319,9 @@ fn cold_noop_and_sketch_only_transitions_use_minimal_commands() {
 
 #[test]
 fn every_runtime_input_class_rebuilds_runtime_and_sketch() {
-    let mutations: Vec<(Box<dyn Fn(&mut FakeRepository)>, bool)> = vec![
+    type Mutation = (Box<dyn Fn(&mut FakeRepository)>, bool);
+
+    let mutations: Vec<Mutation> = vec![
         (
             Box::new(|repo| write(&repo.fastled.join("src/core.cpp"), "core-v2")),
             true,

--- a/crates/fastled-cli/src/dynamic_cache_matrix_tests.rs
+++ b/crates/fastled-cli/src/dynamic_cache_matrix_tests.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -7,6 +7,7 @@ use anyhow::Result;
 use sha2::{Digest, Sha256};
 
 use crate::dynamic_cache;
+use crate::path::NormalizedPath;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct Invocations {
@@ -27,9 +28,9 @@ struct OutputHashes {
 
 struct FakeRepository {
     _temp: tempfile::TempDir,
-    root: PathBuf,
-    fastled: PathBuf,
-    app: PathBuf,
+    root: NormalizedPath,
+    fastled: NormalizedPath,
+    app: NormalizedPath,
     mode: String,
     toolchain: String,
     abi: String,
@@ -39,7 +40,7 @@ struct FakeRepository {
 impl FakeRepository {
     fn new() -> Self {
         let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().to_path_buf();
+        let root = NormalizedPath::new(temp.path());
         let fastled = root.join("FastLED");
         write(&fastled.join("src/core.cpp"), "core-v1");
         write(&fastled.join("src/core.h"), "header-v1");
@@ -75,11 +76,11 @@ impl FakeRepository {
         }
     }
 
-    fn sketch(&self, name: &str) -> PathBuf {
+    fn sketch(&self, name: &str) -> NormalizedPath {
         self.root.join(name)
     }
 
-    fn runtime_root(&self) -> PathBuf {
+    fn runtime_root(&self) -> NormalizedPath {
         self.fastled
             .join(".build")
             .join("fake-dynamic-runtime-cache")

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -171,15 +171,31 @@ fn multipart_parts(version_info: &VersionInfo) -> Option<&[PartRef]> {
 }
 
 #[cfg(unix)]
-fn ensure_bin_executables(install_dir: &Path) -> Result<()> {
+fn ensure_toolchain_executables(install_dir: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    let bin_dir = install_dir.join("bin");
-    if !bin_dir.is_dir() {
-        return Ok(());
+    fn add_execute_bits(path: &Path) -> Result<()> {
+        let metadata =
+            fs::metadata(path).with_context(|| format!("read metadata for {}", path.display()))?;
+        if !metadata.is_file() {
+            return Ok(());
+        }
+        let mut permissions = metadata.permissions();
+        let mode = permissions.mode();
+        if mode & 0o111 == 0 {
+            permissions.set_mode(mode | 0o111);
+            fs::set_permissions(path, permissions)
+                .with_context(|| format!("set executable bit on {}", path.display()))?;
+        }
+        Ok(())
     }
 
-    let mut pending = vec![bin_dir];
+    let bin_dir = install_dir.join("bin");
+    let mut pending = if bin_dir.is_dir() {
+        vec![bin_dir]
+    } else {
+        Vec::new()
+    };
     while let Some(dir) = pending.pop() {
         for entry in fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
             let entry = entry.with_context(|| format!("read entry in {}", dir.display()))?;
@@ -194,13 +210,30 @@ fn ensure_bin_executables(install_dir: &Path) -> Result<()> {
                 continue;
             }
 
-            let mut permissions = metadata.permissions();
-            let mode = permissions.mode();
-            if mode & 0o111 == 0 {
-                permissions.set_mode(mode | 0o111);
-                fs::set_permissions(&path, permissions)
-                    .with_context(|| format!("set executable bit on {}", path.display()))?;
-            }
+            add_execute_bits(&path)?;
+        }
+    }
+
+    // Emscripten invokes these extensionless launchers directly while
+    // building system libraries. They live outside bin/, and some published
+    // archives lose their Unix mode bits.
+    for name in [
+        "em++",
+        "emar",
+        "embuilder",
+        "emcc",
+        "emcmake",
+        "emconfigure",
+        "emmake",
+        "emnm",
+        "emranlib",
+        "emrun",
+        "emsize",
+        "emstrip",
+    ] {
+        let launcher = install_dir.join("emscripten").join(name);
+        if launcher.exists() {
+            add_execute_bits(&launcher)?;
         }
     }
 
@@ -208,7 +241,7 @@ fn ensure_bin_executables(install_dir: &Path) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-fn ensure_bin_executables(_install_dir: &Path) -> Result<()> {
+fn ensure_toolchain_executables(_install_dir: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -236,6 +269,7 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     let install_dir = install_base.join(&version);
     let done_file = install_dir.join("done.txt");
     if done_file.exists() {
+        ensure_toolchain_executables(&install_dir)?;
         return Ok(install_dir);
     }
 
@@ -274,7 +308,7 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     }
     fs::create_dir_all(&staging)?;
     archive::extract_tar_zst(&archive_path, &staging)?;
-    ensure_bin_executables(&staging)?;
+    ensure_toolchain_executables(&staging)?;
 
     fs::write(staging.join("done.txt"), "ok\n")?;
 
@@ -1271,7 +1305,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn ensure_bin_executables_restores_unix_execute_bits() {
+    fn ensure_toolchain_executables_restores_unix_execute_bits() {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -1280,14 +1314,23 @@ mod tests {
         let tool = bin_dir.join("llvm-ar");
         fs::write(&tool, b"#!/bin/sh\n").expect("write tool");
 
-        let mut permissions = fs::metadata(&tool).expect("metadata").permissions();
-        permissions.set_mode(0o644);
-        fs::set_permissions(&tool, permissions).expect("clear executable bit");
+        let emscripten_dir = temp.path().join("emscripten");
+        fs::create_dir_all(&emscripten_dir).expect("create emscripten");
+        let launcher = emscripten_dir.join("emcc");
+        fs::write(&launcher, b"#!/bin/sh\n").expect("write launcher");
 
-        ensure_bin_executables(temp.path()).expect("restore executable bits");
+        for path in [&tool, &launcher] {
+            let mut permissions = fs::metadata(path).expect("metadata").permissions();
+            permissions.set_mode(0o644);
+            fs::set_permissions(path, permissions).expect("clear executable bit");
+        }
 
-        let mode = fs::metadata(&tool).expect("metadata").permissions().mode();
-        assert_ne!(mode & 0o111, 0);
+        ensure_toolchain_executables(temp.path()).expect("restore executable bits");
+
+        for path in [&tool, &launcher] {
+            let mode = fs::metadata(path).expect("metadata").permissions().mode();
+            assert_ne!(mode & 0o111, 0);
+        }
     }
 
     /// Regression for issue #111: the win/x86_64 manifest publishes version

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -12,6 +12,9 @@ mod commands;
 mod compile_stream;
 pub mod debug_symbols;
 mod dwarf_smoke;
+mod dynamic_cache;
+#[cfg(test)]
+mod dynamic_cache_matrix_tests;
 pub mod frontend;
 pub mod install;
 mod install_unlock;

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -953,6 +953,7 @@ fn meson_quote(value: &str) -> String {
     format!("'{escaped}'")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ensure_meson_configured(
     fastled_dir: &Path,
     tools: &ToolPaths,
@@ -1120,6 +1121,7 @@ fn collect_cpp_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_sketch_pch(
     fastled_dir: &Path,
     tools: &ToolPaths,

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -95,7 +95,7 @@ struct BuildFingerprints {
 
 #[derive(Debug)]
 struct CompiledSketch {
-    object: PathBuf,
+    object: crate::path::NormalizedPath,
     fingerprint: String,
 }
 

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use crate::cli::LinkMode;
-use crate::{archive, debug_symbols, frontend, install};
+use crate::{archive, debug_symbols, dynamic_cache, frontend, install};
 
 /// Receives one build-output line at a time. The second argument is the
 /// originating stream: `"stdout"` or `"stderr"`. Called on the build thread.
@@ -84,6 +84,42 @@ struct ToolPaths {
     empp: PathBuf,
     emar: PathBuf,
     python: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct BuildFingerprints {
+    fastled_source: String,
+    toolchain: String,
+    library: String,
+}
+
+#[derive(Debug)]
+struct CompiledSketch {
+    object: PathBuf,
+    fingerprint: String,
+}
+
+impl BuildFingerprints {
+    fn compute(
+        fastled_dir: &Path,
+        tools: &ToolPaths,
+        mode: BuildMode,
+        link_mode: LinkMode,
+    ) -> Result<Self> {
+        let fastled_source = compute_source_file_hash(fastled_dir)?;
+        let toolchain = toolchain_fingerprint(tools)?;
+        let mode_value = format!("mode={};link-mode={link_mode:?}", mode.as_str());
+        let library = dynamic_cache::fingerprint_values([
+            fastled_source.as_bytes(),
+            toolchain.as_bytes(),
+            mode_value.as_bytes(),
+        ]);
+        Ok(Self {
+            fastled_source,
+            toolchain,
+            library,
+        })
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -283,18 +319,22 @@ fn run_status(mut command: Command, label: &str, log: LogSink) -> Result<()> {
 fn link_wasm_dynamic(
     fastled_dir: &Path,
     tools: &ToolPaths,
-    sketch_object: &Path,
+    sketch: &CompiledSketch,
     build_dir: &Path,
     sketch_cache_dir: &Path,
     output_js: &Path,
     mode: BuildMode,
+    fingerprints: &BuildFingerprints,
     log: LogSink,
 ) -> Result<()> {
+    let sketch_object = &sketch.object;
     let archive = library_archive(build_dir);
-    let cached_js = sketch_cache_dir.join("fastled.js");
-    let cached_wasm = sketch_cache_dir.join("fastled.wasm");
-    let cached_sketch = sketch_cache_dir.join("sketch.wasm");
     let link_flags = get_link_flags(fastled_dir, mode)?;
+    let main_link_flags = link_flags
+        .iter()
+        .filter(|flag| flag.as_str() != "-Wl,--no-export-dynamic")
+        .cloned()
+        .collect::<Vec<_>>();
     // Dynamic linking requires an identical ABI for the main and side
     // modules. Emscripten's default WASM_BIGINT behavior differs between
     // ordinary and SIDE_MODULE links, so make the setting explicit on both
@@ -302,42 +342,167 @@ fn link_wasm_dynamic(
     // "imported function does not match the expected type" LinkError.
     let wasm_bigint_flag = dynamic_wasm_bigint_flag(&link_flags);
     let side_module_link_flags = vec![wasm_bigint_flag.clone()];
-    let mut hash_input = vec!["link-mode=dynamic".to_string()];
-    hash_input.extend(link_flags.iter().cloned());
-    hash_input.push("-sMAIN_MODULE=1".to_string());
-    hash_input.push("-sSIDE_MODULE=1".to_string());
-    hash_input.push(format!("main-module:{wasm_bigint_flag}"));
-    hash_input.extend(
-        side_module_link_flags
+    let source_fingerprint = &fingerprints.fastled_source;
+    let toolchain_fingerprint = &fingerprints.toolchain;
+    let generated_cross_file = fastled_dir
+        .join(".build")
+        .join("fastled-wasm-cross-file.ini");
+    let generated_cross_file_contents = fs::read(&generated_cross_file).unwrap_or_default();
+    let mut runtime_values = vec![
+        "schema=1".to_string(),
+        format!("cli={}", env!("CARGO_PKG_VERSION")),
+        format!("mode={}", mode.as_str()),
+        "link-mode=dynamic".to_string(),
+        "main-module=1".to_string(),
+        "autoload-dylibs=0".to_string(),
+        "error-on-undefined-symbols=0".to_string(),
+        "export-dynamic=1".to_string(),
+        "wasm-ld-export-all=1".to_string(),
+        "export-all=1".to_string(),
+        "whole-archive=1".to_string(),
+        format!("source={source_fingerprint}"),
+        format!("toolchain={toolchain_fingerprint}"),
+        format!("wasm-bigint={wasm_bigint_flag}"),
+        format!(
+            "loader={}",
+            dynamic_cache::fingerprint_values([dynamic_cache::DYNAMIC_LOADER_JS.as_bytes()])
+        ),
+        format!(
+            "cross-file={}",
+            dynamic_cache::fingerprint_values([generated_cross_file_contents.as_slice()])
+        ),
+    ];
+    runtime_values.extend(
+        main_link_flags
             .iter()
-            .map(|flag| format!("side-module:{flag}")),
+            .map(|flag| format!("link-flag={flag}")),
     );
-    let current_flags_hash = format!("{:x}", Sha256::digest(hash_input.join("\n").as_bytes()));
-    let flags_hash_path = sketch_cache_dir.join("link_flags.hash");
-    let output_mtime = cached_js
-        .metadata()
-        .and_then(|metadata| metadata.modified())
-        .ok();
-    let inputs_are_older = output_mtime.is_some_and(|output_mtime| {
-        [sketch_object, &archive]
-            .iter()
-            .filter_map(|path| path.metadata().ok())
-            .filter_map(|metadata| metadata.modified().ok())
-            .all(|mtime| mtime <= output_mtime)
-    });
-    if cached_js.is_file()
-        && cached_wasm.is_file()
-        && cached_sketch.is_file()
-        && fs::read_to_string(&flags_hash_path)
-            .unwrap_or_default()
-            .trim()
-            == current_flags_hash
-        && inputs_are_older
-    {
-        copy_linked_output(sketch_cache_dir, output_js)?;
-        log("[WASM] Dynamic link output up-to-date", "stdout");
-        return Ok(());
+    runtime_values.extend(
+        build_env(tools)
+            .into_iter()
+            .map(|(key, value)| format!("env:{key}={value}")),
+    );
+    let runtime_fingerprint =
+        dynamic_cache::fingerprint_values(runtime_values.iter().map(|value| value.as_bytes()));
+    let runtime_root = build_dir.join("dynamic-runtime-cache");
+    let runtime_entry = dynamic_cache::entry_path(&runtime_root, &runtime_fingerprint);
+    let runtime_phase_start = std::time::Instant::now();
+    let _runtime_lock = dynamic_cache::CacheLock::acquire(&runtime_root, &runtime_fingerprint)?;
+    match dynamic_cache::validate_entry(
+        &runtime_entry,
+        &runtime_fingerprint,
+        &["fastled.js", "fastled.wasm"],
+    ) {
+        Ok(()) => {
+            dynamic_cache::clear_attempt(&runtime_root, &runtime_fingerprint)?;
+            log(
+                &format!(
+                    "[WASM] Dynamic runtime cache hit: {} ({:.2}s)",
+                    &runtime_fingerprint[..12],
+                    runtime_phase_start.elapsed().as_secs_f64()
+                ),
+                "stdout",
+            );
+        }
+        Err(reason) => {
+            let prior = dynamic_cache::previous_attempt(&runtime_root, &runtime_fingerprint)
+                .map(|attempt| format!("; previous attempt: {attempt}"))
+                .unwrap_or_default();
+            log(
+                &format!(
+                    "[WASM] Dynamic runtime cache miss: {} ({reason}{prior})",
+                    &runtime_fingerprint[..12],
+                ),
+                "stdout",
+            );
+            dynamic_cache::mark_pending(&runtime_root, &runtime_fingerprint, "main-link")?;
+            let rebuild = (|| -> Result<()> {
+                let staging = dynamic_cache::staging_dir(&runtime_root, ".runtime-staging-")?;
+                let loader = staging.path().join("dynamic_loader.js");
+                fs::write(&loader, dynamic_cache::DYNAMIC_LOADER_JS)?;
+                let js_library = fastled_dir
+                    .join("src")
+                    .join("platforms")
+                    .join("wasm")
+                    .join("compiler")
+                    .join("js_library.js");
+                let cached_js = staging.path().join("fastled.js");
+                let mut main_args = vec![
+                    "-Wl,--whole-archive".to_string(),
+                    archive.display().to_string(),
+                    "-Wl,--no-whole-archive".to_string(),
+                    format!("-I{}", fastled_dir.join("src").display()),
+                    format!("-I{}", fastled_dir.join("src/platforms/wasm").display()),
+                    format!(
+                        "-I{}",
+                        fastled_dir.join("src/platforms/wasm/compiler").display()
+                    ),
+                    format!("--js-library={}", js_library.display()),
+                    "--pre-js".to_string(),
+                    loader.display().to_string(),
+                    "-sMAIN_MODULE=1".to_string(),
+                    "-sAUTOLOAD_DYLIBS=0".to_string(),
+                    "-o".to_string(),
+                    cached_js.display().to_string(),
+                ];
+                main_args.extend(main_link_flags.iter().cloned());
+                main_args.extend([
+                    "-sINCLUDE_FULL_LIBRARY=1".to_string(),
+                    "-sFILESYSTEM=1".to_string(),
+                    "-sAUTO_NATIVE_LIBRARIES=1".to_string(),
+                    "-sERROR_ON_UNDEFINED_SYMBOLS=0".to_string(),
+                    "-sEXPORT_ALL=1".to_string(),
+                    "-Wl,--export-dynamic".to_string(),
+                    "-Wl,--export-all".to_string(),
+                    wasm_bigint_flag.clone(),
+                ]);
+                log("[WASM] Linking cached dynamic runtime...", "stdout");
+                run_em_link_with_retries(fastled_dir, tools, &main_args, log)?;
+                let mut artifacts = vec!["fastled.js", "fastled.wasm"];
+                if staging.path().join("fastled.wasm.map").is_file() {
+                    artifacts.push("fastled.wasm.map");
+                }
+                if staging.path().join("fastled.js.map").is_file() {
+                    artifacts.push("fastled.js.map");
+                }
+                fs::remove_file(loader).ok();
+                dynamic_cache::write_metadata(staging.path(), &runtime_fingerprint, &artifacts)?;
+                dynamic_cache::publish_staging(staging, &runtime_entry)?;
+                dynamic_cache::validate_entry(
+                    &runtime_entry,
+                    &runtime_fingerprint,
+                    &["fastled.js", "fastled.wasm"],
+                )
+                .map_err(anyhow::Error::msg)
+            })();
+            if let Err(error) = rebuild {
+                if let Err(mark_error) = dynamic_cache::mark_failure(
+                    &runtime_root,
+                    &runtime_fingerprint,
+                    "main-link",
+                    &error,
+                ) {
+                    log(
+                        &format!(
+                            "[WASM] warning: failed to record main-link failure: {mark_error:#}"
+                        ),
+                        "stderr",
+                    );
+                }
+                return Err(error);
+            }
+            dynamic_cache::clear_attempt(&runtime_root, &runtime_fingerprint)?;
+            log(
+                &format!(
+                    "[WASM] Dynamic runtime published: {} ({:.2}s)",
+                    &runtime_fingerprint[..12],
+                    runtime_phase_start.elapsed().as_secs_f64()
+                ),
+                "stdout",
+            );
+        }
     }
+    drop(_runtime_lock);
 
     let include_flags = vec![
         format!("-I{}", fastled_dir.join("src").display()),
@@ -360,47 +525,129 @@ fn link_wasm_dynamic(
         ),
     ];
 
-    log("[WASM] Linking sketch side module...", "stdout");
-    let mut side_args = vec![sketch_object.display().to_string()];
-    side_args.extend(include_flags.iter().cloned());
-    side_args.extend(["-pthread".to_string(), "-sSIDE_MODULE=1".to_string()]);
-    side_args.extend(side_module_link_flags);
-    side_args.extend(["-o".to_string(), cached_sketch.display().to_string()]);
-    run_em_link_with_retries(fastled_dir, tools, &side_args, log)?;
-
-    let js_library = fastled_dir
-        .join("src")
-        .join("platforms")
-        .join("wasm")
-        .join("compiler")
-        .join("js_library.js");
-    let mut main_args = vec![
-        archive.display().to_string(),
-        cached_sketch.display().to_string(),
-    ];
-    main_args.extend(include_flags);
-    main_args.extend([
-        format!("--js-library={}", js_library.display()),
-        "-sMAIN_MODULE=1".to_string(),
-        "-sAUTOLOAD_DYLIBS=1".to_string(),
-        "-o".to_string(),
-        cached_js.display().to_string(),
+    let sketch_object_record =
+        fs::read(sketch_object).with_context(|| format!("read {}", sketch_object.display()))?;
+    let sketch_fingerprint = dynamic_cache::fingerprint_values([
+        runtime_fingerprint.as_bytes(),
+        toolchain_fingerprint.as_bytes(),
+        sketch.fingerprint.as_bytes(),
+        sketch_object_record.as_slice(),
+        side_module_link_flags.join("\n").as_bytes(),
+        b"SIDE_MODULE=1",
     ]);
-    main_args.extend(link_flags);
-    // These dynamic-main requirements must come after the shared FastLED
-    // flags, whose static profile intentionally disables them.
-    main_args.extend([
-        "-sINCLUDE_FULL_LIBRARY=1".to_string(),
-        "-sFILESYSTEM=1".to_string(),
-        "-sAUTO_NATIVE_LIBRARIES=1".to_string(),
-        wasm_bigint_flag,
-    ]);
+    let sketch_root = sketch_cache_dir.join("dynamic-sketch-cache");
+    let sketch_entry = dynamic_cache::entry_path(&sketch_root, &sketch_fingerprint);
+    let sketch_phase_start = std::time::Instant::now();
+    let _sketch_lock = dynamic_cache::CacheLock::acquire(&sketch_root, &sketch_fingerprint)?;
+    match dynamic_cache::validate_entry(&sketch_entry, &sketch_fingerprint, &["sketch.wasm"]) {
+        Ok(()) => {
+            dynamic_cache::clear_attempt(&sketch_root, &sketch_fingerprint)?;
+            log(
+                &format!(
+                    "[WASM] Dynamic sketch cache hit: {} ({:.2}s)",
+                    &sketch_fingerprint[..12],
+                    sketch_phase_start.elapsed().as_secs_f64()
+                ),
+                "stdout",
+            );
+        }
+        Err(reason) => {
+            let prior = dynamic_cache::previous_attempt(&sketch_root, &sketch_fingerprint)
+                .map(|attempt| format!("; previous attempt: {attempt}"))
+                .unwrap_or_default();
+            log(
+                &format!(
+                    "[WASM] Dynamic sketch cache miss: {} ({reason}{prior})",
+                    &sketch_fingerprint[..12],
+                ),
+                "stdout",
+            );
+            dynamic_cache::mark_pending(&sketch_root, &sketch_fingerprint, "side-link")?;
+            let rebuild = (|| -> Result<()> {
+                let staging = dynamic_cache::staging_dir(&sketch_root, ".sketch-staging-")?;
+                let cached_sketch = staging.path().join("sketch.wasm");
+                let mut side_args = vec![sketch_object.display().to_string()];
+                side_args.extend(include_flags);
+                side_args.extend(["-pthread".to_string(), "-sSIDE_MODULE=1".to_string()]);
+                side_args.extend(side_module_link_flags);
+                side_args.extend(["-o".to_string(), cached_sketch.display().to_string()]);
+                log("[WASM] Linking cached sketch side module...", "stdout");
+                run_em_link_with_retries(fastled_dir, tools, &side_args, log)?;
+                dynamic_cache::write_metadata(
+                    staging.path(),
+                    &sketch_fingerprint,
+                    &["sketch.wasm"],
+                )?;
+                dynamic_cache::publish_staging(staging, &sketch_entry)?;
+                dynamic_cache::validate_entry(&sketch_entry, &sketch_fingerprint, &["sketch.wasm"])
+                    .map_err(anyhow::Error::msg)
+            })();
+            if let Err(error) = rebuild {
+                if let Err(mark_error) = dynamic_cache::mark_failure(
+                    &sketch_root,
+                    &sketch_fingerprint,
+                    "side-link",
+                    &error,
+                ) {
+                    log(
+                        &format!(
+                            "[WASM] warning: failed to record side-link failure: {mark_error:#}"
+                        ),
+                        "stderr",
+                    );
+                }
+                return Err(error);
+            }
+            dynamic_cache::clear_attempt(&sketch_root, &sketch_fingerprint)?;
+            log(
+                &format!(
+                    "[WASM] Dynamic sketch published: {} ({:.2}s)",
+                    &sketch_fingerprint[..12],
+                    sketch_phase_start.elapsed().as_secs_f64()
+                ),
+                "stdout",
+            );
+        }
+    }
 
-    log("[WASM] Linking dynamic main WASM module...", "stdout");
-    run_em_link_with_retries(fastled_dir, tools, &main_args, log)?;
-    fs::write(flags_hash_path, current_flags_hash)?;
-    copy_linked_output(sketch_cache_dir, output_js)?;
+    copy_dynamic_output(&runtime_entry, &sketch_entry, output_js)?;
     Ok(())
+}
+
+fn toolchain_fingerprint(tools: &ToolPaths) -> Result<String> {
+    let install_root = tools
+        .emscripten_dir
+        .parent()
+        .unwrap_or(&tools.emscripten_dir);
+    let binary_suffix = if cfg!(windows) { ".exe" } else { "" };
+    let include = [
+        "emscripten/emcc.py",
+        "emscripten/em++.py",
+        "emscripten/emar.py",
+        "emscripten/emscripten-version.txt",
+        "lib/clang/**/*",
+        ".emscripten",
+    ];
+    let content = dynamic_cache::fingerprint_tree(install_root, &include, &[])?;
+    let clang = install_root.join(format!("bin/clang{binary_suffix}"));
+    let wasm_ld = install_root.join(format!("bin/wasm-ld{binary_suffix}"));
+    let llvm_ar = install_root.join(format!("bin/llvm-ar{binary_suffix}"));
+    let mut values = vec![
+        format!("content={content}"),
+        format!("python={}", tools.python.display()),
+        format!("clang={}", clang.display()),
+        format!("wasm-ld={}", wasm_ld.display()),
+        format!("llvm-ar={}", llvm_ar.display()),
+        format!("target={}-{}", std::env::consts::ARCH, std::env::consts::OS),
+    ];
+    values.extend(
+        build_env(tools)
+            .into_iter()
+            .map(|(key, value)| format!("{key}={value}")),
+    );
+    Ok(dynamic_cache::fingerprint_values(
+        values.iter().map(|value| value.as_bytes()),
+    ))
 }
 
 fn dynamic_wasm_bigint_flag(link_flags: &[String]) -> String {
@@ -410,6 +657,20 @@ fn dynamic_wasm_bigint_flag(link_flags: &[String]) -> String {
         .find(|flag| flag.starts_with("-sWASM_BIGINT="))
         .cloned()
         .unwrap_or_else(|| "-sWASM_BIGINT=1".to_string())
+}
+
+fn static_link_fingerprint(
+    link_flags: &[String],
+    sketch_fingerprint: &str,
+    library_fingerprint: &str,
+) -> String {
+    let flag_blob = link_flags.join("\n");
+    dynamic_cache::fingerprint_values([
+        b"link-mode=static",
+        flag_blob.as_bytes(),
+        sketch_fingerprint.as_bytes(),
+        library_fingerprint.as_bytes(),
+    ])
 }
 
 /// Canonicalize and lexically normalize, stripping the Windows `\\?\`
@@ -623,64 +884,30 @@ fn normalize_prefix_map_to(prefix: &str) -> String {
     normalized
 }
 
-fn hash_files(root: &Path, files: &[PathBuf]) -> Result<String> {
-    let mut hasher = Sha256::new();
-    for path in files {
-        let full = if path.is_absolute() {
-            path.clone()
-        } else {
-            root.join(path)
-        };
-        if full.is_file() {
-            hasher.update(
-                full.strip_prefix(root)
-                    .unwrap_or(&full)
-                    .to_string_lossy()
-                    .as_bytes(),
-            );
-            hasher.update(fs::metadata(&full)?.len().to_string().as_bytes());
-            hasher.update(fs::read(&full)?);
-        }
-    }
-    Ok(format!("{:x}", hasher.finalize()))
-}
-
-fn collect_source_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    if !dir.is_dir() {
-        return Ok(());
-    }
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if path.is_dir() {
-            if name == ".git" || name == ".build" || name == "build" || name == "fastled_js" {
-                continue;
-            }
-            collect_source_files(root, &path, out)?;
-        } else if matches!(
-            path.extension().and_then(|ext| ext.to_str()),
-            Some("cpp" | "c" | "h" | "hpp" | "ipp" | "toml" | "build")
-        ) {
-            out.push(path.strip_prefix(root).unwrap_or(&path).to_path_buf());
-        }
-    }
-    Ok(())
-}
-
 fn compute_source_file_hash(fastled_dir: &Path) -> Result<String> {
-    let mut files = Vec::new();
-    collect_source_files(fastled_dir, &fastled_dir.join("src"), &mut files)?;
-    for path in [
-        "meson.build",
-        "ci/meson/wasm/meson.build",
-        "ci/meson/wasm_cross_file.ini",
-    ] {
-        files.push(PathBuf::from(path));
-    }
-    files.sort();
-    hash_files(fastled_dir, &files)
+    dynamic_cache::fingerprint_tree(
+        fastled_dir,
+        &[
+            "src/**/*.cpp",
+            "src/**/*.cc",
+            "src/**/*.cxx",
+            "src/**/*.c",
+            "src/**/*.h",
+            "src/**/*.hpp",
+            "src/**/*.hxx",
+            "src/**/*.ipp",
+            "src/**/*.toml",
+            "src/**/*.build",
+            "src/platforms/wasm/compiler/js_library.js",
+            "meson.build",
+            "meson_options.txt",
+            "ci/meson/**/meson.build",
+            "ci/meson/**/*.py",
+            "ci/wasm_flags.py",
+            "ci/meson/wasm_cross_file.ini",
+        ],
+        &[".git/**", ".build/**", "build/**", "fastled_js/**"],
+    )
 }
 
 fn write_native_cross_file(fastled_dir: &Path, tools: &ToolPaths) -> Result<PathBuf> {
@@ -733,10 +960,11 @@ fn ensure_meson_configured(
     mode: BuildMode,
     link_mode: LinkMode,
     force: bool,
+    source_fingerprint: &str,
     log: LogSink,
 ) -> Result<()> {
     let marker = build_dir.join(".src_file_list_hash");
-    let current_hash = compute_source_file_hash(fastled_dir)?;
+    let current_hash = source_fingerprint;
     if build_dir.join("build.ninja").is_file() && !force {
         let stored = fs::read_to_string(&marker).unwrap_or_default();
         if stored.trim() == current_hash {
@@ -781,16 +1009,26 @@ fn library_archive(build_dir: &Path) -> PathBuf {
         .join("libfastled.a")
 }
 
+fn library_archive_is_valid(path: &Path) -> bool {
+    let mut magic = [0_u8; 8];
+    path.metadata().is_ok_and(|metadata| metadata.len() > 8)
+        && fs::File::open(path)
+            .and_then(|mut file| std::io::Read::read_exact(&mut file, &mut magic))
+            .is_ok()
+        && (magic == *b"!<arch>\n" || magic == *b"!<thin>\n")
+}
+
 fn build_library(
     fastled_dir: &Path,
     tools: &ToolPaths,
     build_dir: &Path,
+    source_fingerprint: &str,
     log: LogSink,
 ) -> Result<bool> {
     let archive = library_archive(build_dir);
     let fingerprint_path = build_dir.join("library_src_fingerprint");
-    let current = compute_source_file_hash(fastled_dir)?;
-    if archive.is_file()
+    let current = source_fingerprint;
+    if library_archive_is_valid(&archive)
         && fingerprint_path.is_file()
         && fs::read_to_string(&fingerprint_path)
             .unwrap_or_default()
@@ -799,6 +1037,12 @@ fn build_library(
     {
         log("[WASM] Library up-to-date", "stdout");
         return Ok(false);
+    }
+    if archive.exists() && !library_archive_is_valid(&archive) {
+        log(
+            "[WASM] Invalid or truncated libfastled.a; rebuilding library",
+            "stdout",
+        );
     }
     if archive.exists() {
         fs::remove_file(&archive).ok();
@@ -814,6 +1058,12 @@ fn build_library(
     }
     log("[WASM] Building libfastled.a...", "stdout");
     run_status(command, "meson compile fastled", log)?;
+    if !library_archive_is_valid(&archive) {
+        bail!(
+            "meson reported success but produced an invalid archive at {}",
+            archive.display()
+        );
+    }
     fs::write(fingerprint_path, current)?;
     log("[WASM] Library build successful", "stdout");
     Ok(true)
@@ -877,6 +1127,7 @@ fn build_sketch_pch(
     mode: BuildMode,
     emsdk_root: Option<&Path>,
     lib_was_rebuilt: bool,
+    source_fingerprint: &str,
     log: LogSink,
 ) -> Result<Option<PathBuf>> {
     let pcm = build_dir.join("wasm_pch.h.pcm");
@@ -898,7 +1149,7 @@ fn build_sketch_pch(
     };
     let compile_flags = get_sketch_compile_flags(fastled_dir, mode, Some(&dwarf_roots))?;
     let mut hash_input = compile_flags.join("\n");
-    hash_input.push_str(&compute_source_file_hash(fastled_dir)?);
+    hash_input.push_str(source_fingerprint);
     let current_hash = format!("{:x}", Sha256::digest(hash_input.as_bytes()));
     if !lib_was_rebuilt
         && pcm.is_file()
@@ -974,40 +1225,58 @@ fn compile_sketch(
     mode: BuildMode,
     link_mode: LinkMode,
     dwarf_roots: &DwarfPathRoots,
+    fingerprints: &BuildFingerprints,
     log: LogSink,
-) -> Result<PathBuf> {
+) -> Result<CompiledSketch> {
     let fastled_dir = &dwarf_roots.fastled_dir;
-    let object = sketch_cache_dir.join("sketch.o");
-    let archive = library_archive(build_dir);
-    let ino = sketch_ino_file(example_dir)?;
     let compile_flags = get_sketch_compile_flags(fastled_dir, mode, Some(dwarf_roots))?;
-    let flags_hash_path = sketch_cache_dir.join("sketch_compile_flags.hash");
-    let mut hash_input = compile_flags.join("\n");
-    hash_input.push_str(&format!("\nlink-mode={link_mode:?}"));
-    let current_flags_hash = format!("{:x}", Sha256::digest(hash_input.as_bytes()));
-    if object.is_file() {
-        let object_mtime = object.metadata()?.modified()?;
-        let inputs = [wrapper, &ino, &archive];
-        if fs::read_to_string(&flags_hash_path)
-            .unwrap_or_default()
-            .trim()
-            == current_flags_hash
-            && inputs
-                .iter()
-                .filter_map(|path| path.metadata().ok())
-                .filter_map(|metadata| metadata.modified().ok())
-                .all(|mtime| mtime <= object_mtime)
-        {
-            log("[WASM] Sketch is up-to-date", "stdout");
-            return Ok(object);
-        }
+    let source_fingerprint = dynamic_cache::fingerprint_tree(
+        example_dir,
+        &[
+            "**/*.ino", "**/*.cpp", "**/*.c", "**/*.h", "**/*.hpp", "**/*.ipp",
+        ],
+        &[".git/**", ".build/**", "fastled_js/**"],
+    )?;
+    let fastled_fingerprint = &fingerprints.fastled_source;
+    let toolchain_fingerprint = &fingerprints.toolchain;
+    let wrapper_contents = fs::read(wrapper)
+        .with_context(|| format!("read generated wrapper {}", wrapper.display()))?;
+    let compile_flag_blob = compile_flags.join("\n");
+    let link_mode_value = format!("link-mode={link_mode:?}");
+    let object_fingerprint = dynamic_cache::fingerprint_values([
+        source_fingerprint.as_bytes(),
+        fastled_fingerprint.as_bytes(),
+        toolchain_fingerprint.as_bytes(),
+        compile_flag_blob.as_bytes(),
+        link_mode_value.as_bytes(),
+        wrapper_contents.as_slice(),
+    ]);
+    let object_root = sketch_cache_dir.join("object-cache");
+    let object_entry = dynamic_cache::entry_path(&object_root, &object_fingerprint);
+    let object = object_entry.join("sketch.o");
+    let _lock = dynamic_cache::CacheLock::acquire(&object_root, &object_fingerprint)?;
+    if dynamic_cache::validate_entry(&object_entry, &object_fingerprint, &["sketch.o"]).is_ok() {
+        log(
+            &format!(
+                "[WASM] Sketch object cache hit: {}",
+                &object_fingerprint[..12]
+            ),
+            "stdout",
+        );
+        return Ok(CompiledSketch {
+            object,
+            fingerprint: object_fingerprint,
+        });
     }
+
+    let staging = dynamic_cache::staging_dir(&object_root, ".object-staging-")?;
+    let staging_object = staging.path().join("sketch.o");
 
     let mut args = vec![
         "-c".to_string(),
         wrapper.display().to_string(),
         "-o".to_string(),
-        object.display().to_string(),
+        staging_object.display().to_string(),
     ];
     args.extend(compile_flags);
     if link_mode == LinkMode::Dynamic {
@@ -1039,34 +1308,43 @@ fn compile_sketch(
         .arg(&tools.empp)
         .args(&args);
     run_status(command, "em++ sketch compile", log)?;
-    fs::write(flags_hash_path, current_flags_hash)?;
-    Ok(object)
+    dynamic_cache::write_metadata(staging.path(), &object_fingerprint, &["sketch.o"])?;
+    dynamic_cache::publish_staging(staging, &object_entry)?;
+    dynamic_cache::validate_entry(&object_entry, &object_fingerprint, &["sketch.o"])
+        .map_err(anyhow::Error::msg)?;
+    Ok(CompiledSketch {
+        object,
+        fingerprint: object_fingerprint,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
 fn link_wasm(
     fastled_dir: &Path,
     tools: &ToolPaths,
-    sketch_object: &Path,
+    sketch: &CompiledSketch,
     build_dir: &Path,
     sketch_cache_dir: &Path,
     output_js: &Path,
     mode: BuildMode,
     link_mode: LinkMode,
+    fingerprints: &BuildFingerprints,
     log: LogSink,
 ) -> Result<()> {
     if link_mode == LinkMode::Dynamic {
         return link_wasm_dynamic(
             fastled_dir,
             tools,
-            sketch_object,
+            sketch,
             build_dir,
             sketch_cache_dir,
             output_js,
             mode,
+            fingerprints,
             log,
         );
     }
+    let sketch_object = &sketch.object;
     let archive = library_archive(build_dir);
     let cached_js = sketch_cache_dir.join("fastled.js");
     let cached_wasm = sketch_cache_dir.join("fastled.wasm");
@@ -1079,24 +1357,18 @@ fn link_wasm(
     }
     let link_flags = get_link_flags(fastled_dir, mode)?;
     let flags_hash_path = sketch_cache_dir.join("link_flags.hash");
-    let current_flags_hash = format!("{:x}", Sha256::digest(link_flags.join("\n").as_bytes()));
-    if cached_js.is_file() && cached_wasm.is_file() {
-        let output_mtime = cached_js.metadata()?.modified()?;
-        let inputs = [sketch_object, &archive];
-        if fs::read_to_string(&flags_hash_path)
+    let current_flags_hash =
+        static_link_fingerprint(&link_flags, &sketch.fingerprint, &fingerprints.library);
+    if cached_js.is_file()
+        && cached_wasm.is_file()
+        && fs::read_to_string(&flags_hash_path)
             .unwrap_or_default()
             .trim()
             == current_flags_hash
-            && inputs
-                .iter()
-                .filter_map(|path| path.metadata().ok())
-                .filter_map(|metadata| metadata.modified().ok())
-                .all(|mtime| mtime <= output_mtime)
-        {
-            copy_linked_output(sketch_cache_dir, output_js)?;
-            log("[WASM] Link output up-to-date", "stdout");
-            return Ok(());
-        }
+    {
+        copy_linked_output(sketch_cache_dir, output_js)?;
+        log("[WASM] Link output up-to-date", "stdout");
+        return Ok(());
     }
 
     let js_library = fastled_dir
@@ -1195,6 +1467,31 @@ fn copy_linked_output(sketch_cache_dir: &Path, output_js: &Path) -> Result<()> {
                 .with_context(|| format!("copy {} to {}", src.display(), output_dir.display()))?;
         } else if dst.exists() {
             fs::remove_file(&dst).with_context(|| format!("remove stale {}", dst.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dynamic_output(runtime_entry: &Path, sketch_entry: &Path, output_js: &Path) -> Result<()> {
+    let output_dir = output_js
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("output path has no parent: {}", output_js.display()))?;
+    fs::create_dir_all(output_dir)?;
+    for (source_dir, name) in [
+        (runtime_entry, "fastled.js"),
+        (runtime_entry, "fastled.wasm"),
+        (runtime_entry, "fastled.wasm.map"),
+        (runtime_entry, "fastled.js.map"),
+        (sketch_entry, "sketch.wasm"),
+    ] {
+        let source = source_dir.join(name);
+        let target = output_dir.join(name);
+        if source.is_file() {
+            fs::copy(&source, &target)
+                .with_context(|| format!("copy {} to {}", source.display(), target.display()))?;
+        } else if target.exists() {
+            fs::remove_file(&target)
+                .with_context(|| format!("remove stale {}", target.display()))?;
         }
     }
     Ok(())
@@ -1367,6 +1664,33 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
 
     let build_result = (|| -> Result<()> {
         let build_dir = build_dir(&fastled_dir, request.build_mode, request.link_mode);
+        let sketch_cache = sketch_cache_dir(&example_dir);
+        if request.force_clean {
+            for cache in [
+                build_dir.join("dynamic-runtime-cache"),
+                sketch_cache.join("dynamic-sketch-cache"),
+                sketch_cache.join("object-cache"),
+            ] {
+                if cache.exists() {
+                    fs::remove_dir_all(&cache)
+                        .with_context(|| format!("purge {}", cache.display()))?;
+                }
+            }
+        }
+        let fingerprint_start = std::time::Instant::now();
+        let fingerprints = BuildFingerprints::compute(
+            &fastled_dir,
+            &tools,
+            request.build_mode,
+            request.link_mode,
+        )?;
+        log(
+            &format!(
+                "[WASM] Build fingerprints computed ({:.2}s)",
+                fingerprint_start.elapsed().as_secs_f64()
+            ),
+            "stdout",
+        );
         ensure_meson_configured(
             &fastled_dir,
             &tools,
@@ -1374,9 +1698,11 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             request.build_mode,
             request.link_mode,
             request.force_clean,
+            &fingerprints.library,
             log,
         )?;
-        let lib_rebuilt = build_library(&fastled_dir, &tools, &build_dir, log)?;
+        let lib_rebuilt =
+            build_library(&fastled_dir, &tools, &build_dir, &fingerprints.library, log)?;
         let _ = build_sketch_pch(
             &fastled_dir,
             &tools,
@@ -1384,9 +1710,9 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             request.build_mode,
             emsdk_root.as_deref(),
             lib_rebuilt,
+            &fingerprints.library,
             log,
         );
-        let sketch_cache = sketch_cache_dir(&example_dir);
         let wrapper = create_wrapper(&example_dir, &example_name, &sketch_cache)?;
         let sketch_dwarf_roots = DwarfPathRoots {
             sketch_dir: Some(example_dir.clone()),
@@ -1402,6 +1728,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             request.build_mode,
             request.link_mode,
             &sketch_dwarf_roots,
+            &fingerprints,
             log,
         )?;
         let output_js = output_dir.join("fastled.js");
@@ -1414,6 +1741,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &output_js,
             request.build_mode,
             request.link_mode,
+            &fingerprints,
             log,
         )?;
         if request.no_app {
@@ -1615,6 +1943,70 @@ mod tests {
             "-sWASM_BIGINT=0"
         );
         assert_eq!(dynamic_wasm_bigint_flag(&[]), "-sWASM_BIGINT=1");
+    }
+
+    #[test]
+    fn static_link_fingerprint_tracks_sketch_library_and_flags() {
+        let baseline = static_link_fingerprint(&["-O0".to_string()], "sketch-a", "library-a");
+        assert_ne!(
+            baseline,
+            static_link_fingerprint(&["-O1".to_string()], "sketch-a", "library-a")
+        );
+        assert_ne!(
+            baseline,
+            static_link_fingerprint(&["-O0".to_string()], "sketch-b", "library-a")
+        );
+        assert_ne!(
+            baseline,
+            static_link_fingerprint(&["-O0".to_string()], "sketch-a", "library-b")
+        );
+    }
+
+    #[test]
+    fn runtime_source_fingerprint_includes_js_library_and_meson_helpers() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for (relative, contents) in [
+            ("src/core.cpp", "core"),
+            ("src/platforms/wasm/compiler/js_library.js", "js-v1"),
+            ("meson.build", "root-meson"),
+            ("meson_options.txt", "options"),
+            ("ci/meson/wasm/meson.build", "wasm-meson"),
+            ("ci/meson/rglob.py", "rglob-v1"),
+            ("ci/wasm_flags.py", "flags-v1"),
+            ("ci/meson/wasm_cross_file.ini", "cross"),
+        ] {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, contents).unwrap();
+        }
+
+        let baseline = compute_source_file_hash(root).unwrap();
+        fs::write(
+            root.join("src/platforms/wasm/compiler/js_library.js"),
+            "js-v2",
+        )
+        .unwrap();
+        let js_changed = compute_source_file_hash(root).unwrap();
+        assert_ne!(baseline, js_changed);
+
+        fs::write(root.join("ci/meson/rglob.py"), "rglob-v2").unwrap();
+        assert_ne!(js_changed, compute_source_file_hash(root).unwrap());
+    }
+
+    #[test]
+    fn library_archive_validation_rejects_missing_empty_and_truncated_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("libfastled.a");
+        assert!(!library_archive_is_valid(&archive));
+        fs::write(&archive, []).unwrap();
+        assert!(!library_archive_is_valid(&archive));
+        fs::write(&archive, b"!<arch>").unwrap();
+        assert!(!library_archive_is_valid(&archive));
+        fs::write(&archive, b"!<arch>\nmember").unwrap();
+        assert!(library_archive_is_valid(&archive));
+        fs::write(&archive, b"!<thin>\nmember").unwrap();
+        assert!(library_archive_is_valid(&archive));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cache `fastled.js` + `fastled.wasm` as a sketch-independent `MAIN_MODULE=1` runtime
- build and cache `sketch.wasm` independently with `SIDE_MODULE=1`, loaded by the generated JavaScript API
- fingerprint FastLED, sketch, flags, ABI, generated cross-file, environment, and toolchain inputs with `zccache-fingerprint`
- add per-key locking, staged atomic publication, artifact validation, failure state, purge integration, and corruption recovery
- add the requested transition matrix plus real Chrome coverage for app, `--no-app`, `sketch_assets.json`, and legacy `files.json`

## Validation
- `soldr cargo test --workspace` (175 unit tests + 2 viewer tests + doctest)
- `uv run --no-project pytest -q` (18 passed)
- release real-Chrome dynamic app smoke
- release real-Chrome dynamic no-app smoke
- release real-Chrome legacy `files.json` smoke
- formatting, JavaScript syntax, and diff checks

## Quick-mode benchmark
Release CLI, local FastLED `examples/wasm`, median of 3 runs:

| scenario | static | dynamic |
|---|---:|---:|
| warm no-op | 1.70s | 1.46s |
| sketch edit | 5.91s | 3.62s |

Dynamic sketch edits were about 39% faster. The SHA-256 of `fastled.wasm` remained identical across all dynamic sketch edits, proving that only the sketch unit was rebuilt/relinked.

Closes #188