### PR TITLE
feat(cli): make WASM link mode explicit

### DIFF
--- a/.github/workflows/linux-x86-dwarf-smoke.yml
+++ b/.github/workflows/linux-x86-dwarf-smoke.yml
@@ -86,13 +86,13 @@ jobs:
           mkdir -p "$sketch_dir/data"
           printf '{"dynamic":true}\n' > "$sketch_dir/data/config.json"
 
-          "$fastled_bin" --just-compile --quick --link-mode dynamic --no-interactive "$sketch_dir"
+          "$fastled_bin" --just-compile --quick --link dynamic --no-interactive "$sketch_dir"
           node ci/dynamic_runtime_smoke.mjs "$fastled_bin" "$sketch_dir/fastled_js"
 
           mv "$sketch_dir/fastled_js/sketch_assets.json" "$sketch_dir/fastled_js/files.json"
           node ci/dynamic_runtime_smoke.mjs "$fastled_bin" "$sketch_dir/fastled_js"
 
-          "$fastled_bin" --just-compile --quick --link-mode dynamic --no-app --no-interactive "$sketch_dir"
+          "$fastled_bin" --just-compile --quick --link dynamic --no-app --no-interactive "$sketch_dir"
           node ci/dynamic_runtime_smoke.mjs "$fastled_bin" "$sketch_dir/fastled_js" --no-app
 
       - name: Upload failure logs

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Useful flags:
 |------|-------------|
 | `--just-compile` | Compile and exit without opening a browser or watching files |
 | `--no-app` | Emit the JavaScript API/WASM artifacts without the default `index.js` application |
-| `--link-mode <static|dynamic>` | Static linking is the default; dynamic mode emits and load-links `sketch.wasm` |
+| `--link <static|dynamic>` | Static linking is the default; dynamic mode emits and load-links `sketch.wasm` |
 | `--debug` | Build with debug-friendly compiler settings |
 | `--quick` | Default build mode |
 | `--release` | Optimized build (~1/3 smaller binary) |

--- a/crates/fastled-cli/src/build.rs
+++ b/crates/fastled-cli/src/build.rs
@@ -3,4 +3,46 @@
 //! The Rust CLI owns the build backend directly. Python remains a compatibility
 //! API layer and is not part of the primary compile path.
 
+use crate::cli::LinkMode;
+
 pub use crate::wasm_build::{run_build, run_build_streaming, BuildMode, BuildRequest, BuildResult};
+
+pub(crate) fn effective_link_mode(build_mode: BuildMode, requested: LinkMode) -> LinkMode {
+    if build_mode == BuildMode::Release && requested == LinkMode::Dynamic {
+        LinkMode::Static
+    } else {
+        requested
+    }
+}
+
+pub(crate) fn dynamic_linking_release_fallback(build_mode: BuildMode, requested: LinkMode) -> bool {
+    build_mode == BuildMode::Release && requested == LinkMode::Dynamic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_dynamic_is_normalized_to_static() {
+        assert_eq!(
+            effective_link_mode(BuildMode::Release, LinkMode::Dynamic),
+            LinkMode::Static
+        );
+        assert!(dynamic_linking_release_fallback(
+            BuildMode::Release,
+            LinkMode::Dynamic
+        ));
+    }
+
+    #[test]
+    fn dynamic_is_preserved_in_non_release_modes() {
+        for mode in [BuildMode::Debug, BuildMode::Quick] {
+            assert_eq!(
+                effective_link_mode(mode, LinkMode::Dynamic),
+                LinkMode::Dynamic
+            );
+            assert!(!dynamic_linking_release_fallback(mode, LinkMode::Dynamic));
+        }
+    }
+}

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -88,11 +88,8 @@ pub(crate) struct Cli {
     pub(crate) no_app: bool,
 
     /// Select static linking (the default) or Emscripten side-module linking.
-    #[arg(long = "link", alias = "link-mode", value_enum, default_value_t = LinkMode::Static)]
+    #[arg(long = "link", value_enum, default_value_t = LinkMode::Static)]
     pub(crate) link_mode: LinkMode,
-
-    #[arg(skip)]
-    pub(crate) legacy_link_mode: bool,
 
     /// Enable profiling of the C++ build system used for WASM compilation.
     #[arg(long)]
@@ -218,12 +215,6 @@ mod tests {
     fn api_and_dynamic_linking_flags_parse_together() {
         let cli = Cli::parse_from(["fastled", "sketch", "--no-app", "--link=dynamic"]);
         assert!(cli.no_app);
-        assert_eq!(cli.link_mode, LinkMode::Dynamic);
-    }
-
-    #[test]
-    fn old_link_mode_spelling_remains_parseable() {
-        let cli = Cli::parse_from(["fastled", "sketch", "--link-mode=dynamic"]);
         assert_eq!(cli.link_mode, LinkMode::Dynamic);
     }
 

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -88,8 +88,11 @@ pub(crate) struct Cli {
     pub(crate) no_app: bool,
 
     /// Select static linking (the default) or Emscripten side-module linking.
-    #[arg(long, value_enum, default_value_t = LinkMode::Static)]
+    #[arg(long = "link", alias = "link-mode", value_enum, default_value_t = LinkMode::Static)]
     pub(crate) link_mode: LinkMode,
+
+    #[arg(skip)]
+    pub(crate) legacy_link_mode: bool,
 
     /// Enable profiling of the C++ build system used for WASM compilation.
     #[arg(long)]
@@ -213,8 +216,14 @@ mod tests {
 
     #[test]
     fn api_and_dynamic_linking_flags_parse_together() {
-        let cli = Cli::parse_from(["fastled", "sketch", "--no-app", "--link-mode=dynamic"]);
+        let cli = Cli::parse_from(["fastled", "sketch", "--no-app", "--link=dynamic"]);
         assert!(cli.no_app);
+        assert_eq!(cli.link_mode, LinkMode::Dynamic);
+    }
+
+    #[test]
+    fn old_link_mode_spelling_remains_parseable() {
+        let cli = Cli::parse_from(["fastled", "sketch", "--link-mode=dynamic"]);
         assert_eq!(cli.link_mode, LinkMode::Dynamic);
     }
 

--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use crate::build;
 use crate::cli::{requested_init_ref, validate_init_ref_flags, Cli};
 use crate::compile_stream::{
-    ensure_compile_prerequisites, purge_fastled_cache, report_build_outcome,
+    announce_link_mode, ensure_compile_prerequisites, purge_fastled_cache, report_build_outcome,
     run_native_compile_streaming, selected_build_mode, send_sse, write_build_status,
 };
 use crate::debug_symbols;
@@ -34,6 +34,8 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
         eprintln!("fastled: sketch directory does not exist: {dir}");
         return ExitCode::FAILURE;
     }
+
+    announce_link_mode(cli, None, true);
 
     // Ensure the emscripten + esbuild toolchains are installed before invoking
     // the native Rust build backend. The backend consumes the Rust-installed
@@ -98,6 +100,7 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
             &tx,
             r#"{"type":"status","status":"compiling","message":"Compiling..."}"#,
         );
+        announce_link_mode(cli, Some(&tx), false);
 
         let success =
             run_native_compile_streaming(cli, &sketch_dir, cli.purge, &tx, &debug_symbols);
@@ -320,6 +323,7 @@ pub(crate) fn run_native_init(cli: &Cli, example: Option<&str>) -> ExitCode {
 }
 
 pub(crate) fn run_native_just_compile(cli: &Cli, dir: &str) -> ExitCode {
+    announce_link_mode(cli, None, true);
     if let Err(message) = ensure_compile_prerequisites(!cli.no_app) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
@@ -337,7 +341,7 @@ pub(crate) fn run_native_just_compile(cli: &Cli, dir: &str) -> ExitCode {
         force_clean: cli.purge,
         emit_clangd: cli.clangd,
         no_app: cli.no_app,
-        link_mode: cli.link_mode,
+        link_mode: crate::compile_stream::effective_link_mode(cli),
     };
 
     let result = match build::run_build(&request) {

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -69,8 +69,6 @@ pub(crate) const DYNAMIC_RELEASE_WARNING: &str =
 fn migration_warning(cli: &Cli) -> Option<&'static str> {
     if build::dynamic_linking_release_fallback(selected_build_mode(cli), cli.link_mode) {
         Some(DYNAMIC_RELEASE_WARNING)
-    } else if cli.legacy_link_mode {
-        Some("warning: --link-mode is deprecated; use --link instead")
     } else {
         None
     }

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use crate::build;
@@ -46,6 +47,68 @@ pub(crate) fn selected_build_mode(cli: &Cli) -> build::BuildMode {
         build::BuildMode::Release
     } else {
         build::BuildMode::Quick
+    }
+}
+
+pub(crate) fn effective_link_mode(cli: &Cli) -> crate::cli::LinkMode {
+    build::effective_link_mode(selected_build_mode(cli), cli.link_mode)
+}
+
+pub(crate) fn link_mode_announcement(mode: crate::cli::LinkMode) -> &'static str {
+    match mode {
+        crate::cli::LinkMode::Static => "Link mode: static (sketch linked into fastled.wasm)",
+        crate::cli::LinkMode::Dynamic => {
+            "Link mode: dynamic (sketch emitted as sketch.wasm side module)"
+        }
+    }
+}
+
+pub(crate) const DYNAMIC_RELEASE_WARNING: &str =
+    "warning: dynamic linking is unavailable in release mode; using --link static instead";
+
+fn migration_warning(cli: &Cli) -> Option<&'static str> {
+    if build::dynamic_linking_release_fallback(selected_build_mode(cli), cli.link_mode) {
+        Some(DYNAMIC_RELEASE_WARNING)
+    } else if cli.legacy_link_mode {
+        Some("warning: --link-mode is deprecated; use --link instead")
+    } else {
+        None
+    }
+}
+
+pub(crate) fn announce_link_mode(
+    cli: &Cli,
+    tx: Option<&tokio::sync::broadcast::Sender<String>>,
+    terminal: bool,
+) {
+    let mode = effective_link_mode(cli);
+    if terminal {
+        println!("{}", link_mode_announcement(mode));
+        if let Some(warning) = migration_warning(cli) {
+            if std::io::stderr().is_terminal() {
+                eprintln!("{}", crossterm::style::Stylize::yellow(warning));
+            } else {
+                eprintln!("{warning}");
+            }
+        }
+    }
+    if let Some(tx) = tx {
+        send_sse(
+            tx,
+            &format!(
+                r#"{{"type":"log","line":"{}","stream":"stdout"}}"#,
+                link_mode_announcement(mode)
+            ),
+        );
+        if let Some(warning) = migration_warning(cli) {
+            send_sse(
+                tx,
+                &format!(
+                    r#"{{"type":"log","line":"{}","stream":"stderr"}}"#,
+                    json_escape(warning)
+                ),
+            );
+        }
     }
 }
 
@@ -241,7 +304,7 @@ pub(crate) fn run_native_compile_streaming(
         force_clean,
         emit_clangd: cli.clangd,
         no_app: cli.no_app,
-        link_mode: cli.link_mode,
+        link_mode: effective_link_mode(cli),
     };
 
     let log = |line: &str, stream: &str| emit_build_log(tx, line, stream);
@@ -291,6 +354,7 @@ pub(crate) fn update_debug_symbol_resolver(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     fn read_status(dir: &Path) -> String {
         std::fs::read_to_string(dir.join("build-status.json")).unwrap()
@@ -334,5 +398,18 @@ mod tests {
         assert!(read_status(dir.path()).contains("\"success\""));
         let event = rx.try_recv().unwrap();
         assert!(event.contains("\"status\":\"success\""), "got: {event}");
+    }
+
+    #[test]
+    fn release_dynamic_report_uses_static_mode_and_exact_warning() {
+        let cli = Cli::parse_from(["fastled", "sketch", "--release", "--link", "dynamic"]);
+        assert_eq!(effective_link_mode(&cli), crate::cli::LinkMode::Static);
+        assert_eq!(migration_warning(&cli), Some(DYNAMIC_RELEASE_WARNING));
+    }
+
+    #[test]
+    fn static_mode_has_no_release_warning() {
+        let cli = Cli::parse_from(["fastled", "sketch", "--release", "--link", "static"]);
+        assert_eq!(migration_warning(&cli), None);
     }
 }

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -38,8 +38,6 @@ const DEFAULT_EXAMPLE: &str = "wasm";
 /// Library entry point invoked by the `fastled` binary.
 pub fn run() -> ExitCode {
     let mut cli = cli::Cli::parse();
-    cli.legacy_link_mode = std::env::args_os()
-        .any(|arg| arg == "--link-mode" || arg.to_string_lossy().starts_with("--link-mode="));
 
     if let Err(message) = cli::validate_init_ref_flags(&cli) {
         eprintln!("fastled: {message}");
@@ -216,7 +214,6 @@ mod tests {
             just_compile: false,
             no_app: false,
             link_mode: crate::cli::LinkMode::Static,
-            legacy_link_mode: false,
             profile: false,
             install: false,
             dry_run: false,

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -38,6 +38,8 @@ const DEFAULT_EXAMPLE: &str = "wasm";
 /// Library entry point invoked by the `fastled` binary.
 pub fn run() -> ExitCode {
     let mut cli = cli::Cli::parse();
+    cli.legacy_link_mode = std::env::args_os()
+        .any(|arg| arg == "--link-mode" || arg.to_string_lossy().starts_with("--link-mode="));
 
     if let Err(message) = cli::validate_init_ref_flags(&cli) {
         eprintln!("fastled: {message}");
@@ -214,6 +216,7 @@ mod tests {
             just_compile: false,
             no_app: false,
             link_mode: crate::cli::LinkMode::Static,
+            legacy_link_mode: false,
             profile: false,
             install: false,
             dry_run: false,

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -2034,6 +2034,8 @@ pub fn run_build(request: &BuildRequest) -> Result<BuildResult> {
 /// Run the build, forwarding every output line (tool stdout/stderr plus
 /// `[WASM]` progress markers) to `log` as it is produced.
 pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<BuildResult> {
+    let effective_link_mode =
+        crate::build::effective_link_mode(request.build_mode, request.link_mode);
     let wall_start = std::time::Instant::now();
     let output_dir = mode_output_dir(&request.sketch_dir);
     if request.force_clean && output_dir.exists() {
@@ -2053,10 +2055,10 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
     let sketch_start = std::time::Instant::now();
     let strategy = if output_dir.join("fastled.js").is_file()
         && output_dir.join("fastled.wasm").is_file()
-        && (request.link_mode == LinkMode::Static || output_dir.join("sketch.wasm").is_file())
+        && (effective_link_mode == LinkMode::Static || output_dir.join("sketch.wasm").is_file())
         && !request.force_clean
     {
-        match request.link_mode {
+        match effective_link_mode {
             LinkMode::Static => "incremental-static",
             LinkMode::Dynamic => "incremental-dynamic",
         }
@@ -2066,7 +2068,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
     .to_string();
 
     let build_result = (|| -> Result<()> {
-        let build_dir = build_dir(&fastled_dir, request.build_mode, request.link_mode);
+        let build_dir = build_dir(&fastled_dir, request.build_mode, effective_link_mode);
         let sketch_cache = sketch_cache_dir(&example_dir);
         if request.force_clean {
             for cache in [
@@ -2085,7 +2087,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &fastled_dir,
             &tools,
             request.build_mode,
-            request.link_mode,
+            effective_link_mode,
         )?;
         log(
             &format!(
@@ -2101,7 +2103,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &tools,
             &build_dir,
             request.build_mode,
-            request.link_mode,
+            effective_link_mode,
             request.force_clean,
             &fingerprints.library,
             log,
@@ -2131,7 +2133,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &sketch_cache,
             &example_dir,
             request.build_mode,
-            request.link_mode,
+            effective_link_mode,
             &sketch_dwarf_roots,
             &fingerprints,
             log,
@@ -2145,7 +2147,7 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
             &sketch_cache,
             &output_js,
             request.build_mode,
-            request.link_mode,
+            effective_link_mode,
             &fingerprints,
             log,
         )?;


### PR DESCRIPTION
Implements #198: canonical --link static|dynamic flag with hidden deprecated --link-mode alias, terminal/SSE effective-mode reporting, release+dynamic fallback to static, backend invariant enforcement, and migrated README/CI usage. Validation: cargo fmt check, cargo test --workspace (199 Rust tests), bash lint, bash test (18 Python tests), and CLI help verification. Refs #198