### PR TITLE
feat(vscode): configure FastLED IntelliSense engines

### DIFF
--- a/crates/fastled-cli/src/clangd_config.rs
+++ b/crates/fastled-cli/src/clangd_config.rs
@@ -620,7 +620,9 @@ mod tests {
         assert!(clangd_text.contains("- --target=wasm32-unknown-emscripten"));
         assert!(clangd_text.contains("- -D__EMSCRIPTEN__=1"));
         assert!(clangd_text.contains("- -DSKETCH_COMPILE=1"));
-        assert!(clangd_text.contains("- -isystem") && clangd_text.contains("sysroot/include/compat"));
+        assert!(
+            clangd_text.contains("- -isystem") && clangd_text.contains("sysroot/include/compat")
+        );
         assert!(clangd_text.contains("- -fmodule-file=*"));
         assert!(!clangd_text.contains("\\\\?\\"));
 

--- a/crates/fastled-cli/src/clangd_config.rs
+++ b/crates/fastled-cli/src/clangd_config.rs
@@ -128,6 +128,7 @@ struct ResolvedPaths {
     sysroot: String,
     libcxx_include: String,
     sysroot_include: String,
+    sysroot_compat_include: String,
     system_include: String,
     fastled_src: String,
     fastled_wasm_compiler: String,
@@ -149,6 +150,14 @@ fn resolve_paths(inputs: &ClangdConfigInputs) -> ResolvedPaths {
             .to_string_lossy()
             .replace('\\', "/"),
         sysroot_include: sysroot.join("include").to_string_lossy().replace('\\', "/"),
+        // libc++ selects the BSD-like locale implementation for the wasm
+        // target. Emscripten supplies its xlocale.h compatibility shim here;
+        // em++ adds it implicitly, while a native clangd must receive it.
+        sysroot_compat_include: sysroot
+            .join("include")
+            .join("compat")
+            .to_string_lossy()
+            .replace('\\', "/"),
         system_include: emsdk
             .join("emscripten")
             .join("system")
@@ -195,6 +204,8 @@ fn compile_arguments(
         paths.libcxx_include.clone(),
         "-isystem".to_string(),
         paths.sysroot_include.clone(),
+        "-isystem".to_string(),
+        paths.sysroot_compat_include.clone(),
         "-isystem".to_string(),
         paths.system_include.clone(),
         "-I".to_string(),
@@ -251,6 +262,7 @@ fn write_clangd_file(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Resu
          \x20   - --target=wasm32-unknown-emscripten\n\
          \x20   - --sysroot={sysroot}\n\
          \x20   - -isystem{libcxx}\n\
+         \x20   - -isystem{sysroot_compat}\n\
          \x20   - -I{fastled_src}\n\
          \x20   - -I{fastled_wasm_compiler}\n\
          \x20   - -D__EMSCRIPTEN__=1\n\
@@ -264,6 +276,7 @@ fn write_clangd_file(inputs: &ClangdConfigInputs, paths: &ResolvedPaths) -> Resu
         emcc = display_path(&inputs.tools_emcc_path),
         sysroot = paths.sysroot,
         libcxx = paths.libcxx_include,
+        sysroot_compat = paths.sysroot_compat_include,
         fastled_src = paths.fastled_src,
         fastled_wasm_compiler = paths.fastled_wasm_compiler,
     );
@@ -298,6 +311,7 @@ fn write_vscode_settings(paths: &ResolvedPaths, sketch_dir: &Path) -> Result<()>
             format!("-I{}", paths.fastled_src),
             format!("-I{}", paths.fastled_wasm_compiler),
             format!("-isystem{}", paths.libcxx_include),
+            format!("-isystem{}", paths.sysroot_compat_include),
             "-D__EMSCRIPTEN__=1",
         ]),
     );
@@ -579,6 +593,10 @@ mod tests {
             assert!(include_dirs
                 .iter()
                 .any(|d| d.ends_with("src/platforms/wasm/compiler")));
+            assert!(args.windows(2).any(|pair| {
+                pair[0] == "-isystem"
+                    && pair[1].ends_with("emscripten/cache/sysroot/include/compat")
+            }));
             // directory is the FastLED checkout (build cwd).
             let directory = entry["directory"].as_str().unwrap();
             assert!(directory.ends_with("fastled"));
@@ -602,6 +620,7 @@ mod tests {
         assert!(clangd_text.contains("- --target=wasm32-unknown-emscripten"));
         assert!(clangd_text.contains("- -D__EMSCRIPTEN__=1"));
         assert!(clangd_text.contains("- -DSKETCH_COMPILE=1"));
+        assert!(clangd_text.contains("- -isystem") && clangd_text.contains("sysroot/include/compat"));
         assert!(clangd_text.contains("- -fmodule-file=*"));
         assert!(!clangd_text.contains("\\\\?\\"));
 

--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -27,6 +27,28 @@ artifact lock is intentionally pinned to `clang-tool-chain-bins` 0.4.6;
 updating clangd requires changing that reviewed lock rather than resolving a
 latest version.
 
+## IntelliSense and navigation
+
+FastLED configures one C/C++ language engine for the whole VS Code window.
+The extension pack installs both the LLVM clangd and Microsoft C/C++
+extensions, but it deliberately never leaves both language services active
+for the same sketch:
+
+- `auto` (default) uses the native clangd bundled in a platform VSIX when the
+  clangd VS Code extension is available; otherwise it uses Microsoft C/C++.
+- `clangd`, `cpptools`, and `off` are explicit choices in the
+  `fastled.intelliSenseEngine` setting.
+- **FastLED: Refresh IntelliSense Configuration** regenerates the
+  `compile_commands.json`, `.clangd`, `.vscode/settings.json`, and
+  `.vscode/c_cpp_properties.json` files for every FastLED sketch folder.
+
+The generated settings associate `.ino` files with C++, while FastLED keeps a
+preprocessed live snapshot and prototype prelude current for unsaved Arduino
+tabs. After opening a Blink sketch, use Go to Definition on `CRGB`, `FastLED`,
+or `FastLED.addLeds`; the result should open the materialized FastLED headers.
+Use **View: Output** → **FastLED WASM** to inspect engine selection and setup
+failures.
+
 ## Features
 
 - **One-click compilation**: Compile and run FastLED sketches with a single command

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -29,6 +29,10 @@
     "workspaceContains:**/*.ino"
   ],
   "extensionKind": ["workspace"],
+  "extensionPack": [
+    "ms-vscode.cpptools",
+    "llvm-vs-code-extensions.vscode-clangd"
+  ],
   "fastledBundledClangd": {"packageKind": "universal"},
   "main": "./out/extension.js",
   "contributes": {
@@ -94,6 +98,12 @@
         "icon": "$(preview)"
       }
       ,{
+        "command": "fastled.refreshIntelliSense",
+        "title": "Refresh IntelliSense Configuration",
+        "category": "FastLED",
+        "icon": "$(refresh)"
+      }
+      ,{
         "command": "fastled.showBundledClangdDiagnostics",
         "title": "Show Bundled clangd Diagnostics",
         "category": "FastLED"
@@ -146,6 +156,9 @@
           "command": "fastled.openBrowser"
         },
         {
+          "command": "fastled.refreshIntelliSense"
+        },
+        {
           "command": "fastled.showBundledClangdDiagnostics"
         }
       ]
@@ -178,6 +191,13 @@
           "type": "boolean",
           "default": true,
           "description": "Enable file watching for automatic recompilation"
+        },
+        "fastled.intelliSenseEngine": {
+          "type": "string",
+          "enum": ["auto", "clangd", "cpptools", "off"],
+          "default": "auto",
+          "scope": "window",
+          "description": "Select the one FastLED C/C++ language engine for this VS Code window. Auto uses bundled clangd when available, otherwise Microsoft C/C++."
         }
       }
     },

--- a/vscode-plugin/scripts/verify_vsix.py
+++ b/vscode-plugin/scripts/verify_vsix.py
@@ -31,6 +31,15 @@ def main() -> None:
         package = json.loads(archive.read("extension/package.json"))
         if package.get("extensionKind") != ["workspace"]:
             raise ValueError("extension is not workspace-only")
+        required_pack = {
+            "ms-vscode.cpptools",
+            "llvm-vs-code-extensions.vscode-clangd",
+        }
+        if not required_pack.issubset(set(package.get("extensionPack", []))):
+            raise ValueError("VSIX does not install both FastLED IntelliSense integrations")
+        engine_setting = package.get("contributes", {}).get("configuration", {}).get("properties", {}).get("fastled.intelliSenseEngine", {})
+        if engine_setting.get("default") != "auto" or engine_setting.get("scope") != "window":
+            raise ValueError("VSIX does not expose window-scoped FastLED engine selection")
         clangd_names = [name for name in names if name.startswith("extension/resources/clangd/")]
         if args.target == "universal":
             if clangd_names:

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -4,12 +4,16 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { FastLedExtensionApi, resolveBundledClangd } from './clangdBundle';
 import { IntelliSenseSnapshotController } from './intellisense';
+import { EngineController, registerEngineLifecycle, VscodeEngineRuntime } from './intellisenseEngine';
 
 let serverProcess: cp.ChildProcess | undefined;
 let outputChannel: vscode.OutputChannel;
+let intelliSenseEngines: EngineController | undefined;
 
 export function activate(context: vscode.ExtensionContext): FastLedExtensionApi {
     outputChannel = vscode.window.createOutputChannel('FastLED WASM');
+    intelliSenseEngines = new EngineController(new VscodeEngineRuntime(context, outputChannel));
+    registerEngineLifecycle(context, intelliSenseEngines, outputChannel);
     
     // Register all commands
     const commands = [
@@ -23,6 +27,7 @@ export function activate(context: vscode.ExtensionContext): FastLedExtensionApi 
         vscode.commands.registerCommand('fastled.update', () => updateCompiler()),
         vscode.commands.registerCommand('fastled.purge', () => purgeContainers()),
         vscode.commands.registerCommand('fastled.openBrowser', () => openBrowser()),
+        vscode.commands.registerCommand('fastled.refreshIntelliSense', () => refreshIntelliSense('manual refresh')),
         vscode.commands.registerCommand('fastled.showBundledClangdDiagnostics', async () => {
             const result = await resolveBundledClangd(context);
             outputChannel.show(true);
@@ -39,7 +44,11 @@ export function activate(context: vscode.ExtensionContext): FastLedExtensionApi 
 
     // Keep the generated Arduino prototype prelude in sync with live VS Code
     // buffers. This never saves or rewrites a user sketch.
-    new IntelliSenseSnapshotController(outputChannel).start(context);
+    new IntelliSenseSnapshotController(
+        outputChannel,
+        undefined,
+        () => refreshIntelliSense('workspace activation'),
+    ).start(context);
 
     // Register status bar item
     const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
@@ -103,11 +112,24 @@ async function compile(args: string[] = []): Promise<void> {
 
     try {
         await runFastLEDCommand(commandArgs);
+        await refreshIntelliSense('successful compile');
         vscode.window.showInformationMessage('FastLED compilation completed successfully!');
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`FastLED compilation failed: ${errorMessage}`);
         outputChannel.appendLine(`Error: ${errorMessage}`);
+    }
+}
+
+async function refreshIntelliSense(reason: string): Promise<void> {
+    if (!intelliSenseEngines) { return; }
+    try {
+        await intelliSenseEngines.refresh(reason);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        outputChannel.appendLine(`IntelliSense refresh failed: ${message}`);
+        vscode.window.showErrorMessage(`FastLED IntelliSense: ${message}`);
+        throw error;
     }
 }
 

--- a/vscode-plugin/src/intellisense.ts
+++ b/vscode-plugin/src/intellisense.ts
@@ -6,6 +6,7 @@ export type SnapshotDocument = { path: string; version: number; text: string };
 export type SnapshotRequest = { sketch_dir: string; generation: number; documents: SnapshotDocument[] };
 
 type SnapshotRunner = (request: SnapshotRequest) => Promise<void>;
+type ConfigurationRunner = () => Promise<void>;
 
 /**
  * A tiny generation gate used by the controller and its Extension Development
@@ -42,6 +43,7 @@ export class IntelliSenseSnapshotController implements vscode.Disposable {
     public constructor(
         private readonly output: vscode.OutputChannel,
         private readonly runSnapshot: SnapshotRunner = runSnapshotCommand,
+        private readonly refreshConfiguration: ConfigurationRunner | undefined = undefined,
     ) {
         this.scheduler = new VersionedSnapshotScheduler(350, generation => this.publish(generation));
     }
@@ -76,7 +78,7 @@ export class IntelliSenseSnapshotController implements vscode.Disposable {
         if (!this.configurationReady) {
             const sketchDir = currentSketchDirectory();
             this.configurationReady = sketchDir
-                ? runFastled(['--write-clangd', sketchDir]).catch(error => {
+                ? (this.refreshConfiguration ? this.refreshConfiguration() : runFastled(['--write-clangd', sketchDir])).catch(error => {
                     this.output.appendLine(`IntelliSense configuration was not refreshed: ${error.message}`);
                 })
                 : Promise.resolve();
@@ -123,7 +125,7 @@ function runSnapshotCommand(request: SnapshotRequest): Promise<void> {
     return runFastled(['--write-intellisense-snapshot'], JSON.stringify(request));
 }
 
-function runFastled(args: string[], input?: string): Promise<void> {
+export function runFastled(args: string[], input?: string): Promise<void> {
     return new Promise((resolve, reject) => {
         const child = cp.spawn('fastled', args, { stdio: ['pipe', 'pipe', 'pipe'] });
         let stderr = '';

--- a/vscode-plugin/src/intellisenseEngine.ts
+++ b/vscode-plugin/src/intellisenseEngine.ts
@@ -1,0 +1,228 @@
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+import { BundledClangdResult, resolveBundledClangd } from './clangdBundle';
+import { runFastled } from './intellisense';
+
+const CLANGD_EXTENSION = 'llvm-vs-code-extensions.vscode-clangd';
+const CPPTOOLS_EXTENSION = 'ms-vscode.cpptools';
+
+export type EngineMode = 'auto' | 'clangd' | 'cpptools' | 'off';
+export type SelectedEngine = Exclude<EngineMode, 'auto'>;
+
+export type EngineResult = {
+    engine: SelectedEngine;
+    configuredFolders: readonly string[];
+};
+
+/**
+ * Thin runtime boundary so engine choice and ordering are testable without a
+ * desktop VS Code process or a native clangd binary.
+ */
+export interface EngineRuntime {
+    workspaceFolders(): readonly string[];
+    isSketchDirectory(folder: string): boolean;
+    writeConfiguration(folder: string): Promise<void>;
+    requestedEngine(): EngineMode;
+    resolveBundledClangd(): Promise<BundledClangdResult>;
+    isExtensionAvailable(id: string): boolean;
+    setClangdPath(value: string): Promise<void>;
+    setClangdEnabled(value: boolean): Promise<void>;
+    setCpptoolsEnabled(folder: string, value: boolean | undefined): Promise<void>;
+    restoreManagedSettings(folders: readonly string[]): Promise<void>;
+    runCommand(command: string): Promise<void>;
+    log(message: string): void;
+    warn(message: string): void;
+}
+
+/**
+ * Chooses exactly one language engine for this VS Code window. Metadata is
+ * still emitted once for every FastLED workspace folder because both engines
+ * consume the same generated Arduino translation-unit model.
+ */
+export class EngineController {
+    private tail: Promise<void> = Promise.resolve();
+
+    public constructor(private readonly runtime: EngineRuntime) {}
+
+    public refresh(reason: string): Promise<EngineResult> {
+        let result: EngineResult | undefined;
+        const run = this.tail.then(async () => { result = await this.refreshInner(reason); });
+        // A failed explicit selection must be reported to the caller, but must
+        // not poison later refreshes caused by a configuration change.
+        this.tail = run.catch(() => undefined);
+        return run.then(() => result!);
+    }
+
+    private async refreshInner(reason: string): Promise<EngineResult> {
+        const folders = this.runtime.workspaceFolders().filter(folder => this.runtime.isSketchDirectory(folder));
+        for (const folder of folders) {
+            await this.runtime.writeConfiguration(folder);
+        }
+
+        const engine = await this.selectEngine();
+        if (engine === 'clangd') {
+            const bundle = await this.runtime.resolveBundledClangd();
+            if (bundle.kind !== 'ready') {
+                throw new Error(`bundled clangd is unavailable: ${bundle.reason}`);
+            }
+            // Stop the competing provider before starting clangd. cpptools
+            // remains installed for its non-language-service features.
+            for (const folder of folders) {
+                await this.runtime.setCpptoolsEnabled(folder, false);
+            }
+            await this.runtime.setClangdPath(bundle.path);
+            await this.runtime.setClangdEnabled(true);
+            await this.runtime.runCommand('clangd.restart');
+        } else if (engine === 'cpptools') {
+            // clangd.enable alone does not stop an already-running server.
+            if (this.runtime.isExtensionAvailable(CLANGD_EXTENSION)) {
+                await this.runtime.setClangdEnabled(false);
+                await this.runtime.runCommand('clangd.shutdown');
+            }
+            for (const folder of folders) {
+                await this.runtime.setCpptoolsEnabled(folder, true);
+            }
+            if (!this.runtime.isExtensionAvailable(CPPTOOLS_EXTENSION)) {
+                this.runtime.warn('Microsoft C/C++ is not installed; FastLED generated IntelliSense metadata but no fallback language service is available.');
+            }
+        } else {
+            if (this.runtime.isExtensionAvailable(CLANGD_EXTENSION)) {
+                await this.runtime.setClangdEnabled(false);
+                await this.runtime.runCommand('clangd.shutdown');
+            }
+            await this.runtime.restoreManagedSettings(folders);
+        }
+
+        this.runtime.log(`IntelliSense engine ${engine} refreshed for ${folders.length} sketch folder(s): ${reason}.`);
+        return { engine, configuredFolders: folders };
+    }
+
+    private async selectEngine(): Promise<SelectedEngine> {
+        const requested = this.runtime.requestedEngine();
+        if (requested === 'off' || requested === 'cpptools') { return requested; }
+
+        const hasClangdExtension = this.runtime.isExtensionAvailable(CLANGD_EXTENSION);
+        const bundle = await this.runtime.resolveBundledClangd();
+        const bundledServerReady = bundle.kind === 'ready';
+
+        if (requested === 'clangd') {
+            if (!hasClangdExtension) { throw new Error('clangd extension is not installed; install llvm-vs-code-extensions.vscode-clangd or select Microsoft C/C++.'); }
+            if (!bundledServerReady) { throw new Error(`bundled clangd is unavailable: ${bundle.reason}; select Microsoft C/C++ or install a native FastLED VSIX.`); }
+            return 'clangd';
+        }
+
+        return hasClangdExtension && bundledServerReady ? 'clangd' : 'cpptools';
+    }
+}
+
+/** VS Code implementation of the engine boundary. */
+export class VscodeEngineRuntime implements EngineRuntime {
+    public constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly output: vscode.OutputChannel,
+    ) {}
+
+    workspaceFolders(): readonly string[] {
+        return (vscode.workspace.workspaceFolders ?? []).map(folder => folder.uri.fsPath);
+    }
+
+    isSketchDirectory(folder: string): boolean {
+        try { return fs.readdirSync(folder).some(file => file.toLowerCase().endsWith('.ino')); }
+        catch { return false; }
+    }
+
+    writeConfiguration(folder: string): Promise<void> {
+        return runFastled(['--write-clangd', folder]);
+    }
+
+    requestedEngine(): EngineMode {
+        return vscode.workspace.getConfiguration('fastled').get<EngineMode>('intelliSenseEngine', 'auto');
+    }
+
+    resolveBundledClangd(): Promise<BundledClangdResult> {
+        return resolveBundledClangd(this.context);
+    }
+
+    isExtensionAvailable(id: string): boolean {
+        return vscode.extensions.getExtension(id) !== undefined;
+    }
+
+    async setClangdPath(value: string): Promise<void> {
+        await this.rememberWorkspaceValue('clangd.path', vscode.workspace.getConfiguration('clangd').inspect<string>('path')?.workspaceValue);
+        await vscode.workspace.getConfiguration('clangd').update('path', value, vscode.ConfigurationTarget.Workspace);
+    }
+
+    async setClangdEnabled(value: boolean): Promise<void> {
+        await this.rememberWorkspaceValue('clangd.enable', vscode.workspace.getConfiguration('clangd').inspect<boolean>('enable')?.workspaceValue);
+        await vscode.workspace.getConfiguration('clangd').update('enable', value, vscode.ConfigurationTarget.Workspace);
+    }
+
+    async setCpptoolsEnabled(folder: string, value: boolean | undefined): Promise<void> {
+        const config = vscode.workspace.getConfiguration('C_Cpp', vscode.Uri.file(folder));
+        if (value !== undefined) {
+            await this.rememberWorkspaceValue(`C_Cpp.intelliSenseEngine:${folder}`, config.inspect<string>('intelliSenseEngine')?.workspaceFolderValue);
+        }
+        await config.update(
+            'intelliSenseEngine',
+            value === undefined ? undefined : value ? 'default' : 'disabled',
+            vscode.ConfigurationTarget.WorkspaceFolder,
+        );
+    }
+
+    async restoreManagedSettings(folders: readonly string[]): Promise<void> {
+        await this.restoreWorkspaceValue('clangd.path', 'clangd', 'path');
+        await this.restoreWorkspaceValue('clangd.enable', 'clangd', 'enable');
+        for (const folder of folders) {
+            const key = `C_Cpp.intelliSenseEngine:${folder}`;
+            const saved = this.context.workspaceState.get<ManagedValue>(key);
+            if (!saved?.managed) { continue; }
+            await vscode.workspace.getConfiguration('C_Cpp', vscode.Uri.file(folder)).update(
+                'intelliSenseEngine', saved.value,
+                vscode.ConfigurationTarget.WorkspaceFolder,
+            );
+            await this.context.workspaceState.update(key, undefined);
+        }
+    }
+
+    async runCommand(command: string): Promise<void> {
+        await vscode.commands.executeCommand(command);
+    }
+
+    log(message: string): void { this.output.appendLine(message); }
+
+    warn(message: string): void {
+        this.output.appendLine(`IntelliSense warning: ${message}`);
+        void vscode.window.showWarningMessage(message);
+    }
+
+    private async rememberWorkspaceValue(key: string, value: unknown): Promise<void> {
+        if (this.context.workspaceState.get<ManagedValue>(key)?.managed) { return; }
+        await this.context.workspaceState.update(key, { managed: true, value } satisfies ManagedValue);
+    }
+
+    private async restoreWorkspaceValue(key: string, section: string, setting: string): Promise<void> {
+        const saved = this.context.workspaceState.get<ManagedValue>(key);
+        if (!saved?.managed) { return; }
+        await vscode.workspace.getConfiguration(section).update(setting, saved.value, vscode.ConfigurationTarget.Workspace);
+        await this.context.workspaceState.update(key, undefined);
+    }
+}
+
+type ManagedValue = { managed: true; value: unknown };
+
+/** Register lifecycle refreshes without starting a second engine on activation. */
+export function registerEngineLifecycle(
+    context: vscode.ExtensionContext,
+    controller: EngineController,
+    output: vscode.OutputChannel,
+): void {
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
+        if (!event.affectsConfiguration('fastled.intelliSenseEngine')) { return; }
+        void controller.refresh('engine setting changed').catch(error => {
+            const message = error instanceof Error ? error.message : String(error);
+            output.appendLine(`IntelliSense engine selection failed: ${message}`);
+            void vscode.window.showErrorMessage(`FastLED IntelliSense: ${message}`);
+        });
+    }));
+}

--- a/vscode-plugin/src/test/suite/index.ts
+++ b/vscode-plugin/src/test/suite/index.ts
@@ -5,5 +5,6 @@ export function run(): Promise<void> {
     const mocha = new Mocha({ ui: 'tdd', color: true });
     mocha.addFile(path.resolve(__dirname, 'bundledClangd.test.js'));
     mocha.addFile(path.resolve(__dirname, 'intellisense.test.js'));
+    mocha.addFile(path.resolve(__dirname, 'intellisenseEngine.test.js'));
     return new Promise((resolve, reject) => mocha.run(failures => failures ? reject(new Error(`${failures} tests failed`)) : resolve()));
 }

--- a/vscode-plugin/src/test/suite/intellisenseEngine.test.ts
+++ b/vscode-plugin/src/test/suite/intellisenseEngine.test.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import {
+    EngineController,
+    EngineMode,
+    EngineRuntime,
+} from '../../intellisenseEngine';
+
+type Bundle = Awaited<ReturnType<EngineRuntime['resolveBundledClangd']>>;
+
+class FakeRuntime implements EngineRuntime {
+    public readonly events: string[] = [];
+    public mode: EngineMode = 'auto';
+    public bundle: Bundle = { kind: 'ready', path: 'C:/FastLED/clangd.exe', target: 'win32-x64', version: '21.1.5' };
+    public clangdExtension = true;
+    public cpptoolsExtension = true;
+
+    workspaceFolders(): readonly string[] { return ['C:/sketch-a', 'C:/sketch-b']; }
+    isSketchDirectory(folder: string): boolean { return folder !== 'C:/sketch-b' || true; }
+    async writeConfiguration(folder: string): Promise<void> { this.events.push(`write:${folder}`); }
+    requestedEngine(): EngineMode { return this.mode; }
+    async resolveBundledClangd(): Promise<Bundle> { return this.bundle; }
+    isExtensionAvailable(id: string): boolean {
+        return id === 'llvm-vs-code-extensions.vscode-clangd' ? this.clangdExtension : this.cpptoolsExtension;
+    }
+    async setClangdPath(value: string): Promise<void> { this.events.push(`clangd.path:${value}`); }
+    async setClangdEnabled(value: boolean): Promise<void> { this.events.push(`clangd.enable:${value}`); }
+    async setCpptoolsEnabled(folder: string, value: boolean | undefined): Promise<void> { this.events.push(`cpptools:${folder}:${value === undefined ? 'restore' : value ? 'default' : 'disabled'}`); }
+    async restoreManagedSettings(folders: readonly string[]): Promise<void> { this.events.push(`restore:${folders.join(',')}`); }
+    async runCommand(command: string): Promise<void> { this.events.push(`command:${command}`); }
+    log(message: string): void { this.events.push(`log:${message}`); }
+    warn(message: string): void { this.events.push(`warn:${message}`); }
+}
+
+suite('FastLED IntelliSense engine selection', () => {
+    test('auto uses the bundled clangd and disables cpptools first', async () => {
+        const runtime = new FakeRuntime();
+        const result = await new EngineController(runtime).refresh('test');
+
+        assert.strictEqual(result.engine, 'clangd');
+        assert.deepStrictEqual(runtime.events.slice(0, 7), [
+            'write:C:/sketch-a',
+            'write:C:/sketch-b',
+            'cpptools:C:/sketch-a:disabled',
+            'cpptools:C:/sketch-b:disabled',
+            'clangd.path:C:/FastLED/clangd.exe',
+            'clangd.enable:true',
+            'command:clangd.restart',
+        ]);
+    });
+
+    test('auto falls back to cpptools when no native clangd is available', async () => {
+        const runtime = new FakeRuntime();
+        runtime.bundle = { kind: 'unavailable', reason: 'universal-package' };
+
+        const result = await new EngineController(runtime).refresh('test');
+
+        assert.strictEqual(result.engine, 'cpptools');
+        assert.ok(runtime.events.includes('clangd.enable:false'));
+        assert.ok(runtime.events.includes('command:clangd.shutdown'));
+        assert.ok(runtime.events.includes('cpptools:C:/sketch-a:default'));
+        assert.ok(runtime.events.includes('cpptools:C:/sketch-b:default'));
+    });
+
+    test('explicit clangd fails visibly rather than silently selecting a different engine', async () => {
+        const runtime = new FakeRuntime();
+        runtime.mode = 'clangd';
+        runtime.clangdExtension = false;
+
+        await assert.rejects(
+            new EngineController(runtime).refresh('test'),
+            /clangd extension is not installed/,
+        );
+    });
+
+    test('off stops clangd and restores only FastLED-managed settings', async () => {
+        const runtime = new FakeRuntime();
+        runtime.mode = 'off';
+
+        const result = await new EngineController(runtime).refresh('test');
+
+        assert.strictEqual(result.engine, 'off');
+        assert.ok(runtime.events.includes('clangd.enable:false'));
+        assert.ok(runtime.events.includes('command:clangd.shutdown'));
+        assert.ok(runtime.events.includes('restore:C:/sketch-a,C:/sketch-b'));
+    });
+
+    test('serializes overlapping refresh requests', async () => {
+        const runtime = new FakeRuntime();
+        const controller = new EngineController(runtime);
+        await Promise.all([controller.refresh('first'), controller.refresh('second')]);
+
+        const firstRestart = runtime.events.indexOf('command:clangd.restart');
+        const secondWrite = runtime.events.lastIndexOf('write:C:/sketch-a');
+        assert.ok(firstRestart >= 0);
+        assert.ok(secondWrite > firstRestart, `refreshes interleaved: ${runtime.events.join(', ')}`);
+    });
+});


### PR DESCRIPTION
Closes #203

## Summary
- configure one VS Code C/C++ engine per window: bundled clangd in auto mode, Microsoft C/C++ as a verified fallback, plus explicit `clangd`, `cpptools`, and `off` modes
- install both integrations through the extension pack; refresh metadata on workspace activation, manual command, and successful compilation
- preserve user settings when FastLED is turned off and serialize overlapping refreshes
- add Emscripten's `sysroot/include/compat` to generated configs, fixing native clangd's missing `xlocale.h` parse failure

## Validation
- `npm run compile && npm test`
- `python scripts/package_extension.py --target win32-x64 --out dist --ctcb-home .ctcb-cache`
- `soldr cargo test -p fastled-cli clangd_config --lib -- --nocapture`
- `bash lint`
- `bash test`
- manual Windows integration: installed the VSIX, opened a Blink workspace, verified generated metadata and bundled clangd 21.1.5 parses the `.ino` from `compile_commands.json` with 0 errors