### PR TITLE
fix(vscode): bind sketch tabs to C++ for navigation

### DIFF
--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import { FastLedExtensionApi, resolveBundledClangd } from './clangdBundle';
 import { IntelliSenseSnapshotController } from './intellisense';
 import { EngineController, registerEngineLifecycle, VscodeEngineRuntime } from './intellisenseEngine';
+import { InoLanguageController } from './inoLanguage';
 
 let serverProcess: cp.ChildProcess | undefined;
 let outputChannel: vscode.OutputChannel;
@@ -14,6 +15,9 @@ export function activate(context: vscode.ExtensionContext): FastLedExtensionApi 
     outputChannel = vscode.window.createOutputChannel('FastLED WASM');
     intelliSenseEngines = new EngineController(new VscodeEngineRuntime(context, outputChannel));
     registerEngineLifecycle(context, intelliSenseEngines, outputChannel);
+    // The clangd client only registers navigation providers for C++ document
+    // language IDs. Bind already-open Arduino tabs before configuring it.
+    const inoLanguageReady = new InoLanguageController(outputChannel).start(context);
     
     // Register all commands
     const commands = [
@@ -47,7 +51,10 @@ export function activate(context: vscode.ExtensionContext): FastLedExtensionApi 
     new IntelliSenseSnapshotController(
         outputChannel,
         undefined,
-        () => refreshIntelliSense('workspace activation'),
+        async () => {
+            await inoLanguageReady;
+            await refreshIntelliSense('workspace activation');
+        },
     ).start(context);
 
     // Register status bar item

--- a/vscode-plugin/src/inoLanguage.ts
+++ b/vscode-plugin/src/inoLanguage.ts
@@ -1,0 +1,92 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/** The small document shape needed to bind an Arduino sketch to C++. */
+export type SketchDocument = {
+    uri: { scheme: string; fsPath: string };
+    languageId: string;
+};
+
+export interface InoLanguageRuntime<T extends SketchDocument> {
+    workspaceFolder(document: T): string | undefined;
+    setCppLanguage(document: T): Promise<void>;
+}
+
+/**
+ * clangd activates for C++ language identifiers, while this extension owns
+ * `.ino` as Arduino.  Bind only the sketch's top-level Arduino tabs; library
+ * and nested files retain the language chosen by their owner.
+ */
+export class InoLanguageBinder<T extends SketchDocument> {
+    public constructor(private readonly runtime: InoLanguageRuntime<T>) {}
+
+    public async bind(document: T): Promise<boolean> {
+        if (!isTopLevelSketchIno(document, this.runtime.workspaceFolder(document)) || document.languageId === 'cpp') {
+            return false;
+        }
+        await this.runtime.setCppLanguage(document);
+        return true;
+    }
+}
+
+export function isTopLevelSketchIno(document: SketchDocument, sketchDir: string | undefined): boolean {
+    if (document.uri.scheme !== 'file' || path.extname(document.uri.fsPath).toLowerCase() !== '.ino' || !sketchDir) {
+        return false;
+    }
+    return comparablePath(path.dirname(document.uri.fsPath)) === comparablePath(sketchDir);
+}
+
+/** Binds both documents already open during activation and later sketch tabs. */
+export class InoLanguageController implements vscode.Disposable {
+    private readonly subscriptions: vscode.Disposable[] = [];
+    private readonly activeBindings = new Map<string, Promise<void>>();
+    private readonly binder = new InoLanguageBinder<vscode.TextDocument>({
+        workspaceFolder: document => vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath,
+        setCppLanguage: async document => { await vscode.languages.setTextDocumentLanguage(document, 'cpp'); },
+    });
+
+    public constructor(private readonly output: vscode.OutputChannel) {}
+
+    public start(context: vscode.ExtensionContext): Promise<void> {
+        this.subscriptions.push(vscode.workspace.onDidOpenTextDocument(document => {
+            void this.bindDocument(document);
+        }));
+        this.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
+            for (const document of vscode.workspace.textDocuments) {
+                void this.bindDocument(document);
+            }
+        }));
+        context.subscriptions.push(this);
+        return Promise.all(vscode.workspace.textDocuments.map(document => this.bindDocument(document))).then(() => undefined);
+    }
+
+    public dispose(): void {
+        for (const subscription of this.subscriptions) { subscription.dispose(); }
+        this.subscriptions.length = 0;
+    }
+
+    private bindDocument(document: vscode.TextDocument): Promise<void> {
+        const key = document.uri.toString();
+        const active = this.activeBindings.get(key);
+        if (active) { return active; }
+        const binding = this.bindDocumentInner(document).finally(() => this.activeBindings.delete(key));
+        this.activeBindings.set(key, binding);
+        return binding;
+    }
+
+    private async bindDocumentInner(document: vscode.TextDocument): Promise<void> {
+        try {
+            if (await this.binder.bind(document)) {
+                this.output.appendLine(`IntelliSense bound ${document.uri.fsPath} to C++ for clangd navigation.`);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.output.appendLine(`IntelliSense could not bind ${document.uri.fsPath} to C++: ${message}`);
+        }
+    }
+}
+
+function comparablePath(value: string): string {
+    const normalized = path.normalize(value).replace(/\\/g, '/').replace(/\/+$/, '');
+    return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}

--- a/vscode-plugin/src/test/runTest.ts
+++ b/vscode-plugin/src/test/runTest.ts
@@ -1,19 +1,28 @@
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 
 async function main(): Promise<void> {
     const extensionDevelopmentPath = process.env.FASTLED_TEST_EXTENSION_PATH || path.resolve(__dirname, '../..');
-    await runTests({
-        version: '1.101.0',
-        extensionDevelopmentPath,
-        extensionTestsPath: path.resolve(__dirname, 'suite', 'index'),
-        extensionTestsEnv: {
-            FASTLED_EXPECT_BUNDLED_CLANGD: process.env.FASTLED_EXPECT_BUNDLED_CLANGD || 'universal',
-            // The resolver must prove it is using the bundled absolute path.
-            PATH: process.platform === 'win32' ? '' : ''
-        },
-        launchArgs: ['--disable-extensions']
-    });
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'fastled-vscode-test-'));
+    fs.writeFileSync(path.join(workspace, 'Blink.ino'), '#include <FastLED.h>\nCRGB leds[1];\nvoid setup() {}\nvoid loop() {}\n');
+    try {
+        await runTests({
+            version: '1.101.0',
+            extensionDevelopmentPath,
+            extensionTestsPath: path.resolve(__dirname, 'suite', 'index'),
+            extensionTestsEnv: {
+                FASTLED_EXPECT_BUNDLED_CLANGD: process.env.FASTLED_EXPECT_BUNDLED_CLANGD || 'universal',
+                FASTLED_TEST_WORKSPACE: workspace,
+                // The resolver must prove it is using the bundled absolute path.
+                PATH: process.platform === 'win32' ? '' : ''
+            },
+            launchArgs: [workspace, '--disable-extensions']
+        });
+    } finally {
+        fs.rmSync(workspace, { recursive: true, force: true });
+    }
 }
 
 main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/vscode-plugin/src/test/suite/index.ts
+++ b/vscode-plugin/src/test/suite/index.ts
@@ -6,5 +6,6 @@ export function run(): Promise<void> {
     mocha.addFile(path.resolve(__dirname, 'bundledClangd.test.js'));
     mocha.addFile(path.resolve(__dirname, 'intellisense.test.js'));
     mocha.addFile(path.resolve(__dirname, 'intellisenseEngine.test.js'));
+    mocha.addFile(path.resolve(__dirname, 'inoLanguage.test.js'));
     return new Promise((resolve, reject) => mocha.run(failures => failures ? reject(new Error(`${failures} tests failed`)) : resolve()));
 }

--- a/vscode-plugin/src/test/suite/inoLanguage.test.ts
+++ b/vscode-plugin/src/test/suite/inoLanguage.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { InoLanguageBinder, SketchDocument } from '../../inoLanguage';
+
+type FakeDocument = SketchDocument & { languageId: string };
+
+suite('FastLED .ino language binding', () => {
+    test('rebinds an already-open top-level sketch from Arduino to C++', async () => {
+        const changed: string[] = [];
+        const binder = new InoLanguageBinder<FakeDocument>({
+            workspaceFolder: () => 'C:/sketch',
+            setCppLanguage: async document => {
+                changed.push(document.uri.fsPath);
+                document.languageId = 'cpp';
+            },
+        });
+        const document: FakeDocument = {
+            uri: { scheme: 'file', fsPath: 'C:/sketch/Blink.ino' },
+            languageId: 'arduino',
+        };
+
+        assert.strictEqual(await binder.bind(document), true);
+        assert.deepStrictEqual(changed, ['C:/sketch/Blink.ino']);
+        assert.strictEqual(document.languageId, 'cpp');
+    });
+
+    test('leaves nested, non-sketch, and already-C++ documents alone', async () => {
+        const changed: string[] = [];
+        const binder = new InoLanguageBinder<FakeDocument>({
+            workspaceFolder: () => 'C:/sketch',
+            setCppLanguage: async document => { changed.push(document.uri.fsPath); },
+        });
+        const documents: FakeDocument[] = [
+            { uri: { scheme: 'file', fsPath: 'C:/sketch/tabs/Other.ino' }, languageId: 'arduino' },
+            { uri: { scheme: 'file', fsPath: 'C:/sketch/FastLED.h' }, languageId: 'cpp' },
+            { uri: { scheme: 'file', fsPath: 'C:/sketch/Blink.ino' }, languageId: 'cpp' },
+            { uri: { scheme: 'untitled', fsPath: 'C:/sketch/Blink.ino' }, languageId: 'arduino' },
+        ];
+
+        for (const document of documents) {
+            assert.strictEqual(await binder.bind(document), false);
+        }
+        assert.deepStrictEqual(changed, []);
+    });
+
+    test('routes a bound top-level sketch to C++ definition providers', async () => {
+        const workspace = process.env.FASTLED_TEST_WORKSPACE;
+        assert.ok(workspace, 'test workspace was supplied by the Extension Development Host');
+        const extension = vscode.extensions.getExtension('fastled.fastled-wasm');
+        assert.ok(extension, 'FastLED extension is installed');
+        await extension.activate();
+        const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(workspace, 'Blink.ino')));
+        let bound: vscode.TextDocument | undefined;
+        for (let attempt = 0; attempt < 50; attempt += 1) {
+            const bound = vscode.workspace.textDocuments.find(candidate => candidate.uri.toString() === document.uri.toString());
+            if (bound?.languageId === 'cpp') { break; }
+            await new Promise(resolve => setTimeout(resolve, 20));
+        }
+        bound = vscode.workspace.textDocuments.find(candidate => candidate.uri.toString() === document.uri.toString());
+        assert.strictEqual(bound?.languageId, 'cpp', 'FastLED did not bind the opened Blink.ino document to cpp');
+
+        const expected = new vscode.Location(vscode.Uri.file(path.join(workspace, 'FastLED.h')), new vscode.Position(0, 0));
+        const provider = vscode.languages.registerDefinitionProvider({ language: 'cpp', scheme: 'file' }, {
+            provideDefinition(candidate) {
+                assert.strictEqual(candidate.uri.toString(), document.uri.toString());
+                assert.strictEqual(candidate.languageId, 'cpp');
+                return expected;
+            },
+        });
+        try {
+            const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
+                'vscode.executeDefinitionProvider', document.uri, new vscode.Position(1, 1),
+            );
+            assert.ok(definitions?.some(location => location.uri.toString() === expected.uri.toString()));
+        } finally {
+            provider.dispose();
+        }
+    });
+});


### PR DESCRIPTION
Closes #211\n\n## Summary\n- reclassify top-level workspace .ino sketch documents to cpp at activation and on open\n- wait for that binding before starting the IntelliSense engine refresh\n- add Extension Development Host coverage that proves C++ definition providers receive CRGB in a bound sketch\n\n## Validation\n- 
pm run compile && npm test (10 passing)\n- ash test (232 Rust, 18 Python passing)\n- ash lint\n- python scripts/package_extension.py --target win32-x64 --out dist --ctcb-home .ctcb-cache (installed-VSIX test: 10 passing)\n- native bundled clangd 	extDocument/definition returns FastLED crgb.h for CRGB\n