### PR TITLE
docs: prohibit JSPI for Safari compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,14 @@ Do not pipe pytest through `| tail -N` if you want streaming output; it buffers 
 - The compile path is Rust-owned through `crates/fastled-cli/src/build.rs` and `crates/fastled-cli/src/wasm_build.rs`.
 - Python no longer owns build, toolchain, sketch selection, project init, install, server, debug-symbol, or frontend-bundling orchestration.
 
+## Browser Compatibility Invariants
+
+- Safari is a required production target. Production compiler defaults and generated artifacts must not depend on JavaScript Promise Integration (JSPI), because Safari does not support the JSPI path required by Emscripten.
+- Do not add or preserve `-sJSPI`, `-sJSPI_EXPORTS`, `WebAssembly.Suspending`, or `WebAssembly.promising` as part of an Emscripten upgrade or build-performance change. Newer Emscripten support for JSPI is not an upgrade benefit for this project.
+- Existing JSPI flags or code are compatibility debt, not precedent. Removing or replacing them requires a dedicated Safari-compatible implementation and browser validation; do not silently propagate them into a new toolchain configuration.
+- Every Emscripten upgrade must inspect the effective linker flags and generated JavaScript for newly enabled JSPI behavior, then run a real Safari smoke test before the toolchain can become the release default. Chrome- or Node-only tests are insufficient.
+- Async and coroutine behavior must retain a non-JSPI Safari-compatible implementation. Do not accept an Emscripten default change that narrows browser support without an explicit project decision.
+
 ## Conventions
 
 - Lint command: `bash lint`.
@@ -49,6 +57,7 @@ Do not pipe pytest through `| tail -N` if you want streaming output; it buffers 
 - The installed `fastled` CLI on PATH may be a Python compatibility shim or stale script; the bundled native binary is `fastled[.exe]`.
 - Error messages from the Rust CLI go to stderr.
 - On Windows, stale generated binaries under `src/fastled/bin/` are build artifacts and should not be committed.
+- `src/fastled/frontend/build_flags.toml` currently contains legacy JSPI flags. Their presence does not make JSPI an approved compatibility target; see Browser Compatibility Invariants above.
 
 ## Filing Issues / PRs
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Set `FASTLED_VIEWER_LOGS=1` to forward the viewer window's browser console outpu
 
 ## Features
 
+### Browser Compatibility
+
+Safari is a required production target. Release builds must not depend on Emscripten's JavaScript Promise Integration (JSPI), including `-sJSPI`, `WebAssembly.Suspending`, or `WebAssembly.promising`. Emscripten upgrades must preserve a non-JSPI async path and pass a real Safari smoke test before becoming the default toolchain.
+
 ### Hot Reload
 
 Once launched, the compiler remains open and watches for file changes. Edits to your sketch are automatically recompiled and the browser reloads with the updated output. Build output is streamed to the browser in real time via SSE.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,12 @@ Go to src/fastled/__init__.py and increase the version number.
 Make sure this is the ONLY change in your repo (or the release will fail
 for unknown reasons) and commit and then push. Github builders will do all the rest.
 
+If the release changes the Emscripten toolchain or WASM linker settings, verify
+that the effective flags and generated JavaScript do not use JSPI (`-sJSPI`,
+`-sJSPI_EXPORTS`, `WebAssembly.Suspending`, or `WebAssembly.promising`). Safari
+is a required target, so run a real Safari smoke test before making that
+toolchain the release default. Chrome and Node tests do not satisfy this check.
+
 
 
 Make sure and watch the jobs to verify that it worked.


### PR DESCRIPTION
## Summary

- establish Safari as a required production target
- prohibit JSPI from Emscripten upgrades and default linker settings
- require effective-flag inspection and a real Safari smoke test for toolchain changes
- identify the existing JSPI flags as compatibility debt rather than approved precedent

## Validation

- `bash lint` (with the documented soldr cache bypass after a local daemon failure)
- `bash test` (194 Rust tests, Tauri/doc tests, and 18 Python tests)