### PR TITLE
feat(intellisense): preprocess live Arduino sketches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,8 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.2",
  "tower-http",
+ "tree-sitter",
+ "tree-sitter-cpp",
  "windows-sys 0.61.2",
  "zccache-fingerprint",
  "zip",
@@ -4212,6 +4214,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4522,6 +4525,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -5387,6 +5396,36 @@ dependencies = [
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ windows-sys = "0.61"
 zccache-fingerprint = { git = "https://github.com/zackees/zccache", rev = "1bd5b6387eff54695e37adbfacbb977079d6f174" }
 shell-words = "1"
 globset = "0.4"
+tree-sitter = "0.26.9"
+tree-sitter-cpp = "0.23.4"
 
 [profile.release]
 debug = "line-tables-only"

--- a/crates/fastled-cli/Cargo.toml
+++ b/crates/fastled-cli/Cargo.toml
@@ -49,6 +49,8 @@ zccache-fingerprint = { workspace = true }
 shell-words = { workspace = true }
 globset = { workspace = true }
 getrandom = "0.3"
+tree-sitter = { workspace = true }
+tree-sitter-cpp = { workspace = true }
 
 [build-dependencies]
 indexmap = { version = "1.9.3", features = ["std"] }

--- a/crates/fastled-cli/src/clangd_config.rs
+++ b/crates/fastled-cli/src/clangd_config.rs
@@ -39,8 +39,12 @@ pub struct ClangdConfigInputs {
     pub tools_empp_path: NormalizedPath,
     /// The generated wrapper `.cpp` that is actually compiled.
     pub wrapper_source: NormalizedPath,
-    /// The sketch `.ino` file, so clangd treats it as a translation unit.
-    pub ino_file: NormalizedPath,
+    /// Every top-level sketch `.ino` tab, so clangd sees each user buffer as
+    /// a translation unit with the same generated declaration prelude.
+    pub ino_files: Vec<NormalizedPath>,
+    /// The generated Arduino declaration prelude force-included for raw `.ino`
+    /// buffers. It is shared by clangd and Microsoft C/C++ IntelliSense.
+    pub prototype_header: NormalizedPath,
     /// Result of `get_sketch_compile_flags()` for the active build mode.
     pub compile_flags: Vec<String>,
     /// The active build mode.
@@ -168,12 +172,17 @@ fn compile_arguments(
     paths: &ResolvedPaths,
     file: &str,
     force_cpp: bool,
+    force_include: Option<&str>,
 ) -> Vec<String> {
     let mut args = vec![paths.clangxx.clone()];
     if force_cpp {
         // The `.ino` extension is unknown to clang; force C++.
         args.push("-x".to_string());
         args.push("c++".to_string());
+    }
+    if let Some(header) = force_include {
+        args.push("-include".to_string());
+        args.push(header.to_string());
     }
     args.extend([
         "-c".to_string(),
@@ -205,23 +214,31 @@ fn compile_arguments(
 }
 
 fn write_compile_commands(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Result<()> {
-    let ino = display_path(&inputs.ino_file);
     let wrapper = display_path(&inputs.wrapper_source);
+    let prelude = display_path(&inputs.prototype_header);
     // `directory` must be the FastLED checkout because the real build runs
     // with `current_dir(fastled_dir)`.
-    let entries = json!([
-        {
-            "directory": paths.fastled_dir,
-            "file": ino,
-            "arguments": compile_arguments(inputs, paths, &ino, true),
-        },
-        {
-            "directory": paths.fastled_dir,
-            "file": wrapper,
-            "arguments": compile_arguments(inputs, paths, &wrapper, false),
-        },
-    ]);
-    install::write_json_file(&inputs.sketch_dir.join("compile_commands.json"), &entries)
+    let mut entries = inputs
+        .ino_files
+        .iter()
+        .map(|ino_file| {
+            let ino = display_path(ino_file);
+            json!({
+                "directory": paths.fastled_dir,
+                "file": ino,
+                "arguments": compile_arguments(inputs, paths, &ino, true, Some(&prelude)),
+            })
+        })
+        .collect::<Vec<_>>();
+    entries.push(json!({
+        "directory": paths.fastled_dir,
+        "file": wrapper,
+        "arguments": compile_arguments(inputs, paths, &wrapper, false, None),
+    }));
+    install::write_json_file(
+        &inputs.sketch_dir.join("compile_commands.json"),
+        &serde_json::Value::Array(entries),
+    )
 }
 
 fn write_clangd_file(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Result<()> {
@@ -284,10 +301,6 @@ fn write_vscode_settings(paths: &ResolvedPaths, sketch_dir: &Path) -> Result<()>
             "-D__EMSCRIPTEN__=1",
         ]),
     );
-    object.insert("C_Cpp.intelliSenseEngine".to_string(), json!("disabled"));
-    object.insert("C_Cpp.autocomplete".to_string(), json!("disabled"));
-    object.insert("C_Cpp.errorSquiggles".to_string(), json!("disabled"));
-
     let associations = object
         .entry("files.associations")
         .or_insert_with(|| json!({}));
@@ -302,6 +315,33 @@ fn write_vscode_settings(paths: &ResolvedPaths, sketch_dir: &Path) -> Result<()>
     install::write_json_file(&settings_path, &settings)
 }
 
+/// Emit the same compile database and forced declaration prelude for the
+/// Microsoft C/C++ extension. #203 decides which engine is active; neither
+/// engine gets a different Arduino sketch model.
+fn write_cpptools_config(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Result<()> {
+    let path = inputs
+        .sketch_dir
+        .join(".vscode")
+        .join("c_cpp_properties.json");
+    let mut properties = install::read_json_file(&path, json!({}));
+    if !properties.is_object() {
+        properties = json!({});
+    }
+    let root = properties.as_object_mut().expect("properties root object");
+    root.insert(
+        "configurations".to_string(),
+        json!([{
+            "name": "FastLED WASM",
+            "compilerPath": paths.clangxx,
+            "compileCommands": "${workspaceFolder}/compile_commands.json",
+            "cppStandard": "c++20",
+            "includePath": [paths.sketch_dir, paths.fastled_src, paths.fastled_wasm_compiler],
+            "forcedInclude": [display_path(&inputs.prototype_header)],
+        }]),
+    );
+    install::write_json_file(&path, &properties)
+}
+
 /// Write `compile_commands.json`, `.clangd`, and `.vscode/settings.json`
 /// into the sketch directory. All emitted paths are absolute, use forward
 /// slashes, and carry no Windows `\\?\` prefix.
@@ -310,6 +350,7 @@ pub fn write_clangd_config(inputs: &ClangdConfigInputs) -> Result<()> {
     write_compile_commands(inputs, &paths)?;
     write_clangd_file(inputs, &paths)?;
     write_vscode_settings(&paths, &inputs.sketch_dir)?;
+    write_cpptools_config(inputs, &paths)?;
     Ok(())
 }
 
@@ -327,8 +368,6 @@ pub fn run_write_clangd(dir_arg: &str) -> Result<()> {
     if !sketch_dir.is_dir() {
         anyhow::bail!("sketch directory does not exist: {}", sketch_dir.display());
     }
-    let ino_file = NormalizedPath::new(crate::wasm_build::sketch_ino_file(&sketch_dir)?);
-
     let emsdk_install_dir = NormalizedPath::new(install::ensure_emscripten_installed()?);
     let tools_emcc_path = emsdk_install_dir.join("emscripten").join("emcc.py");
     let tools_empp_path = emsdk_install_dir.join("emscripten").join("em++.py");
@@ -340,6 +379,8 @@ pub fn run_write_clangd(dir_arg: &str) -> Result<()> {
         crate::wasm_build::resolve_example_name(&sketch_dir, &fastled_dir);
     let example_dir = NormalizedPath::new(example_dir);
     let sketch_cache = crate::wasm_build::sketch_cache_dir(&example_dir);
+    let (snapshot, prototype_header) =
+        crate::sketch_preprocessor::write_disk_snapshot(&example_dir)?;
     let wrapper_source = NormalizedPath::new(crate::wasm_build::create_wrapper(
         &example_dir,
         &example_name,
@@ -357,13 +398,18 @@ pub fn run_write_clangd(dir_arg: &str) -> Result<()> {
         tools_emcc_path,
         tools_empp_path,
         wrapper_source,
-        ino_file,
+        ino_files: snapshot
+            .documents
+            .iter()
+            .map(|document| NormalizedPath::new(&document.path))
+            .collect(),
+        prototype_header: NormalizedPath::new(prototype_header),
         compile_flags,
         build_mode,
     })?;
 
     println!(
-        "Wrote clangd configuration (compile_commands.json, .clangd, .vscode/settings.json) to {}",
+        "Wrote IntelliSense configuration (compile_commands.json, .clangd, .vscode settings) to {}",
         example_dir.display()
     );
     Ok(())
@@ -381,6 +427,12 @@ mod tests {
         fs::create_dir_all(&cache).unwrap();
         let ino_file = sketch_dir.join("Blink.ino");
         fs::write(&ino_file, "void setup() {}\nvoid loop() {}\n").unwrap();
+        let prototype_header = sketch_dir
+            .join(".fastled")
+            .join("intellisense")
+            .join("prototypes.hpp");
+        fs::create_dir_all(prototype_header.parent().unwrap()).unwrap();
+        fs::write(&prototype_header, "#pragma once\n").unwrap();
         let wrapper_source = cache.join("Blink_wrapper.cpp");
         fs::write(&wrapper_source, "// wrapper\n").unwrap();
 
@@ -421,7 +473,8 @@ mod tests {
             tools_emcc_path: NormalizedPath::new(emsdk.join("emscripten").join("emcc.py")),
             tools_empp_path: NormalizedPath::new(emsdk.join("emscripten").join("em++.py")),
             wrapper_source: NormalizedPath::new(wrapper_source),
-            ino_file: NormalizedPath::new(ino_file),
+            ino_files: vec![NormalizedPath::new(ino_file)],
+            prototype_header: NormalizedPath::new(prototype_header),
             compile_flags: vec![
                 "-DFASTLED_FORCE_NAMESPACE=1".to_string(),
                 "-DSKETCH_COMPILE=1".to_string(),
@@ -540,6 +593,8 @@ mod tests {
             .collect();
         assert!(entries[0]["file"].as_str().unwrap().ends_with("Blink.ino"));
         assert_eq!(&ino_args[1..3], ["-x", "c++"]);
+        assert!(ino_args.windows(2).any(|pair| pair[0] == "-include"
+            && pair[1].ends_with(".fastled/intellisense/prototypes.hpp")));
 
         // .clangd
         let clangd_text = fs::read_to_string(inputs.sketch_dir.join(".clangd")).unwrap();
@@ -564,8 +619,26 @@ mod tests {
         assert!(clangd_args
             .iter()
             .any(|a| a.starts_with("--query-driver=") && a.contains("clang++")));
-        assert_eq!(settings["C_Cpp.intelliSenseEngine"], "disabled");
         assert_eq!(settings["files.associations"]["*.ino"], "cpp");
+
+        let cpptools: Value = serde_json::from_str(
+            &fs::read_to_string(
+                inputs
+                    .sketch_dir
+                    .join(".vscode")
+                    .join("c_cpp_properties.json"),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            cpptools["configurations"][0]["compileCommands"],
+            "${workspaceFolder}/compile_commands.json"
+        );
+        assert!(cpptools["configurations"][0]["forcedInclude"][0]
+            .as_str()
+            .unwrap()
+            .ends_with(".fastled/intellisense/prototypes.hpp"));
     }
 
     #[test]
@@ -599,5 +672,35 @@ mod tests {
         write_clangd_config(&inputs).unwrap();
         let second = fs::read_to_string(inputs.sketch_dir.join("compile_commands.json")).unwrap();
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn emits_a_forced_prelude_entry_for_every_ino_tab() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut inputs = stub_inputs(tmp.path());
+        let utility = inputs.sketch_dir.join("Utility.ino");
+        fs::write(&utility, "void utility() {}\n").unwrap();
+        inputs.ino_files.push(NormalizedPath::new(utility));
+
+        write_clangd_config(&inputs).unwrap();
+        let commands: Value = serde_json::from_str(
+            &fs::read_to_string(inputs.sketch_dir.join("compile_commands.json")).unwrap(),
+        )
+        .unwrap();
+        let entries = commands.as_array().unwrap();
+        assert_eq!(
+            entries.len(),
+            3,
+            "two visible tabs plus generated C++ source"
+        );
+        for entry in &entries[..2] {
+            let arguments = entry["arguments"].as_array().unwrap();
+            assert!(arguments.windows(2).any(|pair| {
+                pair[0].as_str() == Some("-include")
+                    && pair[1]
+                        .as_str()
+                        .is_some_and(|value| value.ends_with("prototypes.hpp"))
+            }));
+        }
     }
 }

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -231,6 +231,11 @@ pub(crate) struct Cli {
     #[arg(long, value_name = "DIR", num_args = 0..=1, default_missing_value = "__cwd__")]
     pub(crate) write_clangd: Option<String>,
 
+    /// Read a versioned JSON document snapshot from stdin and atomically
+    /// refresh the ignored IntelliSense cache. Used by the VS Code extension.
+    #[arg(long, hide = true)]
+    pub(crate) write_intellisense_snapshot: bool,
+
     /// Internal plumbing flag: ensure the FastLED repo for the given ref
     /// (defaults to latest release) is downloaded and extracted, print the
     /// local path to stdout, and exit. Used by the Python `Api.project_init`
@@ -303,6 +308,12 @@ mod tests {
         assert!(!cli.clangd);
         let cli = Cli::parse_from(["fastled", "--clangd", "sketch"]);
         assert!(cli.clangd);
+    }
+
+    #[test]
+    fn parses_stdin_intellisense_snapshot_command() {
+        let cli = Cli::parse_from(["fastled", "--write-intellisense-snapshot"]);
+        assert!(cli.write_intellisense_snapshot);
     }
 
     #[test]

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -25,6 +25,7 @@ pub mod project;
 pub mod runtime;
 mod selection;
 mod server;
+mod sketch_preprocessor;
 mod test_mode;
 pub mod viewer;
 pub mod wasm_build;
@@ -109,6 +110,16 @@ pub fn run() -> ExitCode {
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
                 eprintln!("fastled: failed to write clangd config: {err:#}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    if cli.write_intellisense_snapshot {
+        return match sketch_preprocessor::run_stdin_snapshot() {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(err) => {
+                eprintln!("fastled: failed to write IntelliSense snapshot: {err:#}");
                 ExitCode::FAILURE
             }
         };
@@ -242,6 +253,7 @@ mod tests {
             purge: false,
             clangd: false,
             write_clangd: None,
+            write_intellisense_snapshot: false,
             internal_ensure_fastled_repo: None,
             internal_dwarf_smoke: false,
             internal_serve_dir_headless: None,

--- a/crates/fastled-cli/src/sketch_preprocessor.rs
+++ b/crates/fastled-cli/src/sketch_preprocessor.rs
@@ -1,0 +1,724 @@
+//! Arduino `.ino` preprocessing shared by the WASM build and editor support.
+//!
+//! This is deliberately adapted from FastLED/fbuild's source scanner at
+//! `1e75ccf5a4ca922b4d922a6da286b965fac8832d`. Keep generic parser fixes in
+//! fbuild: this local adapter is transitional until fbuild publishes a stable
+//! preprocessor crate/API that fastled-wasm can depend on directly (see #206).
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tree_sitter::{Node, Parser};
+
+use crate::path::NormalizedPath;
+
+/// A VS Code document buffer. Paths must name top-level `.ino` tabs in the
+/// sketch directory; unopened tabs are loaded from disk.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SnapshotDocument {
+    pub path: String,
+    pub version: i64,
+    pub text: String,
+}
+
+/// JSON protocol sent over stdin by the VS Code extension.
+#[derive(Debug, Deserialize)]
+pub struct SnapshotRequest {
+    pub sketch_dir: String,
+    pub generation: u64,
+    #[serde(default)]
+    pub documents: Vec<SnapshotDocument>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestDocument {
+    pub path: String,
+    pub version: Option<i64>,
+    pub sha256: String,
+}
+
+/// Completion marker for an IntelliSense cache generation. Consumers should
+/// only use the source/header named by this manifest after validating hashes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotManifest {
+    pub schema: u32,
+    pub generation: u64,
+    pub documents: Vec<ManifestDocument>,
+    pub generated_source: String,
+    pub generated_source_sha256: String,
+    pub prototype_header: String,
+    pub prototype_header_sha256: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreprocessedSketch {
+    pub translation_unit: String,
+    pub prototype_header: String,
+    pub documents: Vec<ManifestDocument>,
+}
+
+/// Read the extension request, render a canonical source view, and publish it
+/// under `<sketch>/.fastled/intellisense`. A malformed half-typed source is
+/// never published, so the previous manifest/header remain available.
+pub fn run_stdin_snapshot() -> Result<()> {
+    let mut request_json = String::new();
+    io::stdin()
+        .read_to_string(&mut request_json)
+        .context("read IntelliSense snapshot request from stdin")?;
+    let request: SnapshotRequest =
+        serde_json::from_str(&request_json).context("parse IntelliSense snapshot JSON")?;
+    let manifest = write_live_snapshot(&request)?;
+    println!("{}", serde_json::to_string(&manifest)?);
+    Ok(())
+}
+
+pub fn preprocess_disk(sketch_dir: &Path) -> Result<PreprocessedSketch> {
+    preprocess(sketch_dir, &BTreeMap::new())
+}
+
+pub fn write_disk_snapshot(sketch_dir: &Path) -> Result<(SnapshotManifest, NormalizedPath)> {
+    let request = SnapshotRequest {
+        sketch_dir: sketch_dir.to_string_lossy().into_owned(),
+        generation: 0,
+        documents: Vec::new(),
+    };
+    // A tab topology refresh must replace a previous live generation so the
+    // compile database reflects renamed/deleted disk tabs. The extension
+    // immediately follows this with a newer live snapshot when buffers exist.
+    let manifest = write_snapshot(&request, true)?;
+    Ok((
+        manifest,
+        intellisense_dir(sketch_dir).join("prototypes.hpp"),
+    ))
+}
+
+pub fn write_live_snapshot(request: &SnapshotRequest) -> Result<SnapshotManifest> {
+    write_snapshot(request, false)
+}
+
+fn write_snapshot(request: &SnapshotRequest, force_disk_refresh: bool) -> Result<SnapshotManifest> {
+    let sketch_dir = crate::path::canonicalize_normalized(Path::new(&request.sketch_dir));
+    if !sketch_dir.is_dir() {
+        bail!("sketch directory does not exist: {}", sketch_dir.display());
+    }
+
+    let mut open_documents: BTreeMap<NormalizedPath, SnapshotDocument> = BTreeMap::new();
+    for document in &request.documents {
+        let path = crate::path::canonicalize_normalized(Path::new(&document.path));
+        if path.as_path().parent() != Some(sketch_dir.as_path()) || !is_ino(&path) {
+            bail!(
+                "snapshot document must be a top-level .ino tab in {}: {}",
+                sketch_dir.display(),
+                path.display()
+            );
+        }
+        open_documents.insert(path, document.clone());
+    }
+
+    let cache_dir = intellisense_dir(&sketch_dir);
+    fs::create_dir_all(
+        cache_dir
+            .as_path()
+            .parent()
+            .expect("intellisense cache parent"),
+    )?;
+    fs::write(
+        cache_dir
+            .as_path()
+            .parent()
+            .expect("cache parent")
+            .join(".gitignore"),
+        "*\n!.gitignore\n",
+    )?;
+    let lock_path = cache_dir
+        .as_path()
+        .parent()
+        .expect("cache parent")
+        .join(".lock");
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("open IntelliSense lock {}", lock_path.display()))?;
+    lock.lock_exclusive()
+        .context("lock IntelliSense snapshot")?;
+
+    if let Some(existing) = read_manifest(&cache_dir) {
+        if !force_disk_refresh && existing.generation > request.generation {
+            return Ok(existing);
+        }
+    }
+
+    // Do all parsing before writing anything. This preserves the last good
+    // prelude when VS Code sends a transient syntactically incomplete buffer.
+    let rendered = preprocess(sketch_dir.as_path(), &open_documents)?;
+    let manifest = SnapshotManifest {
+        schema: 1,
+        generation: request.generation,
+        documents: rendered.documents,
+        generated_source: "sketch.cpp".to_string(),
+        generated_source_sha256: sha256(&rendered.translation_unit),
+        prototype_header: "prototypes.hpp".to_string(),
+        prototype_header_sha256: sha256(&rendered.prototype_header),
+    };
+
+    fs::create_dir_all(&cache_dir)?;
+    atomic_write(
+        &cache_dir.join(&manifest.generated_source),
+        &rendered.translation_unit,
+    )?;
+    atomic_write(
+        &cache_dir.join(&manifest.prototype_header),
+        &rendered.prototype_header,
+    )?;
+    // The manifest is written last and is the atomic publication marker.
+    atomic_write(
+        &cache_dir.join("manifest.json"),
+        &serde_json::to_string_pretty(&manifest)?,
+    )?;
+    Ok(manifest)
+}
+
+fn preprocess(
+    sketch_dir: &Path,
+    open_documents: &BTreeMap<NormalizedPath, SnapshotDocument>,
+) -> Result<PreprocessedSketch> {
+    let tabs = discover_tabs(sketch_dir)?;
+    let mut contents = Vec::with_capacity(tabs.len());
+    let mut documents = Vec::with_capacity(tabs.len());
+    for tab in &tabs {
+        let (text, version) = if let Some(document) = open_documents.get(tab) {
+            (document.text.clone(), Some(document.version))
+        } else {
+            (
+                fs::read_to_string(tab).with_context(|| format!("read {}", tab.display()))?,
+                None,
+            )
+        };
+        let text = normalize_line_endings(&text);
+        documents.push(ManifestDocument {
+            path: display_path(tab),
+            version,
+            sha256: sha256(&text),
+        });
+        contents.push((tab.clone(), text));
+    }
+
+    let combined = contents
+        .iter()
+        .map(|(_, text)| text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let prototypes = extract_function_prototypes(&combined)?;
+    let prototype_declarations = render_prototype_declarations(&prototypes);
+    let prototype_header = format!(
+        "#pragma once\n// Auto-generated Arduino sketch prototypes.\n{prototype_declarations}"
+    );
+
+    let mut translation_unit = String::from(
+        "// Generated by fastled sketch preprocessor; do not edit.\n\
+         // fbuild provenance: 1e75ccf5a4ca922b4d922a6da286b965fac8832d\n\
+         import \"wasm_pch.h\";\n\n",
+    );
+    translation_unit.push_str(&prototype_declarations);
+    translation_unit.push('\n');
+    for (tab, content) in contents {
+        translation_unit.push_str(&format!("#line 1 \"{}\"\n", display_path(&tab)));
+        translation_unit.push_str(&content);
+        if !content.ends_with('\n') {
+            translation_unit.push('\n');
+        }
+    }
+
+    Ok(PreprocessedSketch {
+        translation_unit,
+        prototype_header,
+        documents,
+    })
+}
+
+fn discover_tabs(sketch_dir: &Path) -> Result<Vec<NormalizedPath>> {
+    let mut tabs = fs::read_dir(sketch_dir)
+        .with_context(|| format!("read sketch directory {}", sketch_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| NormalizedPath::new(entry.path())))
+        .filter(|path| path.is_file() && is_ino(path))
+        .collect::<Vec<_>>();
+    if tabs.is_empty() {
+        bail!("sketch has no .ino files: {}", sketch_dir.display());
+    }
+    tabs.sort_by(|a, b| {
+        a.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_ascii_lowercase()
+            .cmp(
+                &b.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_ascii_lowercase(),
+            )
+    });
+    let primary = sketch_dir.file_name().and_then(|name| name.to_str());
+    if let Some(index) = primary.and_then(|name| {
+        tabs.iter().position(|tab| {
+            tab.file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| stem.eq_ignore_ascii_case(name))
+        })
+    }) {
+        let primary = tabs.remove(index);
+        tabs.insert(0, primary);
+    }
+    Ok(tabs)
+}
+
+fn is_ino(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("ino"))
+}
+
+fn intellisense_dir(sketch_dir: &Path) -> NormalizedPath {
+    NormalizedPath::new(sketch_dir)
+        .join(".fastled")
+        .join("intellisense")
+}
+
+fn read_manifest(cache_dir: &Path) -> Option<SnapshotManifest> {
+    serde_json::from_str(&fs::read_to_string(cache_dir.join("manifest.json")).ok()?).ok()
+}
+
+fn atomic_write(path: &Path, contents: &str) -> Result<()> {
+    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+    fs::write(&temporary, contents).with_context(|| format!("write {}", temporary.display()))?;
+    if path.exists() {
+        // On Windows, rename cannot replace an existing file. The manifest is
+        // committed last, so a reader will never accept a mixed generation.
+        fs::remove_file(path).with_context(|| format!("replace {}", path.display()))?;
+    }
+    fs::rename(&temporary, path).with_context(|| format!("publish {}", path.display()))?;
+    Ok(())
+}
+
+fn display_path(path: &Path) -> String {
+    crate::path::canonicalize_normalized(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn sha256(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}
+
+fn normalize_line_endings(source: &str) -> String {
+    source.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn render_prototype_declarations(prototypes: &[String]) -> String {
+    let mut declarations = String::new();
+    for prototype in prototypes {
+        declarations.push_str(prototype);
+        declarations.push_str(";\n");
+    }
+    declarations
+}
+
+/// Tree-sitter based prototype collection copied/adapted from fbuild's
+/// `source_scanner.rs`; regex-only prototype generation is intentionally not
+/// used because Arduino sketches routinely use attributes/default arguments.
+fn extract_function_prototypes(source: &str) -> Result<Vec<String>> {
+    let mut parser = Parser::new();
+    let language = tree_sitter_cpp::LANGUAGE.into();
+    parser.set_language(&language).context("load C++ parser")?;
+    let tree = parser.parse(source, None).context("parse Arduino sketch")?;
+    if tree.root_node().has_error() {
+        bail!("sketch has incomplete C++ syntax; retaining the last good IntelliSense prelude");
+    }
+    let mut candidates = Vec::new();
+    collect_function_prototypes(tree.root_node(), source, &mut candidates);
+    let mut seen = HashSet::new();
+    Ok(candidates
+        .into_iter()
+        .filter(|prototype| seen.insert(prototype.clone()))
+        .collect())
+}
+
+fn collect_function_prototypes(node: Node<'_>, source: &str, output: &mut Vec<String>) {
+    if node.kind() == "function_definition" {
+        if let Some(prototype) = prototype_from_definition(node, source) {
+            output.push(prototype);
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_function_prototypes(child, source, output);
+    }
+}
+
+fn prototype_from_definition(node: Node<'_>, source: &str) -> Option<String> {
+    if has_skipped_context(node) {
+        return None;
+    }
+    let signature_node = node
+        .parent()
+        .filter(|parent| parent.kind() == "template_declaration")
+        .unwrap_or(node);
+    let body = node.child_by_field_name("body")?;
+    let start = signature_node.start_byte();
+    let signature = source.get(start..body.start_byte())?;
+    let parameters = find_descendant(node, "parameter_list")?;
+    let parameters_start = parameters.start_byte().checked_sub(start)?;
+    let parameters_end = parameters.end_byte().checked_sub(start)?;
+    let signature = normalize_signature(&strip_default_arguments(
+        signature,
+        parameters_start,
+        parameters_end,
+    ))?;
+    if signature.contains("::")
+        || signature.starts_with('#')
+        || matches!(
+            signature.trim(),
+            "void setup()" | "void setup(void)" | "void loop()" | "void loop(void)"
+        )
+    {
+        return None;
+    }
+    Some(signature)
+}
+
+fn has_skipped_context(node: Node<'_>) -> bool {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        match parent.kind() {
+            "namespace_definition"
+            | "class_specifier"
+            | "struct_specifier"
+            | "union_specifier"
+            | "field_declaration_list" => return true,
+            _ => current = parent.parent(),
+        }
+    }
+    false
+}
+
+fn find_descendant<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            return Some(child);
+        }
+        if let Some(found) = find_descendant(child, kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn normalize_signature(signature: &str) -> Option<String> {
+    let lines = signature
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    (!lines.is_empty()).then(|| lines.join(" "))
+}
+
+fn strip_default_arguments(signature: &str, start: usize, end: usize) -> String {
+    let Some(parameters) = signature.get(start..end) else {
+        return signature.to_string();
+    };
+    let Some(inner) = parameters
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+    else {
+        return signature.to_string();
+    };
+    format!(
+        "{}({}){}",
+        &signature[..start],
+        strip_defaults(inner),
+        &signature[end..]
+    )
+}
+
+fn strip_defaults(parameters: &str) -> String {
+    let mut output = String::new();
+    let mut skip_default = false;
+    let mut depths = [0usize; 4]; // paren, bracket, brace, angle
+    let mut quote = None;
+    let mut escaped = false;
+    for character in parameters.chars() {
+        if let Some(delimiter) = quote {
+            if !skip_default {
+                output.push(character);
+            }
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '\'' | '"' => {
+                if !skip_default {
+                    output.push(character);
+                }
+                quote = Some(character);
+            }
+            '(' => {
+                depths[0] += 1;
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            ')' => {
+                depths[0] = depths[0].saturating_sub(1);
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            '[' => {
+                depths[1] += 1;
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            ']' => {
+                depths[1] = depths[1].saturating_sub(1);
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            '{' => {
+                depths[2] += 1;
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            '}' => {
+                depths[2] = depths[2].saturating_sub(1);
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            '<' => {
+                depths[3] += 1;
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            '>' => {
+                depths[3] = depths[3].saturating_sub(1);
+                if !skip_default {
+                    output.push(character);
+                }
+            }
+            '=' if depths.iter().all(|depth| *depth == 0) => {
+                skip_default = true;
+                output = output.trim_end().to_string();
+            }
+            ',' if depths.iter().all(|depth| *depth == 0) => {
+                skip_default = false;
+                output = output.trim_end().to_string();
+                output.push(',');
+            }
+            _ if !skip_default => output.push(character),
+            _ => {}
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orders_primary_then_other_top_level_tabs_and_maps_each_tab() {
+        let temp = tempfile::tempdir().unwrap();
+        let sketch = temp.path().join("Blink");
+        fs::create_dir_all(sketch.join("nested")).unwrap();
+        fs::write(
+            sketch.join("Blink.ino"),
+            "void setup() { helper(); }\nvoid loop() {}\n",
+        )
+        .unwrap();
+        fs::write(sketch.join("zeta.ino"), "void zeta() {}\n").unwrap();
+        fs::write(sketch.join("Alpha.ino"), "void helper(int value = 1) {}\n").unwrap();
+        fs::write(
+            sketch.join("nested").join("ignored.ino"),
+            "void ignored() {}\n",
+        )
+        .unwrap();
+        fs::write(sketch.join("old.pde"), "void old() {}\n").unwrap();
+
+        let rendered = preprocess_disk(&sketch).unwrap();
+        let names = rendered
+            .documents
+            .iter()
+            .map(|document| {
+                Path::new(&document.path)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["Blink.ino", "Alpha.ino", "zeta.ino"]);
+        assert!(rendered.prototype_header.contains("void helper(int value)"));
+        assert!(!rendered.translation_unit.contains("ignored.ino"));
+        assert!(!rendered.translation_unit.contains("old.pde"));
+        for document in &rendered.documents {
+            assert!(rendered
+                .translation_unit
+                .contains(&format!("#line 1 \"{}\"", document.path)));
+        }
+    }
+
+    #[test]
+    fn live_snapshot_uses_unsaved_text_and_never_overwrites_sketch() {
+        let temp = tempfile::tempdir().unwrap();
+        let sketch = temp.path().join("Sketch");
+        fs::create_dir_all(&sketch).unwrap();
+        let source = sketch.join("Sketch.ino");
+        fs::write(
+            &source,
+            "void setup() { old_name(); }\nvoid loop() {}\nvoid old_name() {}\n",
+        )
+        .unwrap();
+        let request = SnapshotRequest {
+            sketch_dir: sketch.to_string_lossy().into_owned(),
+            generation: 3,
+            documents: vec![SnapshotDocument {
+                path: source.to_string_lossy().into_owned(),
+                version: 9,
+                text: "void setup() { new_name(); }\nvoid loop() {}\nvoid new_name() {}\n"
+                    .to_string(),
+            }],
+        };
+        let manifest = write_live_snapshot(&request).unwrap();
+        let cache = intellisense_dir(&sketch);
+        assert_eq!(manifest.generation, 3);
+        assert!(fs::read_to_string(cache.join("sketch.cpp"))
+            .unwrap()
+            .contains("new_name"));
+        assert!(fs::read_to_string(&source).unwrap().contains("old_name"));
+        assert_eq!(
+            fs::read_to_string(sketch.join(".fastled/.gitignore")).unwrap(),
+            "*\n!.gitignore\n"
+        );
+    }
+
+    #[test]
+    fn invalid_new_buffer_preserves_last_known_good_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let sketch = temp.path().join("Sketch");
+        fs::create_dir_all(&sketch).unwrap();
+        let source = sketch.join("Sketch.ino");
+        fs::write(
+            &source,
+            "void setup() {}\nvoid loop() {}\nvoid helper() {}\n",
+        )
+        .unwrap();
+        write_live_snapshot(&SnapshotRequest {
+            sketch_dir: sketch.to_string_lossy().into_owned(),
+            generation: 1,
+            documents: vec![],
+        })
+        .unwrap();
+        let bad = SnapshotRequest {
+            sketch_dir: sketch.to_string_lossy().into_owned(),
+            generation: 2,
+            documents: vec![SnapshotDocument {
+                path: source.to_string_lossy().into_owned(),
+                version: 2,
+                text: "void setup(\n".to_string(),
+            }],
+        };
+        assert!(write_live_snapshot(&bad).is_err());
+        assert_eq!(
+            read_manifest(&intellisense_dir(&sketch))
+                .unwrap()
+                .generation,
+            1
+        );
+    }
+
+    #[test]
+    fn older_generation_cannot_replace_newer_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let sketch = temp.path().join("Sketch");
+        fs::create_dir_all(&sketch).unwrap();
+        let source = sketch.join("Sketch.ino");
+        fs::write(&source, "void setup() {}\nvoid loop() {}\n").unwrap();
+        let newest = SnapshotRequest {
+            sketch_dir: sketch.to_string_lossy().into_owned(),
+            generation: 4,
+            documents: vec![SnapshotDocument {
+                path: source.to_string_lossy().into_owned(),
+                version: 4,
+                text: "void setup() { newest(); }\nvoid loop() {}\nvoid newest() {}\n".to_string(),
+            }],
+        };
+        write_live_snapshot(&newest).unwrap();
+        let stale = SnapshotRequest {
+            sketch_dir: sketch.to_string_lossy().into_owned(),
+            generation: 3,
+            documents: vec![SnapshotDocument {
+                path: source.to_string_lossy().into_owned(),
+                version: 3,
+                text: "void setup() { stale(); }\nvoid loop() {}\nvoid stale() {}\n".to_string(),
+            }],
+        };
+        let manifest = write_live_snapshot(&stale).unwrap();
+        assert_eq!(manifest.generation, 4);
+        assert!(
+            fs::read_to_string(intellisense_dir(&sketch).join("sketch.cpp"))
+                .unwrap()
+                .contains("newest")
+        );
+    }
+
+    #[test]
+    fn disk_topology_refresh_replaces_a_previous_live_generation() {
+        let temp = tempfile::tempdir().unwrap();
+        let sketch = temp.path().join("Sketch");
+        fs::create_dir_all(&sketch).unwrap();
+        let source = sketch.join("Sketch.ino");
+        fs::write(
+            &source,
+            "void setup() { disk(); }\nvoid loop() {}\nvoid disk() {}\n",
+        )
+        .unwrap();
+        write_live_snapshot(&SnapshotRequest {
+            sketch_dir: sketch.to_string_lossy().into_owned(),
+            generation: 9,
+            documents: vec![SnapshotDocument {
+                path: source.to_string_lossy().into_owned(),
+                version: 9,
+                text: "void setup() { live(); }\nvoid loop() {}\nvoid live() {}\n".to_string(),
+            }],
+        })
+        .unwrap();
+
+        let (manifest, _) = write_disk_snapshot(&sketch).unwrap();
+        assert_eq!(manifest.generation, 0);
+        assert!(
+            fs::read_to_string(intellisense_dir(&sketch).join("sketch.cpp"))
+                .unwrap()
+                .contains("disk")
+        );
+    }
+}

--- a/crates/fastled-cli/src/sketch_preprocessor.rs
+++ b/crates/fastled-cli/src/sketch_preprocessor.rs
@@ -403,7 +403,11 @@ fn has_skipped_context(node: Node<'_>) -> bool {
             | "class_specifier"
             | "struct_specifier"
             | "union_specifier"
-            | "field_declaration_list" => return true,
+            | "field_declaration_list"
+            // Arduino sketches occasionally expose WASM/browser hooks with
+            // `extern \"C\"`. A generated C++ declaration would change the
+            // function's language linkage and make the later definition fail.
+            | "linkage_specification" => return true,
             _ => current = parent.parent(),
         }
     }
@@ -720,5 +724,22 @@ mod tests {
                 .unwrap()
                 .contains("disk")
         );
+    }
+
+    #[test]
+    fn does_not_generate_cxx_prototypes_for_extern_c_definitions() {
+        let source = r#"
+            extern "C" {
+                __attribute__((noinline, used)) void browser_hook() {}
+            }
+            void helper() {}
+        "#;
+        let prototypes = extract_function_prototypes(source).unwrap();
+        assert!(prototypes
+            .iter()
+            .any(|prototype| prototype.contains("helper")));
+        assert!(!prototypes
+            .iter()
+            .any(|prototype| prototype.contains("browser_hook")));
     }
 }

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -932,33 +932,6 @@ pub(crate) fn sketch_cache_dir(example_dir: &Path) -> PathBuf {
     example_dir.join(".build").join("wasm")
 }
 
-pub(crate) fn sketch_ino_file(example_dir: &Path) -> Result<PathBuf> {
-    let sketch_name = example_dir
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("sketch");
-    let expected = example_dir.join(format!("{sketch_name}.ino"));
-    if expected.is_file() {
-        return Ok(expected);
-    }
-
-    let mut candidates = Vec::new();
-    for entry in fs::read_dir(example_dir)
-        .with_context(|| format!("read sketch directory {}", example_dir.display()))?
-    {
-        let path = entry?.path();
-        if path.extension().and_then(|ext| ext.to_str()) == Some("ino") {
-            candidates.push(path);
-        }
-    }
-    candidates.sort();
-    match candidates.as_slice() {
-        [single] => Ok(single.clone()),
-        [] => bail!("example has no .ino file: {}", example_dir.display()),
-        _ => bail!("example has multiple .ino files: {}", example_dir.display()),
-    }
-}
-
 fn wrapper_stem(example_name: &str) -> String {
     example_name.replace(['\\', '/'], "_")
 }
@@ -1292,30 +1265,22 @@ pub(crate) fn create_wrapper(
     example_name: &str,
     sketch_cache_dir: &Path,
 ) -> Result<PathBuf> {
-    let ino_file = sketch_ino_file(example_dir)?;
+    // The compiler and editor both consume this exact preprocessor rather
+    // than compiling a raw `.ino` include wrapper (see #206).
+    let preprocessed = crate::sketch_preprocessor::preprocess_disk(example_dir)?;
     fs::create_dir_all(sketch_cache_dir)?;
-    let mut lines = vec![
-        format!("// Auto-generated wrapper for {example_name}.ino"),
-        "// C++20 header unit import; the .ino FastLED include is then a no-op.".to_string(),
-        "import \"wasm_pch.h\";".to_string(),
-        format!(
-            "#include \"{}\"",
-            ino_file.to_string_lossy().replace('\\', "/")
-        ),
-    ];
+    let mut content = preprocessed.translation_unit;
+    content.push_str(&format!("// Additional C++ files for {example_name}.\n"));
     let mut extras = Vec::new();
     collect_cpp_files(example_dir, &mut extras)?;
     extras.sort();
     for cpp in extras {
-        if cpp != ino_file {
-            lines.push(format!(
-                "#include \"{}\"",
-                cpp.to_string_lossy().replace('\\', "/")
-            ));
-        }
+        content.push_str(&format!(
+            "#include \"{}\"\n",
+            cpp.to_string_lossy().replace('\\', "/")
+        ));
     }
     let wrapper = sketch_cache_dir.join(format!("{}_wrapper.cpp", wrapper_stem(example_name)));
-    let content = lines.join("\n") + "\n";
     if fs::read_to_string(&wrapper).unwrap_or_default() != content {
         fs::write(&wrapper, content)?;
     }
@@ -2171,7 +2136,8 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
         // an otherwise successful build.
         if request.emit_clangd {
             let clangd_result = (|| -> Result<()> {
-                let ino_file = sketch_ino_file(&example_dir)?;
+                let (snapshot, prototype_header) =
+                    crate::sketch_preprocessor::write_disk_snapshot(&example_dir)?;
                 let compile_flags = get_sketch_compile_flags(
                     &fastled_dir,
                     request.build_mode,
@@ -2185,7 +2151,12 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
                         tools_emcc_path: crate::path::NormalizedPath::new(&tools.emcc),
                         tools_empp_path: crate::path::NormalizedPath::new(&tools.empp),
                         wrapper_source: crate::path::NormalizedPath::new(&wrapper),
-                        ino_file: crate::path::NormalizedPath::new(ino_file),
+                        ino_files: snapshot
+                            .documents
+                            .iter()
+                            .map(|document| crate::path::NormalizedPath::new(&document.path))
+                            .collect(),
+                        prototype_header: crate::path::NormalizedPath::new(prototype_header),
                         compile_flags,
                         build_mode: request.build_mode,
                     },
@@ -2764,5 +2735,24 @@ link_flags = []
         assert!(!output.join("files.json").exists());
         let manifest = fs::read_to_string(output.join("sketch_assets.json")).unwrap();
         assert!(manifest.contains("config.json"));
+    }
+
+    #[test]
+    fn wrapper_compiles_canonical_multi_tab_ino_translation_unit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sketch = tmp.path().join("Blink");
+        fs::create_dir_all(&sketch).unwrap();
+        fs::write(
+            sketch.join("Blink.ino"),
+            "void setup() { helper(); }\nvoid loop() {}\n",
+        )
+        .unwrap();
+        fs::write(sketch.join("Helpers.ino"), "void helper() {}\n").unwrap();
+
+        let wrapper = create_wrapper(&sketch, "Blink", &sketch_cache_dir(&sketch)).unwrap();
+        let source = fs::read_to_string(wrapper).unwrap();
+        assert!(source.contains("void helper();"));
+        assert!(source.contains("#line 1 \""));
+        assert!(!source.contains("#include \""));
     }
 }

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import { FastLedExtensionApi, resolveBundledClangd } from './clangdBundle';
+import { IntelliSenseSnapshotController } from './intellisense';
 
 let serverProcess: cp.ChildProcess | undefined;
 let outputChannel: vscode.OutputChannel;
@@ -35,6 +36,10 @@ export function activate(context: vscode.ExtensionContext): FastLedExtensionApi 
     ];
 
     commands.forEach(cmd => context.subscriptions.push(cmd));
+
+    // Keep the generated Arduino prototype prelude in sync with live VS Code
+    // buffers. This never saves or rewrites a user sketch.
+    new IntelliSenseSnapshotController(outputChannel).start(context);
 
     // Register status bar item
     const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);

--- a/vscode-plugin/src/intellisense.ts
+++ b/vscode-plugin/src/intellisense.ts
@@ -1,0 +1,135 @@
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export type SnapshotDocument = { path: string; version: number; text: string };
+export type SnapshotRequest = { sketch_dir: string; generation: number; documents: SnapshotDocument[] };
+
+type SnapshotRunner = (request: SnapshotRequest) => Promise<void>;
+
+/**
+ * A tiny generation gate used by the controller and its Extension Development
+ * Host tests. An obsolete CLI process may finish after a newer buffer; its
+ * result must never become the current editor state.
+ */
+export class VersionedSnapshotScheduler<T> implements vscode.Disposable {
+    private generation = 0;
+    private timer: NodeJS.Timeout | undefined;
+
+    public constructor(private readonly delayMs: number, private readonly publish: (generation: number) => Promise<T>) {}
+
+    public schedule(): void {
+        const generation = ++this.generation;
+        if (this.timer) { clearTimeout(this.timer); }
+        this.timer = setTimeout(() => {
+            this.timer = undefined;
+            void this.publish(generation).catch(() => undefined);
+        }, this.delayMs);
+    }
+
+    public isCurrent(generation: number): boolean { return generation === this.generation; }
+
+    public dispose(): void {
+        if (this.timer) { clearTimeout(this.timer); this.timer = undefined; }
+    }
+}
+
+export class IntelliSenseSnapshotController implements vscode.Disposable {
+    private readonly scheduler: VersionedSnapshotScheduler<void>;
+    private readonly subscriptions: vscode.Disposable[] = [];
+    private configurationReady: Promise<void> | undefined;
+
+    public constructor(
+        private readonly output: vscode.OutputChannel,
+        private readonly runSnapshot: SnapshotRunner = runSnapshotCommand,
+    ) {
+        this.scheduler = new VersionedSnapshotScheduler(350, generation => this.publish(generation));
+    }
+
+    public start(context: vscode.ExtensionContext): void {
+        const schedule = () => this.scheduler.schedule();
+        this.subscriptions.push(
+            vscode.workspace.onDidOpenTextDocument(document => { if (isTopLevelIno(document)) { schedule(); } }),
+            vscode.workspace.onDidChangeTextDocument(event => { if (isTopLevelIno(event.document)) { schedule(); } }),
+            vscode.workspace.onDidSaveTextDocument(document => { if (isTopLevelIno(document)) { schedule(); } }),
+            vscode.workspace.onDidCloseTextDocument(document => { if (isTopLevelIno(document)) { schedule(); } }),
+            vscode.workspace.onDidCreateFiles(event => this.refreshForTopology(event.files)),
+            vscode.workspace.onDidDeleteFiles(event => this.refreshForTopology(event.files)),
+            vscode.workspace.onDidRenameFiles(event => this.refreshForTopology(event.files.flatMap(file => [file.oldUri, file.newUri]))),
+        );
+        context.subscriptions.push(this, ...this.subscriptions);
+        void this.ensureConfiguration().then(schedule);
+    }
+
+    public dispose(): void {
+        this.scheduler.dispose();
+        for (const subscription of this.subscriptions) { subscription.dispose(); }
+    }
+
+    private refreshForTopology(uris: readonly vscode.Uri[]): void {
+        if (!uris.some(uri => path.extname(uri.fsPath).toLowerCase() === '.ino')) { return; }
+        this.configurationReady = undefined;
+        void this.ensureConfiguration().then(() => this.scheduler.schedule());
+    }
+
+    private ensureConfiguration(): Promise<void> {
+        if (!this.configurationReady) {
+            const sketchDir = currentSketchDirectory();
+            this.configurationReady = sketchDir
+                ? runFastled(['--write-clangd', sketchDir]).catch(error => {
+                    this.output.appendLine(`IntelliSense configuration was not refreshed: ${error.message}`);
+                })
+                : Promise.resolve();
+        }
+        return this.configurationReady;
+    }
+
+    private async publish(generation: number): Promise<void> {
+        try {
+            const sketchDir = currentSketchDirectory();
+            if (!sketchDir) { return; }
+            const request: SnapshotRequest = {
+                sketch_dir: sketchDir,
+                generation,
+                documents: vscode.workspace.textDocuments
+                    .filter(document => isTopLevelIno(document, sketchDir))
+                    .map(document => ({ path: document.uri.fsPath, version: document.version, text: document.getText() })),
+            };
+            await this.runSnapshot(request);
+            if (this.scheduler.isCurrent(generation)) {
+                this.output.appendLine(`IntelliSense snapshot ${generation} refreshed (${request.documents.length} open .ino buffer(s)).`);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.output.appendLine(`IntelliSense snapshot failed: ${message}`);
+            vscode.window.setStatusBarMessage('FastLED IntelliSense kept its last valid snapshot; fix the current .ino syntax for updated prototypes.', 8000);
+        }
+    }
+}
+
+function currentSketchDirectory(): string | undefined {
+    const active = vscode.window.activeTextEditor?.document.uri;
+    const activeFolder = active && vscode.workspace.getWorkspaceFolder(active);
+    return activeFolder?.uri.fsPath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
+function isTopLevelIno(document: vscode.TextDocument, expectedSketchDir?: string): boolean {
+    if (document.uri.scheme !== 'file' || path.extname(document.uri.fsPath).toLowerCase() !== '.ino') { return false; }
+    const sketchDir = expectedSketchDir ?? currentSketchDirectory();
+    return Boolean(sketchDir && path.dirname(document.uri.fsPath) === sketchDir);
+}
+
+function runSnapshotCommand(request: SnapshotRequest): Promise<void> {
+    return runFastled(['--write-intellisense-snapshot'], JSON.stringify(request));
+}
+
+function runFastled(args: string[], input?: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = cp.spawn('fastled', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+        let stderr = '';
+        child.stderr?.on('data', data => { stderr += data.toString(); });
+        child.once('error', reject);
+        child.once('close', code => code === 0 ? resolve() : reject(new Error(stderr.trim() || `fastled exited with code ${code}`)));
+        child.stdin?.end(input);
+    });
+}

--- a/vscode-plugin/src/test/suite/index.ts
+++ b/vscode-plugin/src/test/suite/index.ts
@@ -4,5 +4,6 @@ import * as path from 'path';
 export function run(): Promise<void> {
     const mocha = new Mocha({ ui: 'tdd', color: true });
     mocha.addFile(path.resolve(__dirname, 'bundledClangd.test.js'));
+    mocha.addFile(path.resolve(__dirname, 'intellisense.test.js'));
     return new Promise((resolve, reject) => mocha.run(failures => failures ? reject(new Error(`${failures} tests failed`)) : resolve()));
 }

--- a/vscode-plugin/src/test/suite/intellisense.test.ts
+++ b/vscode-plugin/src/test/suite/intellisense.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert';
+import { VersionedSnapshotScheduler } from '../../intellisense';
+
+suite('FastLED live IntelliSense snapshots', () => {
+    test('rapid edits only allow the latest generation to be current', async () => {
+        const published: number[] = [];
+        const scheduler = new VersionedSnapshotScheduler<number>(1, async generation => {
+            published.push(generation);
+            return generation;
+        });
+        scheduler.schedule();
+        scheduler.schedule();
+        scheduler.schedule();
+        await new Promise(resolve => setTimeout(resolve, 20));
+        assert.deepStrictEqual(published, [3]);
+        assert.strictEqual(scheduler.isCurrent(3), true);
+        assert.strictEqual(scheduler.isCurrent(2), false);
+        scheduler.dispose();
+    });
+});


### PR DESCRIPTION
Closes #206\n\n## Summary\n- preprocess top-level .ino tabs through a tree-sitter C++ adapter from fbuild\n- publish versioned, atomic live-buffer snapshots for clangd and cpptools\n- compile the same canonical translation unit used by IntelliSense\n\n## Validation\n- ash lint\n- focused Rust preprocessing, CDB, and canonical-wrapper tests\n- 
pm run compile and 
pm test in scode-plugin\n\nash test was attempted locally but its workspace Rust phase stalled and held the test executable on this Windows host; CI is required for the full-suite result.