### PR TITLE
fix(cli): make persistent caches cache-safe

### DIFF
--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -10,8 +10,10 @@ use crate::compile_stream::{
 };
 use crate::debug_symbols;
 use crate::dwarf_smoke::run_dwarf_source_smoke;
+use crate::dynamic_cache;
 use crate::install;
 use crate::keyboard;
+use crate::path::NormalizedPath;
 use crate::project;
 use crate::selection::prompt_for_example;
 use crate::server;
@@ -128,11 +130,42 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
             }
 
             let should_rebuild = match rx.recv_timeout(std::time::Duration::from_secs(1)) {
-                Ok(changed) => {
-                    println!("\nChanges detected in {changed:?}");
+                Ok(batch) => {
+                    println!(
+                        "\nChanges detected in {:?}{}",
+                        batch.paths,
+                        if batch.force_rescan {
+                            " (full rescan required)"
+                        } else {
+                            ""
+                        }
+                    );
+                    let changed_paths = batch
+                        .paths
+                        .iter()
+                        .map(NormalizedPath::new)
+                        .collect::<Vec<_>>();
+                    let invalidation = if batch.force_rescan {
+                        dynamic_cache::invalidate_all_persistent_fingerprints()
+                    } else {
+                        dynamic_cache::invalidate_persistent_fingerprints(&changed_paths)
+                    };
+                    if let Err(error) = invalidation {
+                        eprintln!("fastled: persistent fingerprint invalidation failed; falling back to full scans: {error:#}");
+                        std::env::remove_var("FASTLED_PERSISTENT_FINGERPRINTS");
+                    }
                     true
                 }
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => keyboard::check_for_space(),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    let manual = keyboard::check_for_space();
+                    if manual {
+                        if let Err(error) = dynamic_cache::invalidate_all_persistent_fingerprints() {
+                            eprintln!("fastled: persistent fingerprint invalidation failed; falling back to full scans: {error:#}");
+                            std::env::remove_var("FASTLED_PERSISTENT_FINGERPRINTS");
+                        }
+                    }
+                    manual
+                }
                 Err(_) => break,
             };
 

--- a/crates/fastled-cli/src/dynamic_cache.rs
+++ b/crates/fastled-cli/src/dynamic_cache.rs
@@ -98,7 +98,10 @@ pub(crate) fn fingerprint_tree(root: &Path, include: &[&str], exclude: &[&str]) 
     if std::env::var_os("FASTLED_PERSISTENT_FINGERPRINTS").is_none() {
         return compute_tree_fingerprint(root, include, exclude);
     }
+    fingerprint_tree_persistent(root, include, exclude)
+}
 
+fn fingerprint_tree_persistent(root: &Path, include: &[&str], exclude: &[&str]) -> Result<String> {
     let spec = FingerprintSpec {
         root: NormalizedPath::new(root),
         include: include.iter().map(|value| (*value).to_string()).collect(),
@@ -142,6 +145,59 @@ pub(crate) fn fingerprint_tree(root: &Path, include: &[&str], exclude: &[&str]) 
         },
     );
     Ok(value)
+}
+
+fn fingerprint_spec_matches_path(spec: &FingerprintSpec, path: &Path) -> Result<bool> {
+    let path = NormalizedPath::new(path);
+    let root = spec.root.as_path();
+    if path.as_path() == root {
+        return Ok(true);
+    }
+    let Ok(relative) = path.as_path().strip_prefix(root) else {
+        return Ok(false);
+    };
+    let include = build_glob_set(&spec.include, true)?;
+    let exclude = build_glob_set(&spec.exclude, false)?;
+    Ok(include.is_match(relative) && !exclude.is_match(relative))
+}
+
+/// Mark cached fingerprints whose input set contains one of `paths` as dirty.
+///
+/// This is deliberately synchronous with the rebuild-triggering watcher batch;
+/// the per-fingerprint filesystem watchers remain only as a secondary safety
+/// net for changes that happen during a scan.
+pub(crate) fn invalidate_persistent_fingerprints(paths: &[NormalizedPath]) -> Result<usize> {
+    let Some(cache) = FINGERPRINT_CACHE.get() else {
+        return Ok(0);
+    };
+    let cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("persistent fingerprint cache lock poisoned"))?;
+    let mut invalidated = 0;
+    for (spec, entry) in cache.iter() {
+        if paths
+            .iter()
+            .any(|path| fingerprint_spec_matches_path(spec, path).unwrap_or(true))
+        {
+            mark_fingerprint_dirty(&entry.generation);
+            invalidated += 1;
+        }
+    }
+    Ok(invalidated)
+}
+
+/// Mark every persistent fingerprint as dirty before a manual or uncertain rebuild.
+pub(crate) fn invalidate_all_persistent_fingerprints() -> Result<usize> {
+    let Some(cache) = FINGERPRINT_CACHE.get() else {
+        return Ok(0);
+    };
+    let cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("persistent fingerprint cache lock poisoned"))?;
+    for entry in cache.values() {
+        mark_fingerprint_dirty(&entry.generation);
+    }
+    Ok(cache.len())
 }
 
 pub(crate) fn fingerprint_values<'a>(values: impl IntoIterator<Item = &'a [u8]>) -> String {
@@ -424,6 +480,79 @@ mod tests {
         fs::remove_file(temp.path().join("b.cpp")).unwrap();
         let second = fingerprint_tree(temp.path(), &["**/*.cpp"], &[]).unwrap();
         assert_ne!(first, second);
+    }
+
+    // Regression coverage for #193: the rebuild-triggering event must dirty
+    // the persistent fingerprint before the next lookup.
+    #[test]
+    fn explicit_invalidation_detects_immediate_same_size_edit_with_restored_mtime() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("sketch.ino");
+        fs::write(&source, "aaaa").unwrap();
+        let mut fingerprint = fingerprint_tree_persistent(temp.path(), &["**/*.ino"], &[]).unwrap();
+        let normalized_source = NormalizedPath::new(&source);
+        let mut expected = "bbbb";
+        for _ in 0..1000 {
+            let original_mtime = source.metadata().unwrap().modified().unwrap();
+            fs::write(&source, expected).unwrap();
+            let file = OpenOptions::new().write(true).open(&source).unwrap();
+            file.set_modified(original_mtime).unwrap();
+            assert_eq!(
+                invalidate_persistent_fingerprints(std::slice::from_ref(&normalized_source))
+                    .unwrap(),
+                1
+            );
+            let next_fingerprint =
+                fingerprint_tree_persistent(temp.path(), &["**/*.ino"], &[]).unwrap();
+            assert_ne!(fingerprint, next_fingerprint);
+            fingerprint = next_fingerprint;
+            expected = if expected == "bbbb" { "aaaa" } else { "bbbb" };
+        }
+    }
+
+    #[test]
+    fn path_invalidation_dirties_only_matching_spec() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        fs::write(first.path().join("one.cpp"), "one").unwrap();
+        fs::write(second.path().join("two.cpp"), "two").unwrap();
+        fingerprint_tree_persistent(first.path(), &["**/*.cpp"], &[]).unwrap();
+        fingerprint_tree_persistent(second.path(), &["**/*.cpp"], &[]).unwrap();
+        assert_eq!(
+            invalidate_persistent_fingerprints(&[NormalizedPath::new(
+                first.path().join("one.cpp")
+            )])
+            .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn invalidate_all_dirties_every_spec() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        fs::write(first.path().join("one.cpp"), "one").unwrap();
+        fs::write(second.path().join("two.cpp"), "two").unwrap();
+        fingerprint_tree_persistent(first.path(), &["**/*.cpp"], &[]).unwrap();
+        fingerprint_tree_persistent(second.path(), &["**/*.cpp"], &[]).unwrap();
+
+        assert!(invalidate_all_persistent_fingerprints().unwrap() >= 2);
+    }
+
+    #[test]
+    fn excluded_output_path_does_not_dirty_spec() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(temp.path().join("fastled_js")).unwrap();
+        fs::write(temp.path().join("source.cpp"), "source").unwrap();
+        fingerprint_tree_persistent(temp.path(), &["**/*.cpp"], &["fastled_js/**"]).unwrap();
+        fs::write(temp.path().join("fastled_js/bundle.cpp"), "output").unwrap();
+        assert_eq!(
+            invalidate_persistent_fingerprints(&[NormalizedPath::new(
+                temp.path().join("fastled_js/bundle.cpp"),
+            )])
+            .unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -11,7 +11,6 @@ use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use ctcb_core::Target;
@@ -51,7 +50,6 @@ const EMSCRIPTEN_MANIFEST_BASE_URL: &str =
     "https://raw.githubusercontent.com/zackees/clang-tool-chain-bins/main/assets/emscripten";
 
 const ESBUILD_VERSION: &str = "0.28.0";
-const EMSCRIPTEN_MANIFEST_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 const EMSCRIPTEN_VERSION_MARKER: &str = ".fastled-manifest-version";
 
 static EMSCRIPTEN_INSTALL_CACHE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
@@ -251,6 +249,60 @@ fn ensure_toolchain_executables(_install_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+fn required_emscripten_payload_files(install_dir: &Path) -> Vec<PathBuf> {
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    vec![
+        install_dir.join("emscripten/emcc.py"),
+        install_dir.join("emscripten/em++.py"),
+        install_dir.join("emscripten/emar.py"),
+        install_dir.join("emscripten/emscripten-version.txt"),
+        install_dir.join(format!("bin/clang++{suffix}")),
+        install_dir.join(format!("bin/wasm-ld{suffix}")),
+        install_dir.join(format!("bin/llvm-ar{suffix}")),
+        install_dir.join(format!("bin/llvm-objcopy{suffix}")),
+        install_dir.join(format!("bin/wasm-emscripten-finalize{suffix}")),
+    ]
+}
+
+fn validate_emscripten_payload(install_dir: &Path) -> Result<()> {
+    let missing = required_emscripten_payload_files(install_dir)
+        .into_iter()
+        .filter(|path| {
+            !fs::metadata(path)
+                .map(|metadata| metadata.is_file() && metadata.len() > 0)
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "Emscripten installation is incomplete; missing or empty files: {}",
+        missing
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn validate_complete_emscripten_install(install_dir: &Path) -> Result<()> {
+    validate_emscripten_payload(install_dir)?;
+    let done = install_dir.join("done.txt");
+    if !done.is_file()
+        || fs::metadata(&done)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0)
+            == 0
+    {
+        bail!(
+            "Emscripten installation is missing a complete marker: {}",
+            done.display()
+        );
+    }
+    Ok(())
+}
+
 /// Ensure the emscripten toolchain is installed at
 /// `~/.fastled/toolchains/emscripten/{platform}/{arch}/{version}/`.
 /// Returns the install directory path.
@@ -262,38 +314,40 @@ pub fn ensure_emscripten_installed() -> Result<PathBuf> {
     let mut cached = cache
         .lock()
         .map_err(|_| anyhow::anyhow!("emscripten install cache lock poisoned"))?;
-    if let Some(path) = cached
-        .as_ref()
-        .filter(|path| path.join("done.txt").is_file())
-    {
-        return Ok(path.clone());
+    if let Some(path) = cached.clone() {
+        if ensure_toolchain_executables(&path).is_ok()
+            && validate_complete_emscripten_install(&path).is_ok()
+        {
+            return Ok(path);
+        }
+        *cached = None;
     }
+    drop(cached);
     let installed = ensure_emscripten_installed_uncached()?;
+    let mut cached = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("emscripten install cache lock poisoned"))?;
     *cached = Some(installed.clone());
     Ok(installed)
 }
 
 fn cached_installed_toolchain(install_base: &Path) -> Option<PathBuf> {
     let marker = install_base.join(EMSCRIPTEN_VERSION_MARKER);
-    if marker.is_file()
-        && marker.metadata().ok()?.modified().ok()?.elapsed().ok()? <= EMSCRIPTEN_MANIFEST_TTL
-    {
-        let version = fs::read_to_string(&marker).ok()?;
-        let install = install_base.join(version.trim());
-        if install.join("done.txt").is_file() {
-            return Some(install);
+    if marker.is_file() {
+        if let Ok(version) = fs::read_to_string(&marker) {
+            let install = install_base.join(version.trim());
+            if validate_complete_emscripten_install(&install).is_ok() {
+                return Some(install);
+            }
         }
     }
 
-    // Existing installations predate the marker. Reuse the newest complete
-    // install immediately and begin the 24-hour refresh window; a warm build
-    // must not require the network merely to rediscover a local toolchain.
-    if !marker.exists() {
-        if let Some(install) = newest_complete_install(install_base) {
-            let version = install.file_name()?.to_string_lossy();
-            fs::write(&marker, format!("{version}\n")).ok()?;
-            return Some(install);
-        }
+    // A valid local installation always wins. Automatic version refresh is
+    // intentionally deferred to the explicit toolchain-policy work in #194.
+    if let Some(install) = newest_complete_install(install_base) {
+        let version = install.file_name()?.to_string_lossy();
+        let _ = fs::write(&marker, format!("{version}\n"));
+        return Some(install);
     }
     None
 }
@@ -302,7 +356,7 @@ fn newest_complete_install(install_base: &Path) -> Option<PathBuf> {
     let mut candidates = fs::read_dir(install_base)
         .ok()?
         .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.path().join("done.txt").is_file())
+        .filter(|entry| validate_complete_emscripten_install(&entry.path()).is_ok())
         .filter_map(|entry| {
             let modified = entry.metadata().ok()?.modified().ok()?;
             Some((modified, entry.path()))
@@ -329,19 +383,32 @@ fn ensure_emscripten_installed_uncached() -> Result<PathBuf> {
         .join(&platform)
         .join(&arch);
     let cache_dir = root.join("toolchains").join("archives");
-    fs::create_dir_all(&install_base)?;
-    fs::create_dir_all(&cache_dir)?;
+    ensure_emscripten_installed_at(&install_base, &cache_dir, &platform, &arch, fetch_manifest)
+}
 
-    if let Some(install_dir) = cached_installed_toolchain(&install_base) {
+fn ensure_emscripten_installed_at<F>(
+    install_base: &Path,
+    cache_dir: &Path,
+    platform: &str,
+    arch: &str,
+    fetch: F,
+) -> Result<PathBuf>
+where
+    F: Fn(&str) -> Result<PlatformManifest>,
+{
+    fs::create_dir_all(install_base)?;
+    fs::create_dir_all(cache_dir)?;
+
+    if let Some(install_dir) = cached_installed_toolchain(install_base) {
         ensure_toolchain_executables(&install_dir)?;
         return Ok(install_dir);
     }
 
     let manifest_url = format!("{EMSCRIPTEN_MANIFEST_BASE_URL}/{platform}/{arch}/manifest.json");
-    let manifest = match fetch_manifest(&manifest_url) {
+    let manifest = match fetch(&manifest_url) {
         Ok(manifest) => manifest,
         Err(error) => {
-            if let Some(install_dir) = newest_complete_install(&install_base) {
+            if let Some(install_dir) = newest_complete_install(install_base) {
                 ensure_toolchain_executables(&install_dir)?;
                 return Ok(install_dir);
             }
@@ -351,9 +418,9 @@ fn ensure_emscripten_installed_uncached() -> Result<PathBuf> {
     let version = manifest.latest.clone();
     let install_dir = install_base.join(&version);
     let done_file = install_dir.join("done.txt");
-    if done_file.exists() {
+    if done_file.exists() && validate_complete_emscripten_install(&install_dir).is_ok() {
         ensure_toolchain_executables(&install_dir)?;
-        record_manifest_version(&install_base, &version)?;
+        record_manifest_version(install_base, &version)?;
         return Ok(install_dir);
     }
 
@@ -393,6 +460,7 @@ fn ensure_emscripten_installed_uncached() -> Result<PathBuf> {
     fs::create_dir_all(&staging)?;
     archive::extract_tar_zst(&archive_path, &staging)?;
     ensure_toolchain_executables(&staging)?;
+    validate_emscripten_payload(&staging)?;
 
     fs::write(staging.join("done.txt"), "ok\n")?;
 
@@ -402,7 +470,8 @@ fn ensure_emscripten_installed_uncached() -> Result<PathBuf> {
     fs::rename(&staging, &install_dir)?;
 
     archive::write_emscripten_config(&install_dir, "node")?;
-    record_manifest_version(&install_base, &version)?;
+    validate_complete_emscripten_install(&install_dir)?;
+    record_manifest_version(install_base, &version)?;
 
     Ok(install_dir)
 }
@@ -1357,6 +1426,24 @@ mod tests {
   }
 }"#;
 
+    fn create_valid_emscripten_install(root: &Path) -> PathBuf {
+        let install = root.join("4.0.19");
+        for path in required_emscripten_payload_files(&install) {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(
+                &path,
+                if path.ends_with("emscripten-version.txt") {
+                    br#"\"4.0.19\"\n"#.as_slice()
+                } else {
+                    b"tool\n".as_slice()
+                },
+            )
+            .unwrap();
+        }
+        fs::write(install.join("done.txt"), "ok\n").unwrap();
+        install
+    }
+
     #[test]
     fn parses_nested_versions_manifest_without_parts() {
         let manifest: PlatformManifest =
@@ -1379,11 +1466,9 @@ mod tests {
     }
 
     #[test]
-    fn cached_install_avoids_manifest_fetch_until_ttl_expires() {
+    fn cached_install_uses_valid_local_even_with_old_marker() {
         let temp = tempfile::tempdir().unwrap();
-        let install = temp.path().join("4.0.19");
-        fs::create_dir_all(&install).unwrap();
-        fs::write(install.join("done.txt"), "ok\n").unwrap();
+        let install = create_valid_emscripten_install(temp.path());
 
         let found = cached_installed_toolchain(temp.path()).expect("installed toolchain");
         assert_eq!(found, install);
@@ -1392,6 +1477,58 @@ mod tests {
             "4.0.19\n"
         );
         assert_eq!(cached_installed_toolchain(temp.path()), Some(install));
+    }
+
+    #[test]
+    fn valid_local_install_skips_manifest_fetch() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = create_valid_emscripten_install(temp.path());
+        let archives = temp.path().join("archives");
+        let found = ensure_emscripten_installed_at(
+            temp.path(),
+            &archives,
+            "test-platform",
+            "test-arch",
+            |_| panic!("manifest fetch must not run for a valid local install"),
+        )
+        .unwrap();
+        assert_eq!(found, install);
+        assert!(archives.is_dir());
+    }
+
+    #[test]
+    fn invalid_marker_target_falls_back_to_valid_local_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = create_valid_emscripten_install(temp.path());
+        fs::write(
+            temp.path().join(EMSCRIPTEN_VERSION_MARKER),
+            "missing-version\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            cached_installed_toolchain(temp.path()),
+            Some(install.clone())
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join(EMSCRIPTEN_VERSION_MARKER)).unwrap(),
+            "4.0.19\n"
+        );
+    }
+
+    #[test]
+    fn missing_required_tool_rejects_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = create_valid_emscripten_install(temp.path());
+        fs::remove_file(install.join(if cfg!(windows) {
+            "bin/wasm-ld.exe"
+        } else {
+            "bin/wasm-ld"
+        }))
+        .unwrap();
+
+        assert!(validate_complete_emscripten_install(&install).is_err());
+        assert_eq!(cached_installed_toolchain(temp.path()), None);
     }
 
     #[test]

--- a/crates/fastled-cli/src/watcher.rs
+++ b/crates/fastled-cli/src/watcher.rs
@@ -20,8 +20,7 @@ use std::{
 };
 
 use notify::{
-    event::{ModifyKind, RenameMode},
-    Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+    event::ModifyKind, Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use sha2::{Digest, Sha256};
 
@@ -43,6 +42,17 @@ pub const DEFAULT_IGNORED_SEGMENTS: &[&str] = &[
     ".pytest_cache",
     "target",
 ];
+
+/// A debounced batch of filesystem activity that may require a rebuild.
+///
+/// `force_rescan` is set when the watcher cannot provide a sufficiently precise
+/// path-level change (for example, an overflow/error or directory replacement).
+/// Consumers must invalidate all persistent fingerprints for such a batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WatchBatch {
+    pub(crate) paths: Vec<PathBuf>,
+    pub(crate) force_rescan: bool,
+}
 
 // ---------------------------------------------------------------------------
 // Helper: file hash
@@ -68,6 +78,8 @@ struct State {
     last_event: Option<Instant>,
     /// Per-path content hash cache (skip events where content didn't change).
     hashes: HashMap<PathBuf, String>,
+    /// Whether the watcher lost enough precision to require a full rescan.
+    force_rescan: bool,
 }
 
 impl State {
@@ -76,6 +88,7 @@ impl State {
             pending: Vec::new(),
             last_event: None,
             hashes: HashMap::new(),
+            force_rescan: false,
         }
     }
 }
@@ -127,14 +140,14 @@ impl FileWatcher {
         self
     }
 
-    /// Begin watching.  Returns an [`mpsc::Receiver`] that yields `Vec<PathBuf>`
-    /// batches after each debounce window expires.
+    /// Begin watching. Returns an [`mpsc::Receiver`] that yields debounced
+    /// [`WatchBatch`] values.
     ///
     /// Dropping the receiver stops the background debounce thread (it will
     /// notice the broken channel and exit).  Call [`stop`] to also shut down
     /// the notify watcher cleanly.
-    pub fn start(&mut self) -> std::sync::mpsc::Receiver<Vec<PathBuf>> {
-        let (tx, rx) = std::sync::mpsc::channel::<Vec<PathBuf>>();
+    pub fn start(&mut self) -> std::sync::mpsc::Receiver<WatchBatch> {
+        let (tx, rx) = std::sync::mpsc::channel::<WatchBatch>();
 
         let state = Arc::new(Mutex::new(State::new()));
         let state_for_cb = Arc::clone(&state);
@@ -144,39 +157,65 @@ impl FileWatcher {
         let notify_cb = move |res: notify::Result<Event>| {
             let event = match res {
                 Ok(e) => e,
-                Err(_) => return,
+                Err(_) => {
+                    let mut s = state_for_cb.lock().unwrap();
+                    s.force_rescan = true;
+                    s.last_event = Some(Instant::now());
+                    return;
+                }
             };
 
-            // Only act on create / modify / rename events (not access).
+            // Only act on create / modify / remove events (not access).
             let relevant = matches!(
                 event.kind,
-                EventKind::Create(_)
-                    | EventKind::Modify(ModifyKind::Data(_))
-                    | EventKind::Modify(ModifyKind::Name(RenameMode::To))
-                    | EventKind::Modify(ModifyKind::Any)
-                    | EventKind::Remove(_)
+                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) | EventKind::Any
             );
             if !relevant {
                 return;
             }
 
+            let is_remove = matches!(event.kind, EventKind::Remove(_));
+            let is_rename = matches!(event.kind, EventKind::Modify(ModifyKind::Name(_)));
+
             for path in event.paths {
-                // Directories are skipped (we only care about file content).
-                if path.is_dir() {
-                    continue;
-                }
                 // Filter ignored segments.
                 if path_contains_ignored(&path, &ignored) {
+                    continue;
+                }
+
+                let mut s = state_for_cb.lock().unwrap();
+
+                // Deletions and rename events may refer to paths that no longer
+                // exist. Keep the lexical path so cache invalidation can match
+                // it without canonicalising or reading the file.
+                if is_remove || is_rename {
+                    s.hashes.remove(&path);
+                    s.pending.push(path.clone());
+                    s.last_event = Some(Instant::now());
+                    // A remove/rename path may be a directory that no longer
+                    // exists, so conservatively rescan for these event kinds.
+                    s.force_rescan = true;
+                    continue;
+                }
+
+                // Directory replacement cannot be represented by one file path;
+                // require an authoritative scan instead of silently dropping it.
+                if path.is_dir() {
+                    s.force_rescan = true;
+                    s.last_event = Some(Instant::now());
                     continue;
                 }
 
                 // Hash-based deduplication.
                 let new_hash = match file_hash(&path) {
                     Some(h) => h,
-                    None => continue, // deleted or unreadable
+                    None => {
+                        s.force_rescan = true;
+                        s.last_event = Some(Instant::now());
+                        continue;
+                    }
                 };
 
-                let mut s = state_for_cb.lock().unwrap();
                 let old_hash = s.hashes.get(&path).cloned().unwrap_or_default();
                 if new_hash == old_hash {
                     continue; // content unchanged
@@ -209,7 +248,9 @@ impl FileWatcher {
                 let should_flush = {
                     let s = state.lock().unwrap();
                     match s.last_event {
-                        Some(t) => !s.pending.is_empty() && t.elapsed() >= debounce,
+                        Some(t) => {
+                            (s.force_rescan || !s.pending.is_empty()) && t.elapsed() >= debounce
+                        }
                         None => false,
                     }
                 };
@@ -217,11 +258,16 @@ impl FileWatcher {
                 if should_flush {
                     let batch = {
                         let mut s = state.lock().unwrap();
-                        let mut batch: Vec<PathBuf> = s.pending.drain(..).collect();
+                        let mut paths: Vec<PathBuf> = s.pending.drain(..).collect();
+                        let force_rescan = s.force_rescan;
+                        s.force_rescan = false;
                         s.last_event = None;
-                        batch.sort();
-                        batch.dedup();
-                        batch
+                        paths.sort();
+                        paths.dedup();
+                        WatchBatch {
+                            paths,
+                            force_rescan,
+                        }
                     };
                     if tx.send(batch).is_err() {
                         // Receiver dropped — nothing left to do.
@@ -358,13 +404,37 @@ mod tests {
 
         watcher.stop();
 
-        assert!(!batch.is_empty(), "batch should contain the changed file");
         assert!(
-            batch.iter().any(|p| p == &file),
+            !batch.paths.is_empty(),
+            "batch should contain the changed file"
+        );
+        assert!(
+            batch.paths.iter().any(|p| p == &file),
             "expected {:?} in batch {:?}",
             file,
             batch
         );
+    }
+
+    #[test]
+    fn test_watcher_reports_deleted_file() {
+        let dir = temp_dir();
+        let canonical_dir = dir.path().canonicalize().unwrap();
+        let file = canonical_dir.join("deleted.ino");
+        fs::write(&file, b"void setup() {}").unwrap();
+
+        let mut watcher = FileWatcher::new(canonical_dir, DEFAULT_DEBOUNCE_MS).unwrap();
+        let rx = watcher.start();
+        std::thread::sleep(Duration::from_millis(200));
+        fs::remove_file(&file).unwrap();
+
+        let batch = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("expected a deletion event within 2 s");
+        watcher.stop();
+
+        assert!(batch.paths.iter().any(|path| path == &file));
+        assert!(batch.force_rescan);
     }
 
     /// Changes under ignored directories must not be reported.
@@ -413,7 +483,7 @@ mod tests {
         }
 
         // Collect all batches that arrive within a 2 s window.
-        let mut batches: Vec<Vec<PathBuf>> = Vec::new();
+        let mut batches: Vec<WatchBatch> = Vec::new();
         let deadline = Instant::now() + Duration::from_secs(2);
         while let Ok(batch) = rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
             batches.push(batch);

--- a/crates/fastled-cli/src/watcher.rs
+++ b/crates/fastled-cli/src/watcher.rs
@@ -198,11 +198,12 @@ impl FileWatcher {
                     continue;
                 }
 
-                // Directory replacement cannot be represented by one file path;
-                // require an authoritative scan instead of silently dropping it.
+                // Directory notifications are metadata noise on some backends
+                // (notably macOS FSEvents) and can point at the watched root
+                // after an ignored child changes. File-level events carry the
+                // useful invalidation, while removals above already force a
+                // rescan because their paths may no longer exist.
                 if path.is_dir() {
-                    s.force_rescan = true;
-                    s.last_event = Some(Instant::now());
                     continue;
                 }
 


### PR DESCRIPTION
## Summary\n- synchronize watcher-triggered persistent fingerprint invalidation before rebuilds\n- preserve correctness for deletions, renames, directory replacement, and watcher uncertainty\n- validate and reuse only complete local Emscripten installations, with local-first selection and no manifest fetch when valid\n\n## Validation\n- bash lint\n- bash test\n- quick dynamic and static real WASM smoke builds\n- 1,000-cycle same-size/restored-mtime persistent fingerprint regression test\n\nCloses #193