### PR TITLE
perf(cli): accelerate dynamic sketch rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +726,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1145,6 +1167,7 @@ dependencies = [
  "dirs 5.0.1",
  "flate2",
  "fs2",
+ "globset",
  "indexmap 1.9.3",
  "notify",
  "reqwest 0.12.28",
@@ -1152,6 +1175,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shell-words",
  "strsim",
  "tar",
  "tauri",
@@ -2321,6 +2345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2447,15 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2613,6 +2656,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4988,6 +5040,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6532,8 +6604,8 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.1.8"
-source = "git+https://github.com/zackees/zccache?rev=7721650d587085de3dc5d4ca77399c7ee2fa4fff#7721650d587085de3dc5d4ca77399c7ee2fa4fff"
+version = "1.1.10"
+source = "git+https://github.com/zackees/zccache?rev=1bd5b6387eff54695e37adbfacbb977079d6f174#1bd5b6387eff54695e37adbfacbb977079d6f174"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6543,24 +6615,27 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.1.8"
-source = "git+https://github.com/zackees/zccache?rev=7721650d587085de3dc5d4ca77399c7ee2fa4fff#7721650d587085de3dc5d4ca77399c7ee2fa4fff"
+version = "1.1.10"
+source = "git+https://github.com/zackees/zccache?rev=1bd5b6387eff54695e37adbfacbb977079d6f174#1bd5b6387eff54695e37adbfacbb977079d6f174"
 dependencies = [
  "clap",
  "fs2",
  "globset",
+ "jwalk",
+ "mimalloc",
+ "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tracing",
- "walkdir",
  "zccache-hash",
 ]
 
 [[package]]
 name = "zccache-hash"
-version = "1.1.8"
-source = "git+https://github.com/zackees/zccache?rev=7721650d587085de3dc5d4ca77399c7ee2fa4fff#7721650d587085de3dc5d4ca77399c7ee2fa4fff"
+version = "1.1.10"
+source = "git+https://github.com/zackees/zccache?rev=1bd5b6387eff54695e37adbfacbb977079d6f174#1bd5b6387eff54695e37adbfacbb977079d6f174"
 dependencies = [
  "blake3",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,10 @@ toml = "0.8"
 tauri = { version = "2", features = ["devtools"] }
 tauri-build = { version = "2", features = [] }
 windows-sys = "0.61"
-# Last zccache-fingerprint revision compatible with this workspace's Rust 1.85 MSRV.
-zccache-fingerprint = { git = "https://github.com/zackees/zccache", rev = "7721650d587085de3dc5d4ca77399c7ee2fa4fff" }
+# Parallel content-authoritative walker/hasher; remains compatible with Rust 1.85.
+zccache-fingerprint = { git = "https://github.com/zackees/zccache", rev = "1bd5b6387eff54695e37adbfacbb977079d6f174" }
+shell-words = "1"
+globset = "0.4"
 
 [profile.release]
 debug = "line-tables-only"

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -46,6 +46,8 @@ toml = { workspace = true }
 tauri = { workspace = true, optional = true }
 tempfile = "3"
 zccache-fingerprint = { workspace = true }
+shell-words = { workspace = true }
+globset = { workspace = true }
 
 [build-dependencies]
 indexmap = { version = "1.9.3", features = ["std"] }

--- a/crates/fastled-cli/src/archive.rs
+++ b/crates/fastled-cli/src/archive.rs
@@ -258,6 +258,9 @@ pub fn write_emscripten_config(install_dir: &Path, node_path: &str) -> Result<()
     );
 
     let config_path = install_dir.join(".emscripten");
+    if fs::read_to_string(&config_path).ok().as_deref() == Some(config.as_str()) {
+        return Ok(());
+    }
     fs::write(&config_path, config)
         .with_context(|| format!("cannot write {}", config_path.display()))?;
 
@@ -504,6 +507,19 @@ mod tests {
             contents.contains(node),
             "config should contain the node path ({node}): {contents}"
         );
+    }
+
+    #[test]
+    fn test_write_emscripten_config_does_not_touch_unchanged_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let install_dir = dir.path().join("emscripten").join("4.0.19");
+        fs::create_dir_all(&install_dir).unwrap();
+        write_emscripten_config(&install_dir, "node").unwrap();
+        let path = install_dir.join(".emscripten");
+        let first = path.metadata().unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        write_emscripten_config(&install_dir, "node").unwrap();
+        assert_eq!(first, path.metadata().unwrap().modified().unwrap());
     }
 
     // ------------------------------------------------------------------

--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -89,6 +89,9 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
         };
 
         // --- Initial compilation ------------------------------------------------
+        // This process stays alive for rebuilds. Keep authoritative startup
+        // fingerprints in memory and invalidate them from filesystem events.
+        std::env::set_var("FASTLED_PERSISTENT_FINGERPRINTS", "1");
         send_sse(
             &tx,
             r#"{"type":"status","status":"compiling","message":"Compiling..."}"#,

--- a/crates/fastled-cli/src/dynamic_cache.rs
+++ b/crates/fastled-cli/src/dynamic_cache.rs
@@ -2,8 +2,12 @@ use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::Read;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{Context, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -14,14 +18,130 @@ const METADATA_FILE: &str = "cache-metadata.json";
 
 pub(crate) const DYNAMIC_LOADER_JS: &str = include_str!("../assets/dynamic_loader.js");
 
-/// Hash a selected source tree with zccache's content-authoritative scanner.
-/// Paths, file count, and bytes all participate, so additions, deletions, and
-/// same-size edits with restored mtimes cannot produce a false cache hit.
-pub(crate) fn fingerprint_tree(root: &Path, include: &[&str], exclude: &[&str]) -> Result<String> {
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct FingerprintSpec {
+    root: NormalizedPath,
+    include: Vec<String>,
+    exclude: Vec<String>,
+}
+
+struct WatchedFingerprint {
+    value: String,
+    observed_generation: u64,
+    generation: Arc<AtomicU64>,
+    _watcher: RecommendedWatcher,
+}
+
+static FINGERPRINT_CACHE: OnceLock<
+    Mutex<std::collections::HashMap<FingerprintSpec, WatchedFingerprint>>,
+> = OnceLock::new();
+
+fn build_glob_set(patterns: &[String], default_all: bool) -> Result<GlobSet> {
+    let mut builder = GlobSetBuilder::new();
+    if patterns.is_empty() && default_all {
+        builder.add(Glob::new("**/*")?);
+    } else {
+        for pattern in patterns {
+            builder.add(Glob::new(pattern)?);
+        }
+    }
+    Ok(builder.build()?)
+}
+
+fn mark_fingerprint_dirty(generation: &AtomicU64) {
+    generation.fetch_add(1, Ordering::Release);
+}
+
+fn create_fingerprint_watcher(
+    spec: &FingerprintSpec,
+    generation: Arc<AtomicU64>,
+) -> Result<RecommendedWatcher> {
+    let root = spec.root.clone();
+    let include = build_glob_set(&spec.include, true)?;
+    let exclude = build_glob_set(&spec.exclude, false)?;
+    let callback_generation = Arc::clone(&generation);
+    let mut watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+        let relevant = match result {
+            Err(_) => true, // overflow/backend uncertainty: force a full rescan
+            Ok(event) => {
+                matches!(
+                    event.kind,
+                    EventKind::Create(_)
+                        | EventKind::Modify(_)
+                        | EventKind::Remove(_)
+                        | EventKind::Any
+                ) && event.paths.iter().any(|path| {
+                    let relative = path.strip_prefix(root.as_path()).unwrap_or(path);
+                    include.is_match(relative) && !exclude.is_match(relative)
+                })
+            }
+        };
+        if relevant {
+            mark_fingerprint_dirty(&callback_generation);
+        }
+    })?;
+    watcher.watch(spec.root.as_path(), RecursiveMode::Recursive)?;
+    Ok(watcher)
+}
+
+fn compute_tree_fingerprint(root: &Path, include: &[&str], exclude: &[&str]) -> Result<String> {
     let files = zccache_fingerprint::walk_files_glob(root, include, exclude)
         .with_context(|| format!("scan fingerprint inputs under {}", root.display()))?;
     zccache_fingerprint::compute_aggregate_hash(&files)
         .with_context(|| format!("hash fingerprint inputs under {}", root.display()))
+}
+
+/// Hash a selected source tree with zccache's content-authoritative scanner.
+/// Paths, file count, and bytes all participate, so additions, deletions, and
+/// same-size edits with restored mtimes cannot produce a false cache hit.
+pub(crate) fn fingerprint_tree(root: &Path, include: &[&str], exclude: &[&str]) -> Result<String> {
+    if std::env::var_os("FASTLED_PERSISTENT_FINGERPRINTS").is_none() {
+        return compute_tree_fingerprint(root, include, exclude);
+    }
+
+    let spec = FingerprintSpec {
+        root: NormalizedPath::new(root),
+        include: include.iter().map(|value| (*value).to_string()).collect(),
+        exclude: exclude.iter().map(|value| (*value).to_string()).collect(),
+    };
+    let cache = FINGERPRINT_CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("persistent fingerprint cache lock poisoned"))?;
+
+    if let Some(entry) = cache.get_mut(&spec) {
+        let current = entry.generation.load(Ordering::Acquire);
+        if current == entry.observed_generation {
+            return Ok(entry.value.clone());
+        }
+        // If writes continue during the scan, leave the generation stale so
+        // the next build performs another authoritative scan.
+        let before = current;
+        let value = compute_tree_fingerprint(root, include, exclude)?;
+        let after = entry.generation.load(Ordering::Acquire);
+        entry.value = value.clone();
+        entry.observed_generation = if before == after { after } else { before };
+        return Ok(value);
+    }
+
+    let generation = Arc::new(AtomicU64::new(0));
+    let watcher = match create_fingerprint_watcher(&spec, Arc::clone(&generation)) {
+        Ok(watcher) => watcher,
+        Err(_) => return compute_tree_fingerprint(root, include, exclude),
+    };
+    let before = generation.load(Ordering::Acquire);
+    let value = compute_tree_fingerprint(root, include, exclude)?;
+    let after = generation.load(Ordering::Acquire);
+    cache.insert(
+        spec,
+        WatchedFingerprint {
+            value: value.clone(),
+            observed_generation: if before == after { after } else { before },
+            generation,
+            _watcher: watcher,
+        },
+    );
+    Ok(value)
 }
 
 pub(crate) fn fingerprint_values<'a>(values: impl IntoIterator<Item = &'a [u8]>) -> String {
@@ -304,6 +424,24 @@ mod tests {
         fs::remove_file(temp.path().join("b.cpp")).unwrap();
         let second = fingerprint_tree(temp.path(), &["**/*.cpp"], &[]).unwrap();
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn watcher_error_or_overflow_marks_fingerprint_dirty() {
+        let generation = AtomicU64::new(7);
+        mark_fingerprint_dirty(&generation);
+        assert_eq!(generation.load(Ordering::Acquire), 8);
+    }
+
+    #[test]
+    fn watcher_globs_match_selected_files_and_ignore_build_outputs() {
+        let include = build_glob_set(&["emscripten/emcc.py".to_string()], false).unwrap();
+        assert!(include.is_match(Path::new("emscripten/emcc.py")));
+        if cfg!(windows) {
+            assert!(include.is_match(Path::new(r"emscripten\emcc.py")));
+        }
+        let exclude = build_glob_set(&[".build/**".to_string()], false).unwrap();
+        assert!(exclude.is_match(Path::new(".build/wasm/sketch.o")));
     }
 
     #[test]

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -10,6 +10,8 @@ use std::fs;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use ctcb_core::Target;
@@ -49,6 +51,10 @@ const EMSCRIPTEN_MANIFEST_BASE_URL: &str =
     "https://raw.githubusercontent.com/zackees/clang-tool-chain-bins/main/assets/emscripten";
 
 const ESBUILD_VERSION: &str = "0.28.0";
+const EMSCRIPTEN_MANIFEST_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const EMSCRIPTEN_VERSION_MARKER: &str = ".fastled-manifest-version";
+
+static EMSCRIPTEN_INSTALL_CACHE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 
 const FASTLED_REPO: &str = "FastLED/FastLED";
 const FASTLED_LATEST_RELEASE_API: &str =
@@ -252,6 +258,69 @@ fn ensure_toolchain_executables(_install_dir: &Path) -> Result<()> {
 /// The layout intentionally matches the Python implementation so a previously
 /// Python-installed toolchain is picked up without re-downloading.
 pub fn ensure_emscripten_installed() -> Result<PathBuf> {
+    let cache = EMSCRIPTEN_INSTALL_CACHE.get_or_init(|| Mutex::new(None));
+    let mut cached = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("emscripten install cache lock poisoned"))?;
+    if let Some(path) = cached
+        .as_ref()
+        .filter(|path| path.join("done.txt").is_file())
+    {
+        return Ok(path.clone());
+    }
+    let installed = ensure_emscripten_installed_uncached()?;
+    *cached = Some(installed.clone());
+    Ok(installed)
+}
+
+fn cached_installed_toolchain(install_base: &Path) -> Option<PathBuf> {
+    let marker = install_base.join(EMSCRIPTEN_VERSION_MARKER);
+    if marker.is_file()
+        && marker.metadata().ok()?.modified().ok()?.elapsed().ok()? <= EMSCRIPTEN_MANIFEST_TTL
+    {
+        let version = fs::read_to_string(&marker).ok()?;
+        let install = install_base.join(version.trim());
+        if install.join("done.txt").is_file() {
+            return Some(install);
+        }
+    }
+
+    // Existing installations predate the marker. Reuse the newest complete
+    // install immediately and begin the 24-hour refresh window; a warm build
+    // must not require the network merely to rediscover a local toolchain.
+    if !marker.exists() {
+        if let Some(install) = newest_complete_install(install_base) {
+            let version = install.file_name()?.to_string_lossy();
+            fs::write(&marker, format!("{version}\n")).ok()?;
+            return Some(install);
+        }
+    }
+    None
+}
+
+fn newest_complete_install(install_base: &Path) -> Option<PathBuf> {
+    let mut candidates = fs::read_dir(install_base)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().join("done.txt").is_file())
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|(modified, _)| *modified);
+    candidates.pop().map(|(_, path)| path)
+}
+
+fn record_manifest_version(install_base: &Path, version: &str) -> Result<()> {
+    fs::write(
+        install_base.join(EMSCRIPTEN_VERSION_MARKER),
+        format!("{version}\n"),
+    )?;
+    Ok(())
+}
+
+fn ensure_emscripten_installed_uncached() -> Result<PathBuf> {
     let (platform, arch) = detect_platform_arch()?;
     let root = fastled_root()?;
     let install_base = root
@@ -263,13 +332,28 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     fs::create_dir_all(&install_base)?;
     fs::create_dir_all(&cache_dir)?;
 
+    if let Some(install_dir) = cached_installed_toolchain(&install_base) {
+        ensure_toolchain_executables(&install_dir)?;
+        return Ok(install_dir);
+    }
+
     let manifest_url = format!("{EMSCRIPTEN_MANIFEST_BASE_URL}/{platform}/{arch}/manifest.json");
-    let manifest = fetch_manifest(&manifest_url)?;
+    let manifest = match fetch_manifest(&manifest_url) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            if let Some(install_dir) = newest_complete_install(&install_base) {
+                ensure_toolchain_executables(&install_dir)?;
+                return Ok(install_dir);
+            }
+            return Err(error);
+        }
+    };
     let version = manifest.latest.clone();
     let install_dir = install_base.join(&version);
     let done_file = install_dir.join("done.txt");
     if done_file.exists() {
         ensure_toolchain_executables(&install_dir)?;
+        record_manifest_version(&install_base, &version)?;
         return Ok(install_dir);
     }
 
@@ -318,6 +402,7 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     fs::rename(&staging, &install_dir)?;
 
     archive::write_emscripten_config(&install_dir, "node")?;
+    record_manifest_version(&install_base, &version)?;
 
     Ok(install_dir)
 }
@@ -1291,6 +1376,22 @@ mod tests {
         );
         assert!(entry.parts.is_none());
         assert!(multipart_parts(entry).is_none());
+    }
+
+    #[test]
+    fn cached_install_avoids_manifest_fetch_until_ttl_expires() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = temp.path().join("4.0.19");
+        fs::create_dir_all(&install).unwrap();
+        fs::write(install.join("done.txt"), "ok\n").unwrap();
+
+        let found = cached_installed_toolchain(temp.path()).expect("installed toolchain");
+        assert_eq!(found, install);
+        assert_eq!(
+            fs::read_to_string(temp.path().join(EMSCRIPTEN_VERSION_MARKER)).unwrap(),
+            "4.0.19\n"
+        );
+        assert_eq!(cached_installed_toolchain(temp.path()), Some(install));
     }
 
     #[test]

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::cli::LinkMode;
@@ -83,6 +83,11 @@ struct ToolPaths {
     emcc: PathBuf,
     empp: PathBuf,
     emar: PathBuf,
+    clangpp: PathBuf,
+    wasm_ld: PathBuf,
+    llvm_objcopy: PathBuf,
+    wasm_finalize: PathBuf,
+    emscripten_version: String,
     python: PathBuf,
 }
 
@@ -91,6 +96,8 @@ struct BuildFingerprints {
     fastled_source: String,
     toolchain: String,
     library: String,
+    source_duration_secs: f64,
+    toolchain_duration_secs: f64,
 }
 
 #[derive(Debug)]
@@ -106,8 +113,26 @@ impl BuildFingerprints {
         mode: BuildMode,
         link_mode: LinkMode,
     ) -> Result<Self> {
-        let fastled_source = compute_source_file_hash(fastled_dir)?;
-        let toolchain = toolchain_fingerprint(tools)?;
+        let ((fastled_source, source_duration_secs), (toolchain, toolchain_duration_secs)) =
+            std::thread::scope(|scope| {
+                let source = scope.spawn(|| {
+                    let started = std::time::Instant::now();
+                    compute_source_file_hash(fastled_dir)
+                        .map(|value| (value, started.elapsed().as_secs_f64()))
+                });
+                let toolchain = scope.spawn(|| {
+                    let started = std::time::Instant::now();
+                    toolchain_fingerprint(tools)
+                        .map(|value| (value, started.elapsed().as_secs_f64()))
+                });
+                let source = source
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("FastLED fingerprint worker panicked"))??;
+                let toolchain = toolchain
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("toolchain fingerprint worker panicked"))??;
+                Ok::<_, anyhow::Error>((source, toolchain))
+            })?;
         let mode_value = format!("mode={};link-mode={link_mode:?}", mode.as_str());
         let library = dynamic_cache::fingerprint_values([
             fastled_source.as_bytes(),
@@ -118,6 +143,8 @@ impl BuildFingerprints {
             fastled_source,
             toolchain,
             library,
+            source_duration_secs,
+            toolchain_duration_secs,
         })
     }
 }
@@ -190,6 +217,25 @@ fn resolve_tool_paths(install_dir: &Path) -> Result<ToolPaths> {
     let emcc = emscripten_dir.join("emcc.py");
     let empp = emscripten_dir.join("em++.py");
     let emar = emscripten_dir.join("emar.py");
+    let clangpp = install_dir.join("bin").join(if cfg!(windows) {
+        "clang++.exe"
+    } else {
+        "clang++"
+    });
+    let tool_name = |name: &str| {
+        install_dir.join("bin").join(if cfg!(windows) {
+            format!("{name}.exe")
+        } else {
+            name.to_string()
+        })
+    };
+    let wasm_ld = tool_name("wasm-ld");
+    let llvm_objcopy = tool_name("llvm-objcopy");
+    let wasm_finalize = tool_name("wasm-emscripten-finalize");
+    let emscripten_version = fs::read_to_string(emscripten_dir.join("emscripten-version.txt"))
+        .ok()
+        .and_then(|value| serde_json::from_str::<String>(value.trim()).ok())
+        .unwrap_or_default();
     if !emcc.is_file() {
         bail!("missing emcc.py at {}", emcc.display());
     }
@@ -199,11 +245,19 @@ fn resolve_tool_paths(install_dir: &Path) -> Result<ToolPaths> {
     if !emar.is_file() {
         bail!("missing emar.py at {}", emar.display());
     }
+    if !clangpp.is_file() {
+        bail!("missing clang++ at {}", clangpp.display());
+    }
     Ok(ToolPaths {
         emscripten_dir,
         emcc,
         empp,
         emar,
+        clangpp,
+        wasm_ld,
+        llvm_objcopy,
+        wasm_finalize,
+        emscripten_version,
         python: resolve_python_executable(),
     })
 }
@@ -257,6 +311,94 @@ fn command_with_env(program: impl AsRef<Path>, tools: &ToolPaths) -> Command {
         command.env(key, value);
     }
     command
+}
+
+const DIRECT_CFLAGS_SCHEMA: u32 = 1;
+const DIRECT_CFLAGS_FILE: &str = ".fastled-direct-cflags.json";
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DirectCflagsCache {
+    schema: u32,
+    entries: BTreeMap<String, Vec<String>>,
+}
+
+fn direct_cflags_key(toolchain_fingerprint: &str, driver_args: &[String]) -> String {
+    let mut values = vec![toolchain_fingerprint.to_string()];
+    values.extend(driver_args.iter().cloned());
+    let mut environment = std::env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.to_string_lossy();
+            (key.starts_with("EMCC_") || matches!(key.as_ref(), "CFLAGS" | "CXXFLAGS"))
+                .then(|| format!("env:{key}={}", value.to_string_lossy()))
+        })
+        .collect::<Vec<_>>();
+    environment.sort();
+    values.extend(environment);
+    dynamic_cache::fingerprint_values(values.iter().map(|value| value.as_bytes()))
+}
+
+/// Ask the active Emscripten driver for the backend flags it would pass to
+/// clang, then persist them by toolchain + driver arguments. This keeps the
+/// supported `em++ --cflags` contract while removing Python startup from warm
+/// sketch compiles, including new CLI processes.
+fn direct_clang_cflags(
+    tools: &ToolPaths,
+    toolchain_fingerprint: &str,
+    driver_args: &[String],
+    current_dir: &Path,
+) -> Result<Vec<String>> {
+    let install_dir = tools
+        .emscripten_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Emscripten directory has no install parent"))?;
+    let cache_path = install_dir.join(DIRECT_CFLAGS_FILE);
+    let lock_path = install_dir.join(format!("{DIRECT_CFLAGS_FILE}.lock"));
+    let lock = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("open direct cflags lock {}", lock_path.display()))?;
+    fs2::FileExt::lock_exclusive(&lock)
+        .with_context(|| format!("lock direct cflags cache {}", cache_path.display()))?;
+
+    let key = direct_cflags_key(toolchain_fingerprint, driver_args);
+    let mut cache = fs::read(&cache_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<DirectCflagsCache>(&bytes).ok())
+        .filter(|cache| cache.schema == DIRECT_CFLAGS_SCHEMA)
+        .unwrap_or_else(|| DirectCflagsCache {
+            schema: DIRECT_CFLAGS_SCHEMA,
+            entries: BTreeMap::new(),
+        });
+    if let Some(flags) = cache.entries.get(&key) {
+        return Ok(flags.clone());
+    }
+
+    let mut command = command_with_env(&tools.python, tools);
+    command
+        .current_dir(current_dir)
+        .arg(&tools.empp)
+        .args(driver_args)
+        .arg("--cflags");
+    let output = command.output().context("run em++ --cflags")?;
+    if !output.status.success() {
+        bail!(
+            "em++ --cflags failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8(output.stdout).context("em++ --cflags returned non-UTF-8")?;
+    let flags = shell_words::split(stdout.trim()).context("parse em++ --cflags output")?;
+    if flags.is_empty() {
+        bail!("em++ --cflags returned no backend flags");
+    }
+    cache.entries.insert(key, flags.clone());
+    fs::write(&cache_path, serde_json::to_vec_pretty(&cache)?)
+        .with_context(|| format!("write direct cflags cache {}", cache_path.display()))?;
+    Ok(flags)
 }
 
 fn spawn_line_reader<R: std::io::Read + Send + 'static>(
@@ -527,6 +669,12 @@ fn link_wasm_dynamic(
 
     let sketch_object_record =
         fs::read(sketch_object).with_context(|| format!("read {}", sketch_object.display()))?;
+    let direct_side_link = direct_side_link_supported(tools, mode, &wasm_bigint_flag);
+    let side_link_strategy = if direct_side_link {
+        "direct-emscripten-4.0.19-v1"
+    } else {
+        "empp-driver-v1"
+    };
     let sketch_fingerprint = dynamic_cache::fingerprint_values([
         runtime_fingerprint.as_bytes(),
         toolchain_fingerprint.as_bytes(),
@@ -534,6 +682,7 @@ fn link_wasm_dynamic(
         sketch_object_record.as_slice(),
         side_module_link_flags.join("\n").as_bytes(),
         b"SIDE_MODULE=1",
+        side_link_strategy.as_bytes(),
     ]);
     let sketch_root = sketch_cache_dir.join("dynamic-sketch-cache");
     let sketch_entry = dynamic_cache::entry_path(&sketch_root, &sketch_fingerprint);
@@ -571,8 +720,34 @@ fn link_wasm_dynamic(
                 side_args.extend(["-pthread".to_string(), "-sSIDE_MODULE=1".to_string()]);
                 side_args.extend(side_module_link_flags);
                 side_args.extend(["-o".to_string(), cached_sketch.display().to_string()]);
-                log("[WASM] Linking cached sketch side module...", "stdout");
-                run_em_link_with_retries(fastled_dir, tools, &side_args, log)?;
+                if direct_side_link {
+                    log(
+                        "[WASM] Linking sketch side module directly (Emscripten 4.0.19 quick plan)...",
+                        "stdout",
+                    );
+                    if let Err(error) = run_direct_side_link_4019(
+                        tools,
+                        sketch_object,
+                        &cached_sketch,
+                        fastled_dir,
+                        log,
+                    ) {
+                        log(
+                            &format!(
+                                "[WASM] Direct side link failed ({error:#}); falling back to em++"
+                            ),
+                            "stderr",
+                        );
+                        fs::remove_file(&cached_sketch).ok();
+                        run_em_link_with_retries(fastled_dir, tools, &side_args, log)?;
+                    }
+                } else {
+                    log(
+                        "[WASM] Linking cached sketch side module with em++...",
+                        "stdout",
+                    );
+                    run_em_link_with_retries(fastled_dir, tools, &side_args, log)?;
+                }
                 dynamic_cache::write_metadata(
                     staging.path(),
                     &sketch_fingerprint,
@@ -610,7 +785,15 @@ fn link_wasm_dynamic(
         }
     }
 
-    copy_dynamic_output(&runtime_entry, &sketch_entry, output_js)?;
+    let output_phase_start = std::time::Instant::now();
+    let copied = copy_dynamic_output(&runtime_entry, &sketch_entry, output_js)?;
+    log(
+        &format!(
+            "[WASM] Dynamic output publication: {copied} changed artifact(s) ({:.2}s)",
+            output_phase_start.elapsed().as_secs_f64()
+        ),
+        "stdout",
+    );
     Ok(())
 }
 
@@ -1230,8 +1413,28 @@ fn compile_sketch(
     fingerprints: &BuildFingerprints,
     log: LogSink,
 ) -> Result<CompiledSketch> {
+    let compile_phase_start = std::time::Instant::now();
     let fastled_dir = &dwarf_roots.fastled_dir;
     let compile_flags = get_sketch_compile_flags(fastled_dir, mode, Some(dwarf_roots))?;
+    let fastled_fingerprint = &fingerprints.fastled_source;
+    let toolchain_fingerprint = &fingerprints.toolchain;
+    let mut driver_args = compile_flags.clone();
+    if link_mode == LinkMode::Dynamic {
+        driver_args.push("-fPIC".to_string());
+    }
+    let (direct_backend_flags, direct_cflags_error, backend_identity) =
+        match direct_clang_cflags(tools, toolchain_fingerprint, &driver_args, fastled_dir) {
+            Ok(flags) => {
+                let identity =
+                    dynamic_cache::fingerprint_values(flags.iter().map(|flag| flag.as_bytes()));
+                (Some(flags), None, format!("direct-clang-v1:{identity}"))
+            }
+            Err(error) => (
+                None,
+                Some(format!("{error:#}")),
+                "empp-fallback-v1".to_string(),
+            ),
+        };
     let source_fingerprint = dynamic_cache::fingerprint_tree(
         example_dir,
         &[
@@ -1239,8 +1442,6 @@ fn compile_sketch(
         ],
         &[".git/**", ".build/**", "fastled_js/**"],
     )?;
-    let fastled_fingerprint = &fingerprints.fastled_source;
-    let toolchain_fingerprint = &fingerprints.toolchain;
     let wrapper_contents = fs::read(wrapper)
         .with_context(|| format!("read generated wrapper {}", wrapper.display()))?;
     let compile_flag_blob = compile_flags.join("\n");
@@ -1252,6 +1453,7 @@ fn compile_sketch(
         compile_flag_blob.as_bytes(),
         link_mode_value.as_bytes(),
         wrapper_contents.as_slice(),
+        backend_identity.as_bytes(),
     ]);
     let object_root = sketch_cache_dir.join("object-cache");
     let object_entry = dynamic_cache::entry_path(&object_root, &object_fingerprint);
@@ -1260,8 +1462,9 @@ fn compile_sketch(
     if dynamic_cache::validate_entry(&object_entry, &object_fingerprint, &["sketch.o"]).is_ok() {
         log(
             &format!(
-                "[WASM] Sketch object cache hit: {}",
-                &object_fingerprint[..12]
+                "[WASM] Sketch object cache hit: {} ({:.2}s)",
+                &object_fingerprint[..12],
+                compile_phase_start.elapsed().as_secs_f64()
             ),
             "stdout",
         );
@@ -1280,7 +1483,7 @@ fn compile_sketch(
         "-o".to_string(),
         staging_object.display().to_string(),
     ];
-    args.extend(compile_flags);
+    args.extend(compile_flags.iter().cloned());
     if link_mode == LinkMode::Dynamic {
         args.push("-fPIC".to_string());
     }
@@ -1304,16 +1507,46 @@ fn compile_sketch(
         &format!("[WASM] Compiling sketch: {}", wrapper.display()),
         "stdout",
     );
-    let mut command = command_with_env(&tools.python, tools);
-    command
-        .current_dir(fastled_dir)
-        .arg(&tools.empp)
-        .args(&args);
-    run_status(command, "em++ sketch compile", log)?;
+    let direct_result = if let Some(backend_flags) = direct_backend_flags {
+        let mut command = command_with_env(&tools.clangpp, tools);
+        command
+            .current_dir(fastled_dir)
+            .args(backend_flags)
+            .args(&args);
+        run_status(command, "clang++ sketch compile", log)
+    } else {
+        Err(anyhow::anyhow!(
+            "{}",
+            direct_cflags_error.unwrap_or_else(|| "em++ --cflags unavailable".to_string())
+        ))
+    };
+    if let Err(direct_error) = direct_result {
+        log(
+            &format!(
+                "[WASM] Direct clang compile unavailable ({direct_error:#}); falling back to em++"
+            ),
+            "stderr",
+        );
+        fs::remove_file(&staging_object).ok();
+        let mut command = command_with_env(&tools.python, tools);
+        command
+            .current_dir(fastled_dir)
+            .arg(&tools.empp)
+            .args(&args);
+        run_status(command, "em++ sketch compile fallback", log)?;
+    }
     dynamic_cache::write_metadata(staging.path(), &object_fingerprint, &["sketch.o"])?;
     dynamic_cache::publish_staging(staging, &object_entry)?;
     dynamic_cache::validate_entry(&object_entry, &object_fingerprint, &["sketch.o"])
         .map_err(anyhow::Error::msg)?;
+    log(
+        &format!(
+            "[WASM] Sketch compile published: {} ({:.2}s)",
+            &object_fingerprint[..12],
+            compile_phase_start.elapsed().as_secs_f64()
+        ),
+        "stdout",
+    );
     Ok(CompiledSketch {
         object,
         fingerprint: object_fingerprint,
@@ -1450,6 +1683,97 @@ fn run_em_link_with_retries(
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("em++ wasm link failed")))
 }
 
+fn direct_side_link_supported(tools: &ToolPaths, mode: BuildMode, wasm_bigint: &str) -> bool {
+    mode == BuildMode::Quick
+        && wasm_bigint == "-sWASM_BIGINT=0"
+        && tools.emscripten_version == "4.0.19"
+        && tools.wasm_ld.is_file()
+        && tools.llvm_objcopy.is_file()
+        && tools.wasm_finalize.is_file()
+        && std::env::var_os("FASTLED_DISABLE_DIRECT_SIDE_LINK").is_none()
+}
+
+/// Version-pinned quick-mode side-link plan matching Emscripten 4.0.19's
+/// final (post metadata-discovery) SIDE_MODULE=1 wasm-ld invocation. Unknown
+/// versions and configurations never enter this path.
+fn direct_side_link_args(tools: &ToolPaths, object: &Path, output: &Path) -> Vec<String> {
+    let pic_lib = tools
+        .emscripten_dir
+        .join("cache/sysroot/lib/wasm32-emscripten/pic");
+    vec![
+        "-o".to_string(),
+        output.display().to_string(),
+        "--whole-archive".to_string(),
+        object.display().to_string(),
+        format!("-L{}", pic_lib.display()),
+        format!("-L{}", tools.emscripten_dir.join("src/lib").display()),
+        pic_lib.join("crtbegin.o").display().to_string(),
+        "--no-whole-archive".to_string(),
+        "-mllvm".to_string(),
+        "-combiner-global-alias-analysis=false".to_string(),
+        "-mllvm".to_string(),
+        "-enable-emscripten-sjlj".to_string(),
+        "-mllvm".to_string(),
+        "-disable-lsr".to_string(),
+        "--import-memory".to_string(),
+        "--shared-memory".to_string(),
+        "--strip-debug".to_string(),
+        "--export-dynamic".to_string(),
+        "--export=__wasm_call_ctors".to_string(),
+        "--export=_emscripten_tls_init".to_string(),
+        "--export-if-defined=__start_em_asm".to_string(),
+        "--export-if-defined=__stop_em_asm".to_string(),
+        "--export-if-defined=__start_em_lib_deps".to_string(),
+        "--export-if-defined=__stop_em_lib_deps".to_string(),
+        "--export-if-defined=__start_em_js".to_string(),
+        "--export-if-defined=__stop_em_js".to_string(),
+        "--export-if-defined=main".to_string(),
+        "--export-if-defined=__main_argc_argv".to_string(),
+        "--export-if-defined=fflush".to_string(),
+        "--experimental-pic".to_string(),
+        "--unresolved-symbols=import-dynamic".to_string(),
+        "--no-shlib-sigcheck".to_string(),
+        "-shared".to_string(),
+        "--stack-first".to_string(),
+    ]
+}
+
+fn run_direct_side_link_4019(
+    tools: &ToolPaths,
+    object: &Path,
+    output: &Path,
+    current_dir: &Path,
+    log: LogSink,
+) -> Result<()> {
+    let mut linker = command_with_env(&tools.wasm_ld, tools);
+    linker
+        .current_dir(current_dir)
+        .args(direct_side_link_args(tools, object, output));
+    run_status(linker, "direct wasm-ld side link", log)?;
+
+    let mut objcopy = command_with_env(&tools.llvm_objcopy, tools);
+    objcopy
+        .current_dir(current_dir)
+        .arg(output)
+        .arg(output)
+        .arg("--remove-section=.debug*")
+        .arg("--remove-section=producers")
+        .arg("--remove-section=name");
+    run_status(objcopy, "direct side-link strip", log)?;
+
+    let mut finalize = command_with_env(&tools.wasm_finalize, tools);
+    finalize
+        .current_dir(current_dir)
+        .arg("--dyncalls-i64")
+        .arg("--pass-arg=legalize-js-interface-export-originals")
+        .arg("--side-module")
+        .arg(output)
+        .arg("-o")
+        .arg(output)
+        .arg("--detect-features");
+    run_status(finalize, "direct side-link finalize", log)
+}
+
 fn copy_linked_output(sketch_cache_dir: &Path, output_js: &Path) -> Result<()> {
     let output_dir = output_js
         .parent()
@@ -1474,11 +1798,53 @@ fn copy_linked_output(sketch_cache_dir: &Path, output_js: &Path) -> Result<()> {
     Ok(())
 }
 
-fn copy_dynamic_output(runtime_entry: &Path, sketch_entry: &Path, output_js: &Path) -> Result<()> {
+fn files_equal(left: &Path, right: &Path) -> Result<bool> {
+    use std::io::Read;
+
+    let left_meta = fs::metadata(left)?;
+    let right_meta = match fs::metadata(right) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if left_meta.len() != right_meta.len() {
+        return Ok(false);
+    }
+    let mut left = fs::File::open(left)?;
+    let mut right = fs::File::open(right)?;
+    let mut left_buffer = [0_u8; 64 * 1024];
+    let mut right_buffer = [0_u8; 64 * 1024];
+    loop {
+        let left_read = left.read(&mut left_buffer)?;
+        let right_read = right.read(&mut right_buffer)?;
+        if left_read != right_read || left_buffer[..left_read] != right_buffer[..right_read] {
+            return Ok(false);
+        }
+        if left_read == 0 {
+            return Ok(true);
+        }
+    }
+}
+
+fn copy_file_if_changed(source: &Path, target: &Path) -> Result<bool> {
+    if files_equal(source, target)? {
+        return Ok(false);
+    }
+    fs::copy(source, target)
+        .with_context(|| format!("copy {} to {}", source.display(), target.display()))?;
+    Ok(true)
+}
+
+fn copy_dynamic_output(
+    runtime_entry: &Path,
+    sketch_entry: &Path,
+    output_js: &Path,
+) -> Result<usize> {
     let output_dir = output_js
         .parent()
         .ok_or_else(|| anyhow::anyhow!("output path has no parent: {}", output_js.display()))?;
     fs::create_dir_all(output_dir)?;
+    let mut copied = 0;
     for (source_dir, name) in [
         (runtime_entry, "fastled.js"),
         (runtime_entry, "fastled.wasm"),
@@ -1489,14 +1855,15 @@ fn copy_dynamic_output(runtime_entry: &Path, sketch_entry: &Path, output_js: &Pa
         let source = source_dir.join(name);
         let target = output_dir.join(name);
         if source.is_file() {
-            fs::copy(&source, &target)
-                .with_context(|| format!("copy {} to {}", source.display(), target.display()))?;
+            if copy_file_if_changed(&source, &target)? {
+                copied += 1;
+            }
         } else if target.exists() {
             fs::remove_file(&target)
                 .with_context(|| format!("remove stale {}", target.display()))?;
         }
     }
-    Ok(())
+    Ok(copied)
 }
 
 fn generate_manifest(example_dir: &Path, output_dir: &Path) -> Result<()> {
@@ -1688,8 +2055,10 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
         )?;
         log(
             &format!(
-                "[WASM] Build fingerprints computed ({:.2}s)",
-                fingerprint_start.elapsed().as_secs_f64()
+                "[WASM] Build fingerprints computed ({:.2}s; FastLED {:.2}s, toolchain {:.2}s, parallel)",
+                fingerprint_start.elapsed().as_secs_f64(),
+                fingerprints.source_duration_secs,
+                fingerprints.toolchain_duration_secs,
             ),
             "stdout",
         );
@@ -1961,6 +2330,164 @@ mod tests {
         assert_ne!(
             baseline,
             static_link_fingerprint(&["-O0".to_string()], "sketch-a", "library-b")
+        );
+    }
+
+    #[test]
+    fn direct_cflags_key_tracks_toolchain_and_driver_arguments() {
+        let baseline = direct_cflags_key("toolchain-a", &["-pthread".to_string()]);
+        assert_eq!(
+            baseline,
+            direct_cflags_key("toolchain-a", &["-pthread".to_string()])
+        );
+        assert_ne!(
+            baseline,
+            direct_cflags_key("toolchain-b", &["-pthread".to_string()])
+        );
+        assert_ne!(
+            baseline,
+            direct_cflags_key("toolchain-a", &["-fPIC".to_string()])
+        );
+    }
+
+    fn fake_tools_for_direct_link(root: &Path, version: &str) -> ToolPaths {
+        let emscripten_dir = root.join("emscripten");
+        let bin = root.join("bin");
+        fs::create_dir_all(&emscripten_dir).unwrap();
+        fs::create_dir_all(&bin).unwrap();
+        let wasm_ld = bin.join("wasm-ld");
+        let llvm_objcopy = bin.join("llvm-objcopy");
+        let wasm_finalize = bin.join("wasm-emscripten-finalize");
+        for path in [&wasm_ld, &llvm_objcopy, &wasm_finalize] {
+            fs::write(path, "tool").unwrap();
+        }
+        ToolPaths {
+            emscripten_dir,
+            emcc: root.join("emcc.py"),
+            empp: root.join("em++.py"),
+            emar: root.join("emar.py"),
+            clangpp: bin.join("clang++"),
+            wasm_ld,
+            llvm_objcopy,
+            wasm_finalize,
+            emscripten_version: version.to_string(),
+            python: PathBuf::from("python"),
+        }
+    }
+
+    #[test]
+    fn direct_side_link_is_strictly_version_mode_and_abi_gated() {
+        let temp = tempfile::tempdir().unwrap();
+        let tools = fake_tools_for_direct_link(temp.path(), "4.0.19");
+        assert!(direct_side_link_supported(
+            &tools,
+            BuildMode::Quick,
+            "-sWASM_BIGINT=0"
+        ));
+        assert!(!direct_side_link_supported(
+            &tools,
+            BuildMode::Debug,
+            "-sWASM_BIGINT=0"
+        ));
+        assert!(!direct_side_link_supported(
+            &tools,
+            BuildMode::Quick,
+            "-sWASM_BIGINT=1"
+        ));
+        let unknown = fake_tools_for_direct_link(&temp.path().join("unknown"), "4.0.20");
+        assert!(!direct_side_link_supported(
+            &unknown,
+            BuildMode::Quick,
+            "-sWASM_BIGINT=0"
+        ));
+    }
+
+    #[test]
+    fn direct_side_link_plan_preserves_side_module_one_contract() {
+        let temp = tempfile::tempdir().unwrap();
+        let tools = fake_tools_for_direct_link(temp.path(), "4.0.19");
+        let args = direct_side_link_args(&tools, Path::new("sketch.o"), Path::new("sketch.wasm"));
+        assert!(args.contains(&"--whole-archive".to_string()));
+        assert!(args.contains(&"--unresolved-symbols=import-dynamic".to_string()));
+        assert!(args.contains(&"-shared".to_string()));
+        assert!(!args.iter().any(|arg| arg.contains("SIDE_MODULE=2")));
+    }
+
+    #[test]
+    fn dynamic_output_does_not_recopy_unchanged_runtime() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime = temp.path().join("runtime");
+        let sketch = temp.path().join("sketch");
+        let output = temp.path().join("output");
+        fs::create_dir_all(&runtime).unwrap();
+        fs::create_dir_all(&sketch).unwrap();
+        fs::write(runtime.join("fastled.js"), "loader").unwrap();
+        fs::write(runtime.join("fastled.wasm"), b"runtime-wasm").unwrap();
+        fs::write(sketch.join("sketch.wasm"), b"sketch-v1").unwrap();
+
+        assert_eq!(
+            copy_dynamic_output(&runtime, &sketch, &output.join("fastled.js")).unwrap(),
+            3
+        );
+        let js_mtime = output
+            .join("fastled.js")
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+        let wasm_mtime = output
+            .join("fastled.wasm")
+            .metadata()
+            .unwrap()
+            .modified()
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        assert_eq!(
+            copy_dynamic_output(&runtime, &sketch, &output.join("fastled.js")).unwrap(),
+            0
+        );
+        assert_eq!(
+            output
+                .join("fastled.js")
+                .metadata()
+                .unwrap()
+                .modified()
+                .unwrap(),
+            js_mtime
+        );
+        assert_eq!(
+            output
+                .join("fastled.wasm")
+                .metadata()
+                .unwrap()
+                .modified()
+                .unwrap(),
+            wasm_mtime
+        );
+
+        fs::write(sketch.join("sketch.wasm"), b"sketch-v2").unwrap();
+        assert_eq!(
+            copy_dynamic_output(&runtime, &sketch, &output.join("fastled.js")).unwrap(),
+            1
+        );
+        assert_eq!(
+            output
+                .join("fastled.js")
+                .metadata()
+                .unwrap()
+                .modified()
+                .unwrap(),
+            js_mtime
+        );
+        assert_eq!(
+            output
+                .join("fastled.wasm")
+                .metadata()
+                .unwrap()
+                .modified()
+                .unwrap(),
+            wasm_mtime
         );
     }
 


### PR DESCRIPTION
## Summary

- parallelize content-authoritative FastLED/toolchain fingerprints and memoize them safely in long-lived watch sessions
- compile sketches with cached `em++ --cflags` + direct Clang, while retaining an automatic `em++` fallback
- use a version/ABI/mode-gated Emscripten 4.0.19 quick side-link plan with automatic driver fallback
- cache installed-toolchain discovery, avoid unchanged `.emscripten` writes, skip unchanged runtime output copies, and expose phase timings

## Performance

Reference Windows machine, external Blink sketch, `--just-compile --no-app --link-mode dynamic`, warm runtime cache:

| Scenario | Before | After | Improvement |
|---|---:|---:|---:|
| Warm no-op | 1.46s | 0.34s | 76.7% faster |
| Sketch edit median | 3.62s | 0.62s | 82.9% faster |

Final fresh-edit samples: 0.62s, 0.58s, 0.62s, 0.64s, 0.70s.

For the same object, the direct side-link output and `em++ -sSIDE_MODULE=1` output were both 48,721 bytes and had identical SHA-256 `6938E84F169E2371BBB32CF77DF4AF775947124353EE9BD38EA38D28DF4906EB`.

## Validation

- `bash lint`
- `bash test` (183 Rust tests plus Python/package tests)
- real static-mode quick WASM build
- real dynamic-mode no-op and repeated fresh sketch-edit benchmarks
- direct side-link versus `em++` byte-equivalence check
- focused cache, watcher invalidation, fallback gating, unchanged-output, and same-size/restored-mtime tests

Closes #190