### PR TITLE
fix(cli): make macOS wheel builds self-contained

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: ""
+      wheel-smoke:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -111,6 +115,82 @@ jobs:
           else
             uv run --with "setuptools>=69" --with "wheel>=0.43" python setup.py bdist_wheel
           fi
+
+      # This deliberately runs the packaged console script outside this
+      # checkout. It exercises the wheel's bundled Rust binary and frontend,
+      # rather than development fallbacks such as CARGO_MANIFEST_DIR.
+      - name: Smoke test installed wheel in shipped viewer
+        if: inputs.wheel-smoke
+        env:
+          FASTLED_VIEWER_LOGS: "1"
+        run: |
+          set -euo pipefail
+          SMOKE_ROOT="$RUNNER_TEMP/fastled-wheel-smoke"
+          rm -rf "$SMOKE_ROOT"
+          mkdir -p "$SMOKE_ROOT/home" "$SMOKE_ROOT/bin" "$SMOKE_ROOT/sketch" "$SMOKE_ROOT/artifacts"
+          uv venv "$SMOKE_ROOT/venv" --python "$UV_PYTHON"
+          uv pip install --python "$SMOKE_ROOT/venv/bin/python" dist/*.whl
+          ln -s "$(command -v uv)" "$SMOKE_ROOT/bin/uv"
+
+          cat > "$SMOKE_ROOT/sketch/wheel_smoke.ino" <<'EOF'
+          #include <FastLED.h>
+
+          #define LED_PIN 3
+          #define WIDTH 16
+          #define HEIGHT 16
+          #define NUM_LEDS (WIDTH * HEIGHT)
+
+          using namespace fl;
+
+          CRGB leds[NUM_LEDS];
+          XYMap screenMap = XYMap::constructRectangularGrid(WIDTH, HEIGHT);
+
+          void setup() {
+            FastLED.addLeds<WS2812B, LED_PIN, GRB>(leds, NUM_LEDS)
+                .setScreenMap(screenMap);
+          }
+
+          void loop() {
+            static uint8_t hue = 0;
+            fill_rainbow(leds, NUM_LEDS, hue++, 7);
+            FastLED.show();
+            delay(20);
+          }
+          EOF
+
+          # Keep uv available for the managed FastLED environment but omit
+          # ambient node and bare python. The installed launcher supplies its
+          # own absolute Python and frontend paths to the Rust binary.
+          cd "$SMOKE_ROOT"
+          env -i \
+            HOME="$SMOKE_ROOT/home" \
+            PATH="$SMOKE_ROOT/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+            FASTLED_VIEWER_LOGS="$FASTLED_VIEWER_LOGS" \
+            "$SMOKE_ROOT/venv/bin/fastled" "$SMOKE_ROOT/sketch" \
+              --test \
+              --test-wait-secs=2 \
+              --test-timeout-secs=240 \
+              --test-ready-timeout-secs=45 \
+              --test-screenshot="$SMOKE_ROOT/artifacts/screenmap.png" \
+              --test-log="$SMOKE_ROOT/artifacts/viewer.log" \
+              --test-exit-on-error
+          test -s "$SMOKE_ROOT/artifacts/screenmap.png"
+
+      - name: Upload installed wheel viewer screenshot
+        if: always() && inputs.wheel-smoke
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-smoke-screenshot-${{ inputs.runs-on }}-${{ inputs.rust-target || 'native' }}
+          path: ${{ runner.temp }}/fastled-wheel-smoke/artifacts/*.png
+          if-no-files-found: error
+
+      - name: Upload installed wheel viewer log
+        if: always() && inputs.wheel-smoke
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-smoke-log-${{ inputs.runs-on }}-${{ inputs.rust-target || 'native' }}
+          path: ${{ runner.temp }}/fastled-wheel-smoke/artifacts/viewer.log
+          if-no-files-found: warn
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-arm-build.yml
+++ b/.github/workflows/macos-arm-build.yml
@@ -15,3 +15,4 @@ jobs:
       # builds in auto-release.yml (same artifact names, plat-name tags, and
       # soldr cache key), letting auto-release reuse them (#170).
       rust-target: aarch64-apple-darwin
+      wheel-smoke: true

--- a/crates/fastled-cli/src/archive.rs
+++ b/crates/fastled-cli/src/archive.rs
@@ -236,12 +236,19 @@ pub fn extract_member_from_tgz(archive: &Path, member: &str, dest: &Path) -> Res
 /// (not a staging directory), matching the Python implementation's post-rename
 /// behaviour.
 ///
-/// `node_path` is the path to the Node.js executable.  Pass the result of
-/// `which("node")` or a literal `"node"` when the executable is on `PATH`.
+/// `node_path` is the absolute path to the Node.js executable.  Emscripten
+/// invokes this program from child processes, so a bare `node` name would
+/// accidentally depend on the caller's shell PATH.
 ///
 /// # Errors
 /// Returns an error if the file cannot be written.
-pub fn write_emscripten_config(install_dir: &Path, node_path: &str) -> Result<()> {
+pub fn write_emscripten_config(install_dir: &Path, node_path: &Path) -> Result<()> {
+    if !node_path.is_absolute() {
+        anyhow::bail!(
+            "NODE_JS must be an absolute path, got {}",
+            node_path.display()
+        );
+    }
     let bin_dir = install_dir.join("bin");
     // Normalise to forward-slash paths (the Python side does the same).
     let llvm_root = path_to_forward_slash(&bin_dir);
@@ -253,8 +260,9 @@ pub fn write_emscripten_config(install_dir: &Path, node_path: &str) -> Result<()
          \n\
          LLVM_ROOT = {llvm_root:?}\n\
          BINARYEN_ROOT = {binaryen_root:?}\n\
-         NODE_JS = {node_path:?}\n\
-         "
+         NODE_JS = {:?}\n\
+         ",
+        path_to_forward_slash(node_path),
     );
 
     let config_path = install_dir.join(".emscripten");
@@ -441,7 +449,8 @@ mod tests {
         let install_dir = dir.path().join("emscripten").join("3.1.50");
         fs::create_dir_all(&install_dir).unwrap();
 
-        write_emscripten_config(&install_dir, "node").expect("write_emscripten_config");
+        let node = install_dir.join("managed-node");
+        write_emscripten_config(&install_dir, &node).expect("write_emscripten_config");
 
         let config_path = install_dir.join(".emscripten");
         assert!(config_path.exists(), ".emscripten file should exist");
@@ -481,7 +490,8 @@ mod tests {
         let install_dir = dir.path().join("emscripten").join("3.1.50");
         fs::create_dir_all(&install_dir).unwrap();
 
-        write_emscripten_config(&install_dir, "/usr/bin/node").expect("write_emscripten_config");
+        let node = dir.path().join("node");
+        write_emscripten_config(&install_dir, &node).expect("write_emscripten_config");
 
         let config_path = install_dir.join(".emscripten");
         let contents = fs::read_to_string(&config_path).unwrap();
@@ -499,13 +509,14 @@ mod tests {
         let install_dir = dir.path().join("emscripten").join("3.1.50");
         fs::create_dir_all(&install_dir).unwrap();
 
-        let node = "/custom/path/to/node";
-        write_emscripten_config(&install_dir, node).expect("write_emscripten_config");
+        let node = dir.path().join("custom").join("path").join("node");
+        write_emscripten_config(&install_dir, &node).expect("write_emscripten_config");
 
         let contents = fs::read_to_string(install_dir.join(".emscripten")).unwrap();
         assert!(
-            contents.contains(node),
-            "config should contain the node path ({node}): {contents}"
+            contents.contains(&path_to_forward_slash(&node)),
+            "config should contain the node path ({}): {contents}",
+            node.display()
         );
     }
 
@@ -514,12 +525,25 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let install_dir = dir.path().join("emscripten").join("4.0.19");
         fs::create_dir_all(&install_dir).unwrap();
-        write_emscripten_config(&install_dir, "node").unwrap();
+        let node = install_dir.join("managed-node");
+        write_emscripten_config(&install_dir, &node).unwrap();
         let path = install_dir.join(".emscripten");
         let first = path.metadata().unwrap().modified().unwrap();
         std::thread::sleep(std::time::Duration::from_millis(20));
-        write_emscripten_config(&install_dir, "node").unwrap();
+        write_emscripten_config(&install_dir, &node).unwrap();
         assert_eq!(first, path.metadata().unwrap().modified().unwrap());
+    }
+
+    #[test]
+    fn test_write_emscripten_config_rejects_relative_node_path() {
+        let dir = temp_dir();
+        let install_dir = dir.path().join("emscripten").join("4.0.19");
+        fs::create_dir_all(&install_dir).unwrap();
+
+        let error = write_emscripten_config(&install_dir, Path::new("node"))
+            .expect_err("bare node must be rejected")
+            .to_string();
+        assert!(error.contains("absolute path"), "got: {error}");
     }
 
     // ------------------------------------------------------------------

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -9,6 +9,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         action: ToolchainAction,
     },
+    /// Inspect and explicitly manage cached FastLED source checkouts.
+    Source {
+        #[command(subcommand)]
+        action: SourceAction,
+    },
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -37,6 +42,29 @@ pub(crate) enum ToolchainAction {
     Rollback,
     /// Remove inactive package installations.
     Prune,
+}
+
+/// Explicit management actions for the cached FastLED source checkout.
+#[derive(Clone, Debug, Subcommand)]
+pub(crate) enum SourceAction {
+    /// Show the cached source revision, fetch time, and freshness state.
+    Status {
+        /// Cached FastLED ref to inspect.
+        #[arg(long = "ref", default_value = "master")]
+        reference: String,
+    },
+    /// Download a fresh source checkout while preserving the old checkout on failure.
+    Update {
+        /// Cached FastLED ref to refresh.
+        #[arg(long = "ref", default_value = "master")]
+        reference: String,
+    },
+    /// Remove one cached FastLED source checkout.
+    Purge {
+        /// Cached FastLED ref to remove.
+        #[arg(long = "ref", default_value = "master")]
+        reference: String,
+    },
 }
 
 /// How the sketch code is linked into the generated WASM program.
@@ -338,6 +366,33 @@ mod tests {
             Some(Command::Toolchain {
                 action: ToolchainAction::Status
             })
+        ));
+    }
+
+    #[test]
+    fn source_commands_are_explicit_subcommands() {
+        let cli = Cli::parse_from(["fastled", "source", "status"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Source {
+                action: SourceAction::Status { reference }
+            }) if reference == "master"
+        ));
+
+        let cli = Cli::parse_from(["fastled", "source", "update", "--ref", "main"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Source {
+                action: SourceAction::Update { reference }
+            }) if reference == "main"
+        ));
+
+        let cli = Cli::parse_from(["fastled", "source", "purge", "--ref", "3.10.0"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Source {
+                action: SourceAction::Purge { reference }
+            }) if reference == "3.10.0"
         ));
     }
 

--- a/crates/fastled-cli/src/commands.rs
+++ b/crates/fastled-cli/src/commands.rs
@@ -45,7 +45,7 @@ pub(crate) fn compile_and_serve(dir: &str, cli: &Cli) -> ExitCode {
     // Ensure the emscripten + esbuild toolchains are installed before invoking
     // the native Rust build backend. The backend consumes the Rust-installed
     // directories via these environment variables.
-    if let Err(message) = ensure_compile_prerequisites(true) {
+    if let Err(message) = ensure_compile_prerequisites(true, cli.fastled_path.as_deref()) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
     }
@@ -693,7 +693,7 @@ pub(crate) fn run_native_init(cli: &Cli, example: Option<&str>) -> ExitCode {
 
 pub(crate) fn run_native_just_compile(cli: &Cli, dir: &str) -> ExitCode {
     announce_link_mode(cli, None, true);
-    if let Err(message) = ensure_compile_prerequisites(!cli.no_app) {
+    if let Err(message) = ensure_compile_prerequisites(!cli.no_app, cli.fastled_path.as_deref()) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
     }
@@ -827,7 +827,7 @@ pub(crate) fn run_internal_dwarf_smoke(cli: &Cli) -> ExitCode {
         eprintln!("fastled: --internal-dwarf-smoke must be run with --debug");
         return ExitCode::FAILURE;
     }
-    if let Err(message) = ensure_compile_prerequisites(true) {
+    if let Err(message) = ensure_compile_prerequisites(true, cli.fastled_path.as_deref()) {
         eprintln!("fastled: {message}");
         return ExitCode::FAILURE;
     }

--- a/crates/fastled-cli/src/compile_stream.rs
+++ b/crates/fastled-cli/src/compile_stream.rs
@@ -7,7 +7,28 @@ use crate::debug_symbols;
 use crate::install;
 use crate::server;
 
-pub(crate) fn ensure_compile_prerequisites(include_app: bool) -> Result<(), String> {
+pub(crate) fn ensure_compile_prerequisites(
+    include_app: bool,
+    fastled_path: Option<&str>,
+) -> Result<(), String> {
+    // Bootstrap the runtime before Emscripten's first-install health check.
+    // In particular, macOS does not provide bare `python` or `node` commands.
+    // Preserve the concrete paths so every later health check and child process
+    // uses the same uv-managed executables instead of consulting ambient PATH.
+    let fastled_dir = match fastled_path {
+        Some(path) => PathBuf::from(path),
+        None => install::ensure_fastled_repo(Some("master"))
+            .map_err(|e| format!("FastLED source bootstrap failed: {e:#}"))?,
+    };
+    install::ensure_fastled_uv_environment(&fastled_dir)
+        .map_err(|e| format!("FastLED runtime bootstrap failed: {e:#}"))?;
+    let python = install::resolve_fastled_python(&fastled_dir)
+        .map_err(|e| format!("Python runtime resolution failed: {e:#}"))?;
+    let node = install::resolve_managed_node(Some(&fastled_dir))
+        .map_err(|e| format!("Node.js runtime resolution failed: {e:#}"))?;
+    std::env::set_var("FASTLED_PYTHON_EXECUTABLE", &python);
+    std::env::set_var("FASTLED_NODE_EXECUTABLE", &node);
+
     match install::ensure_emscripten_installed() {
         Ok(install_dir) => {
             std::env::set_var("FASTLED_EMSCRIPTEN_DIR", &install_dir);
@@ -208,7 +229,9 @@ pub(crate) fn emit_build_log(
     line: &str,
     stream: &str,
 ) {
-    if stream == "stderr" {
+    if stream == "warning" && std::io::stderr().is_terminal() {
+        eprintln!("{}", crossterm::style::Stylize::yellow(line));
+    } else if stream == "stderr" || stream == "warning" {
         eprintln!("{line}");
     } else {
         println!("{line}");

--- a/crates/fastled-cli/src/frontend.rs
+++ b/crates/fastled-cli/src/frontend.rs
@@ -29,22 +29,65 @@ fn workspace_root() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
 }
 
+fn validate_source_dir(candidate: PathBuf, origin: &str) -> Result<PathBuf> {
+    if !candidate.is_dir() {
+        anyhow::bail!("{origin} is not a directory: {}", candidate.display());
+    }
+
+    // These are the source inputs that build_dist requires. Validate all of
+    // them up front so a wheel installation fails with an actionable path
+    // error instead of a later, unrelated esbuild or file-copy failure.
+    for relative in [
+        "app.ts",
+        "index.html",
+        "index.css",
+        "modules/core/fastled_background_worker.ts",
+        "modules/audio/audio_worklet_processor.js",
+    ] {
+        let required = candidate.join(relative);
+        if !required.is_file() {
+            anyhow::bail!(
+                "{origin} does not contain required frontend file {}",
+                required.display()
+            );
+        }
+    }
+    Ok(candidate)
+}
+
+/// Resolve the frontend directory embedded in an installed Python wheel.
+/// The Python launcher supplies this absolute path. It intentionally takes
+/// priority over source-tree discovery because a packaged native binary has a
+/// `CARGO_MANIFEST_DIR` from the machine that built it, not the user's host.
+fn packaged_source_dir() -> Result<Option<PathBuf>> {
+    let Ok(value) = std::env::var("FASTLED_FRONTEND_DIR") else {
+        return Ok(None);
+    };
+    if value.trim().is_empty() {
+        anyhow::bail!("FASTLED_FRONTEND_DIR is set but empty");
+    }
+    validate_source_dir(PathBuf::from(value), "FASTLED_FRONTEND_DIR").map(Some)
+}
+
 /// Walk up from `CARGO_MANIFEST_DIR` looking for the workspace's
 /// `src/fastled/frontend` directory.
 fn default_source_dir() -> Result<PathBuf> {
+    if let Some(packaged) = packaged_source_dir()? {
+        return Ok(packaged);
+    }
     let candidate = workspace_root()
         .join("src")
         .join("fastled")
         .join("frontend");
     if candidate.is_dir() {
-        return Ok(candidate);
+        return validate_source_dir(candidate, "frontend relative to CARGO_MANIFEST_DIR");
     }
     // Fall back to walking parents (defensive: layout may shift).
     let mut current = Some(workspace_root());
     while let Some(dir) = current {
         let candidate = dir.join("src").join("fastled").join("frontend");
         if candidate.is_dir() {
-            return Ok(candidate);
+            return validate_source_dir(candidate, "frontend relative to CARGO_MANIFEST_DIR");
         }
         current = dir.parent().map(Path::to_path_buf);
     }
@@ -408,6 +451,7 @@ pub fn remove_app_from_output(output_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
     use std::thread;
     use std::time::Duration;
     use tempfile::TempDir;
@@ -417,6 +461,34 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, content).unwrap();
+    }
+
+    fn frontend_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn write_frontend_source(root: &Path) {
+        write(&root.join("app.ts"), b"// app");
+        write(
+            &root.join("index.html"),
+            b"<!doctype html><title>test</title>",
+        );
+        write(&root.join("index.css"), b"body {}");
+        write(
+            &root
+                .join("modules")
+                .join("core")
+                .join("fastled_background_worker.ts"),
+            b"// worker",
+        );
+        write(
+            &root
+                .join("modules")
+                .join("audio")
+                .join("audio_worklet_processor.js"),
+            b"// worklet",
+        );
     }
 
     #[test]
@@ -522,6 +594,49 @@ mod tests {
             app_js_meta_before, app_js_meta_after,
             "files must not be re-copied when the hash marker already matches"
         );
+    }
+
+    #[test]
+    fn installed_wheel_frontend_overrides_build_machine_manifest_dir() {
+        // Wheels embed the build machine's CARGO_MANIFEST_DIR, which is not a
+        // usable path on the host. The installed Python launcher must provide
+        // the packaged frontend through FASTLED_FRONTEND_DIR instead.
+        let _guard = frontend_env_lock().lock().unwrap();
+        let package = TempDir::new().unwrap();
+        let frontend = package.path().join("site-packages/fastled/frontend");
+        write_frontend_source(&frontend);
+
+        let old = std::env::var_os("FASTLED_FRONTEND_DIR");
+        std::env::set_var("FASTLED_FRONTEND_DIR", &frontend);
+        let resolved = default_source_dir().expect("wheel frontend must resolve");
+        if let Some(value) = old {
+            std::env::set_var("FASTLED_FRONTEND_DIR", value);
+        } else {
+            std::env::remove_var("FASTLED_FRONTEND_DIR");
+        }
+
+        assert_eq!(resolved, frontend);
+        assert!(resolved.is_absolute());
+    }
+
+    #[test]
+    fn installed_wheel_frontend_must_be_complete() {
+        let _guard = frontend_env_lock().lock().unwrap();
+        let package = TempDir::new().unwrap();
+        let frontend = package.path().join("site-packages/fastled/frontend");
+        fs::create_dir_all(&frontend).unwrap();
+
+        let old = std::env::var_os("FASTLED_FRONTEND_DIR");
+        std::env::set_var("FASTLED_FRONTEND_DIR", &frontend);
+        let error = default_source_dir().expect_err("incomplete wheel frontend must fail");
+        if let Some(value) = old {
+            std::env::set_var("FASTLED_FRONTEND_DIR", value);
+        } else {
+            std::env::remove_var("FASTLED_FRONTEND_DIR");
+        }
+
+        assert!(error.to_string().contains("FASTLED_FRONTEND_DIR"));
+        assert!(error.to_string().contains("app.ts"));
     }
 
     #[test]

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -648,6 +648,18 @@ pub(crate) fn resolve_managed_python() -> Result<PathBuf> {
 /// Resolve Python from the selected FastLED uv environment while preserving
 /// the virtual-environment path. Canonicalizing this symlink would produce the
 /// base interpreter path and silently discard the environment's dependencies.
+fn fastled_venv_executable(fastled_dir: &Path, program: &str) -> Option<PathBuf> {
+    let candidate = if cfg!(windows) {
+        fastled_dir
+            .join(".venv")
+            .join("Scripts")
+            .join(format!("{program}.exe"))
+    } else {
+        fastled_dir.join(".venv").join("bin").join(program)
+    };
+    (candidate.is_file() && candidate.is_absolute()).then_some(candidate)
+}
+
 pub(crate) fn resolve_fastled_python(fastled_dir: &Path) -> Result<PathBuf> {
     let mut roots = vec![fastled_dir.to_path_buf()];
     if let Ok(root) = fastled_root() {
@@ -655,13 +667,8 @@ pub(crate) fn resolve_fastled_python(fastled_dir: &Path) -> Result<PathBuf> {
         roots.push(root.join("cache").join("fastled-master"));
     }
     for root in roots {
-        let candidate = if cfg!(windows) {
-            root.join(".venv").join("Scripts").join("python.exe")
-        } else {
-            root.join(".venv").join("bin").join("python")
-        };
-        if candidate.is_file() && candidate.is_absolute() {
-            return Ok(candidate);
+        if let Some(python) = fastled_venv_executable(&root, "python") {
+            return Ok(python);
         }
     }
     resolve_managed_python()
@@ -705,7 +712,15 @@ pub(crate) fn resolve_managed_node(fastled_dir: Option<&Path>) -> Result<PathBuf
 /// its Meson helpers and Emscripten. This is intentionally project-local and
 /// never modifies the user's global Python, Node, or shell PATH.
 pub(crate) fn ensure_fastled_uv_environment(fastled_dir: &Path) -> Result<()> {
-    if resolve_managed_node(Some(fastled_dir)).is_ok() {
+    if fastled_venv_executable(fastled_dir, "python").is_some()
+        && fastled_venv_executable(fastled_dir, "node").is_some()
+    {
+        return Ok(());
+    }
+    if !fastled_dir.join("pyproject.toml").is_file() {
+        // Older pinned FastLED releases predate the uv project. They can still
+        // use an explicitly supplied or ambient Node runtime.
+        resolve_managed_node(Some(fastled_dir))?;
         return Ok(());
     }
     let uv = resolve_managed_uv()?;
@@ -723,12 +738,14 @@ pub(crate) fn ensure_fastled_uv_environment(fastled_dir: &Path) -> Result<()> {
     if !status.success() {
         bail!("uv failed to provision FastLED runtime with {status}");
     }
-    resolve_managed_node(Some(fastled_dir)).with_context(|| {
-        format!(
-            "uv completed but did not provide Node in {}",
-            fastled_dir.join(".venv").display()
-        )
-    })?;
+    for program in ["python", "node"] {
+        fastled_venv_executable(fastled_dir, program).with_context(|| {
+            format!(
+                "uv completed but did not provide {program} in {}",
+                fastled_dir.join(".venv").display()
+            )
+        })?;
+    }
     Ok(())
 }
 

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -570,11 +570,181 @@ fn package_key_for_archive(path: &Path) -> String {
         .to_string()
 }
 
-fn resolve_node() -> Option<String> {
-    if cfg!(windows) {
-        Some("node.exe".to_string())
+/// Return an absolute executable path when `candidate` names a file.
+fn absolute_executable(candidate: &Path) -> Option<PathBuf> {
+    fs::canonicalize(candidate)
+        .ok()
+        .filter(|path| path.is_file())
+}
+
+/// Resolve `program` from the process PATH without ever returning a bare
+/// program name.  Child tools must receive concrete paths so their behaviour
+/// does not change when they spawn another process with a narrower PATH.
+fn executable_from_path(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let suffixes: &[&str] = if cfg!(windows) {
+        &[".exe", ".cmd", ".bat", ""]
     } else {
-        Some("node".to_string())
+        &[""]
+    };
+    std::env::split_paths(&path).find_map(|directory| {
+        suffixes
+            .iter()
+            .find_map(|suffix| absolute_executable(&directory.join(format!("{program}{suffix}"))))
+    })
+}
+
+fn resolve_managed_uv() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("FASTLED_UV_EXECUTABLE").map(PathBuf::from) {
+        if let Some(path) = absolute_executable(&path) {
+            return Ok(path);
+        }
+    }
+    if let Ok(python) = resolve_managed_python() {
+        if let Some(parent) = python.parent() {
+            let candidate = parent.join(if cfg!(windows) { "uv.exe" } else { "uv" });
+            if let Some(path) = absolute_executable(&candidate) {
+                return Ok(path);
+            }
+        }
+    }
+    executable_from_path("uv")
+        .context("uv is required to provision FastLED's managed Python and Node environment")
+}
+
+/// Resolve the exact Python interpreter that Emscripten child processes use.
+/// The wheel launcher supplies `FASTLED_PYTHON_EXECUTABLE`; a virtual
+/// environment is the next best source.  Falling back to PATH still returns
+/// an absolute path, not a shell-dependent `python` token.
+pub(crate) fn resolve_managed_python() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("FASTLED_PYTHON_EXECUTABLE").map(PathBuf::from) {
+        if let Some(path) = absolute_executable(&path) {
+            return Ok(path);
+        }
+    }
+    if let Some(venv) = std::env::var_os("VIRTUAL_ENV").map(PathBuf::from) {
+        let candidate = if cfg!(windows) {
+            venv.join("Scripts").join("python.exe")
+        } else {
+            venv.join("bin").join("python")
+        };
+        if let Some(path) = absolute_executable(&candidate) {
+            return Ok(path);
+        }
+    }
+    let names: &[&str] = if cfg!(windows) {
+        &["python"]
+    } else {
+        &["python3", "python"]
+    };
+    names
+        .iter()
+        .find_map(|name| executable_from_path(name))
+        .context(
+            "Python is required; set FASTLED_PYTHON_EXECUTABLE or activate a virtual environment",
+        )
+}
+
+/// Resolve Python from the selected FastLED uv environment while preserving
+/// the virtual-environment path. Canonicalizing this symlink would produce the
+/// base interpreter path and silently discard the environment's dependencies.
+pub(crate) fn resolve_fastled_python(fastled_dir: &Path) -> Result<PathBuf> {
+    let mut roots = vec![fastled_dir.to_path_buf()];
+    if let Ok(root) = fastled_root() {
+        roots.push(root.join("cache").join("fl").join("repo"));
+        roots.push(root.join("cache").join("fastled-master"));
+    }
+    for root in roots {
+        let candidate = if cfg!(windows) {
+            root.join(".venv").join("Scripts").join("python.exe")
+        } else {
+            root.join(".venv").join("bin").join("python")
+        };
+        if candidate.is_file() && candidate.is_absolute() {
+            return Ok(candidate);
+        }
+    }
+    resolve_managed_python()
+}
+
+/// Resolve Node from the FastLED uv environment before considering the
+/// caller's PATH. `fastled_dir` is normally the short cached checkout at
+/// `~/.fastled/cache/fl/repo`; the cache fallback keeps toolchain health
+/// checks aligned with normal builds.
+pub(crate) fn resolve_managed_node(fastled_dir: Option<&Path>) -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("FASTLED_NODE_EXECUTABLE").map(PathBuf::from) {
+        if let Some(path) = absolute_executable(&path) {
+            return Ok(path);
+        }
+    }
+
+    let mut roots = Vec::new();
+    if let Some(fastled_dir) = fastled_dir {
+        roots.push(fastled_dir.to_path_buf());
+    }
+    if let Ok(root) = fastled_root() {
+        roots.push(root.join("cache").join("fl").join("repo"));
+        roots.push(root.join("cache").join("fastled-master"));
+    }
+    for root in roots {
+        let candidate = if cfg!(windows) {
+            root.join(".venv").join("Scripts").join("node.exe")
+        } else {
+            root.join(".venv").join("bin").join("node")
+        };
+        if let Some(path) = absolute_executable(&candidate) {
+            return Ok(path);
+        }
+    }
+
+    executable_from_path("node")
+        .context("Node.js is required; FastLED's uv environment did not provide .venv/bin/node and node was not found on PATH")
+}
+
+/// Ensure the selected FastLED checkout has the uv-managed runtime required by
+/// its Meson helpers and Emscripten. This is intentionally project-local and
+/// never modifies the user's global Python, Node, or shell PATH.
+pub(crate) fn ensure_fastled_uv_environment(fastled_dir: &Path) -> Result<()> {
+    if resolve_managed_node(Some(fastled_dir)).is_ok() {
+        return Ok(());
+    }
+    let uv = resolve_managed_uv()?;
+    let python = resolve_managed_python()?;
+    let mut command = Command::new(&uv);
+    command
+        .args(["sync", "--no-dev", "--project"])
+        .arg(fastled_dir)
+        .arg("--python")
+        .arg(&python)
+        .env("FASTLED_PYTHON_EXECUTABLE", &python);
+    let status = command
+        .status()
+        .with_context(|| format!("provision FastLED runtime with {}", uv.display()))?;
+    if !status.success() {
+        bail!("uv failed to provision FastLED runtime with {status}");
+    }
+    resolve_managed_node(Some(fastled_dir)).with_context(|| {
+        format!(
+            "uv completed but did not provide Node in {}",
+            fastled_dir.join(".venv").display()
+        )
+    })?;
+    Ok(())
+}
+
+fn prepend_runtime_path(command: &mut Command, python: &Path, node: &Path) {
+    let mut entries = Vec::new();
+    if let Some(parent) = python.parent() {
+        entries.push(parent.to_path_buf());
+    }
+    if let Some(parent) = node.parent() {
+        entries.push(parent.to_path_buf());
+    }
+    if let Some(path) = std::env::var_os("PATH") {
+        entries.extend(std::env::split_paths(&path));
+    }
+    if let Ok(path) = std::env::join_paths(entries) {
+        command.env("PATH", path);
     }
 }
 
@@ -587,20 +757,20 @@ fn run_health_checks(install: &Path) -> Result<()> {
     fs::create_dir_all(&temp)?;
     let result = (|| -> Result<()> {
         let empp = install.join("emscripten").join("em++.py");
-        let python = if cfg!(windows) {
-            "python.exe"
-        } else {
-            "python3"
-        };
+        let python = resolve_managed_python()?;
+        let node = resolve_managed_node(None)?;
         let run = |args: &[&str]| -> Result<()> {
-            let status = Command::new(python)
+            let mut command = Command::new(&python);
+            command
                 .arg(&empp)
                 .args(args)
                 .env("EM_CONFIG", install.join(".emscripten"))
                 .env("EMSCRIPTEN", install.join("emscripten"))
-                .current_dir(&temp)
-                .status()
-                .context("run Emscripten health check")?;
+                .env("EMSDK_PYTHON", &python)
+                .env("FASTLED_PYTHON_EXECUTABLE", &python)
+                .current_dir(&temp);
+            prepend_runtime_path(&mut command, &python, &node);
+            let status = command.status().context("run Emscripten health check")?;
             if !status.success() {
                 bail!(
                     "Emscripten health-check command failed: em++ {}",
@@ -618,7 +788,6 @@ fn run_health_checks(install: &Path) -> Result<()> {
             "-o",
             "static.js",
         ])?;
-        let node = resolve_node().context("Node.js is required for Emscripten health checks")?;
         let static_status = Command::new(&node)
             .arg(temp.join("static.js"))
             .current_dir(&temp)
@@ -717,7 +886,8 @@ fn install_spec(
         archive::extract_tar_zst(&archive_path, &staging)?;
         ensure_toolchain_executables(&staging)?;
         validate_emscripten_payload(&staging)?;
-        archive::write_emscripten_config(&staging, "node")?;
+        let node = resolve_managed_node(None)?;
+        archive::write_emscripten_config(&staging, &node)?;
         fs::write(staging.join("done.txt"), "ok\n")?;
         write_receipt(&staging, spec, false)?;
         validate_complete_emscripten_install(&staging)?;
@@ -891,6 +1061,16 @@ fn run_toolchain_action_locked(
 }
 
 pub(crate) fn run_toolchain_action(action: crate::cli::ToolchainAction) -> Result<()> {
+    if matches!(
+        &action,
+        crate::cli::ToolchainAction::Install { .. }
+            | crate::cli::ToolchainAction::Activate { .. }
+            | crate::cli::ToolchainAction::Update
+            | crate::cli::ToolchainAction::Repair { .. }
+    ) {
+        let fastled_dir = ensure_fastled_repo(Some("master"))?;
+        ensure_fastled_uv_environment(&fastled_dir)?;
+    }
     let spec = release_default_toolchain()?;
     let base = install_base(spec)?;
     fs::create_dir_all(&base)?;
@@ -1120,6 +1300,64 @@ fn find_fastled_extract_root(dir: &Path) -> Result<PathBuf> {
     anyhow::bail!("no FastLED* directory found inside {}", dir.display())
 }
 
+/// Remove the derived short-path checkout when it represents `reference`.
+/// The authoritative source checkout remains untouched.
+pub(crate) fn invalidate_short_fastled_copy(reference: &str) -> Result<()> {
+    let cache_base = fastled_root()?.join("cache");
+    let authoritative = crate::source::repo_dir(&cache_base, reference)?;
+    let short_root = cache_base.join("fl");
+    let marker = short_root.join("repo").join(".fastled-source");
+    let matches = fs::read_to_string(&marker)
+        .map(|value| value.lines().next() == Some(authoritative.to_string_lossy().as_ref()))
+        .unwrap_or(false);
+    if matches && short_root.exists() {
+        fs::remove_dir_all(&short_root).with_context(|| {
+            format!(
+                "invalidate derived FastLED checkout {}",
+                short_root.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Force-refresh one explicitly named FastLED ref using staged publication.
+pub(crate) fn refresh_fastled_repo(reference: &str) -> Result<PathBuf> {
+    let (ref_name, url) = resolve_fastled_ref(Some(reference));
+    if ref_name != reference {
+        bail!("requested FastLED ref {reference:?} resolved unexpectedly as {ref_name:?}");
+    }
+    let cache_base = fastled_root()?.join("cache");
+    let archive_cache = cache_base.join("archives");
+    fs::create_dir_all(&archive_cache)?;
+    let download_dir = tempfile::Builder::new()
+        .prefix("fastled-source-download-")
+        .tempdir_in(&archive_cache)
+        .context("create temporary FastLED download directory")?;
+    let archive_path = download_dir.path().join("FastLED.zip");
+    archive::download(&url, &archive_path)
+        .with_context(|| format!("download FastLED archive from {url}"))?;
+    let receipt =
+        crate::source::SourceReceipt::new(&ref_name, &url, None, std::time::SystemTime::now())?;
+    let repo = crate::source::update_checkout(&cache_base, &receipt, |staging| {
+        let unpacked = staging.join(".unpacked");
+        archive::extract_zip(&archive_path, &unpacked)?;
+        let extracted_root = find_fastled_extract_root(&unpacked)?;
+        for entry in fs::read_dir(&extracted_root)? {
+            let entry = entry?;
+            fs::rename(entry.path(), staging.join(entry.file_name())).with_context(|| {
+                format!("promote FastLED archive entry {}", entry.path().display())
+            })?;
+        }
+        fs::remove_dir_all(&unpacked)?;
+        Ok(())
+    })?;
+    // A prior short checkout has the same authoritative path in its marker;
+    // remove it so the next build cannot silently reuse old source bytes.
+    invalidate_short_fastled_copy(&ref_name)?;
+    Ok(repo.into_path_buf())
+}
+
 /// Ensure the FastLED repo for `ref_opt` is downloaded and extracted under
 /// `~/.fastled/cache/fastled-{ref}/`. Returns the resolved local repo root.
 ///
@@ -1134,6 +1372,10 @@ pub fn ensure_fastled_repo(ref_opt: Option<&str>) -> Result<PathBuf> {
 
     if repo_dir.join("library.json").is_file() {
         return Ok(repo_dir);
+    }
+
+    if ref_name == "master" {
+        return refresh_fastled_repo("master");
     }
 
     let archive_cache = cache_base.join("archives");
@@ -1160,6 +1402,10 @@ pub fn ensure_fastled_repo(ref_opt: Option<&str>) -> Result<PathBuf> {
     }
     fs::rename(&extracted_root, &repo_dir)?;
     fs::remove_dir_all(&staging).ok();
+
+    let receipt =
+        crate::source::SourceReceipt::new(&ref_name, &url, None, std::time::SystemTime::now())?;
+    crate::source::write_receipt(&repo_dir, &receipt)?;
 
     Ok(repo_dir)
 }
@@ -1914,6 +2160,25 @@ mod tests {
         fs::write(install.join("done.txt"), "ok\n").unwrap();
         write_receipt(&install, spec, true).unwrap();
         install
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fastled_python_keeps_virtual_environment_symlink_path() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let base_python = temp.path().join("base-python");
+        fs::write(&base_python, "python").unwrap();
+        let venv_bin = temp.path().join("FastLED/.venv/bin");
+        fs::create_dir_all(&venv_bin).unwrap();
+        let venv_python = venv_bin.join("python");
+        symlink(&base_python, &venv_python).unwrap();
+
+        assert_eq!(
+            resolve_fastled_python(&temp.path().join("FastLED")).unwrap(),
+            venv_python
+        );
     }
 
     #[test]

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -26,6 +26,7 @@ pub mod runtime;
 mod selection;
 mod server;
 mod sketch_preprocessor;
+mod source;
 mod test_mode;
 pub mod viewer;
 pub mod wasm_build;
@@ -52,6 +53,16 @@ pub fn run() -> ExitCode {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
                 eprintln!("fastled: toolchain command failed: {error:#}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    if let Some(cli::Command::Source { action }) = cli.command.clone() {
+        return match source::run_source_action(action) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("fastled: source command failed: {error:#}");
                 ExitCode::FAILURE
             }
         };

--- a/crates/fastled-cli/src/server.rs
+++ b/crates/fastled-cli/src/server.rs
@@ -148,7 +148,7 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
       if (l.includes('error:') || l.includes('fatal error') ||
           l.includes('undefined symbol') ||
           (stream === 'stderr' && l.includes('failed'))) { return 'err'; }
-      if (l.includes('warning:')) { return 'warn'; }
+      if (l.includes('warning:') || stream === 'warning') { return 'warn'; }
       return '';
     }
     function appendLog(line, stream) {

--- a/crates/fastled-cli/src/source.rs
+++ b/crates/fastled-cli/src/source.rs
@@ -1,0 +1,450 @@
+//! Cached FastLED source checkout metadata and safe replacement primitives.
+//!
+//! The compiler owns downloading a checkout, while this module owns the cache
+//! contract shared by normal compilation and `fastled source ...` commands.
+//! In particular, updates are staged beside the live checkout and the old
+//! checkout is restored if publishing the staged checkout fails.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::SourceAction;
+use crate::path::NormalizedPath;
+
+/// A `master` checkout is considered old after this duration. It remains
+/// usable; callers should surface [`master_stale_warning`] rather than fail a
+/// build.
+pub(crate) const MASTER_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+const RECEIPT_FILE: &str = ".fastled-source.json";
+
+/// Provenance for a downloaded FastLED checkout.
+///
+/// `fetched_at_unix_secs` intentionally uses a simple UTC epoch timestamp so
+/// receipts remain portable and can be inspected without a date-time crate.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct SourceReceipt {
+    pub(crate) requested_ref: String,
+    pub(crate) fetched_at_unix_secs: u64,
+    pub(crate) source_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) resolved_commit: Option<String>,
+}
+
+impl SourceReceipt {
+    pub(crate) fn new(
+        requested_ref: impl Into<String>,
+        source_url: impl Into<String>,
+        resolved_commit: Option<String>,
+        fetched_at: SystemTime,
+    ) -> Result<Self> {
+        Ok(Self {
+            requested_ref: requested_ref.into(),
+            fetched_at_unix_secs: fetched_at
+                .duration_since(UNIX_EPOCH)
+                .context("source receipt fetch time predates the Unix epoch")?
+                .as_secs(),
+            source_url: source_url.into(),
+            resolved_commit,
+        })
+    }
+
+    pub(crate) fn fetched_at(&self) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(self.fetched_at_unix_secs)
+    }
+}
+
+/// The state of one cache entry, suitable for `fastled source status` output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SourceStatus {
+    pub(crate) requested_ref: String,
+    pub(crate) repo_dir: NormalizedPath,
+    pub(crate) receipt: Option<SourceReceipt>,
+    pub(crate) age: Option<Duration>,
+    pub(crate) checkout_exists: bool,
+}
+
+impl SourceStatus {
+    /// A cache is stale only for `master`. Missing metadata is deliberately
+    /// stale: older CLI releases did not record when they downloaded master.
+    pub(crate) fn is_stale_master(&self) -> bool {
+        self.checkout_exists
+            && self.requested_ref == "master"
+            && (self.receipt.is_none() || self.age.is_none_or(|age| age > MASTER_MAX_AGE))
+    }
+}
+
+/// Resolve the `~/.fastled/cache` directory.
+pub(crate) fn default_cache_base() -> Result<NormalizedPath> {
+    let home = dirs::home_dir().context("cannot resolve home directory")?;
+    Ok(NormalizedPath::new(home.join(".fastled").join("cache")))
+}
+
+/// Resolve the checkout directory for one cache key.
+///
+/// Ref names are made path-safe before they are used in a deletion or rename
+/// operation. Git ref names containing `/` are intentionally not accepted by
+/// this management API until a compatible cache-key encoding is introduced.
+pub(crate) fn repo_dir(cache_base: &Path, requested_ref: &str) -> Result<NormalizedPath> {
+    validate_cache_ref(requested_ref)?;
+    Ok(NormalizedPath::new(
+        cache_base.join(format!("fastled-{requested_ref}")),
+    ))
+}
+
+pub(crate) fn receipt_path(repo_dir: &Path) -> NormalizedPath {
+    NormalizedPath::new(repo_dir.join(RECEIPT_FILE))
+}
+
+pub(crate) fn read_receipt(repo_dir: &Path) -> Result<Option<SourceReceipt>> {
+    let path = receipt_path(repo_dir);
+    match fs::read_to_string(&path) {
+        Ok(text) => serde_json::from_str(&text)
+            .with_context(|| format!("parse source receipt {}", path.display()))
+            .map(Some),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read source receipt {}", path.display())),
+    }
+}
+
+pub(crate) fn source_status(
+    cache_base: &Path,
+    requested_ref: &str,
+    now: SystemTime,
+) -> Result<SourceStatus> {
+    let repo_dir = repo_dir(cache_base, requested_ref)?;
+    let receipt = read_receipt(&repo_dir)?;
+    let age = receipt
+        .as_ref()
+        .and_then(|receipt| now.duration_since(receipt.fetched_at()).ok());
+    Ok(SourceStatus {
+        requested_ref: requested_ref.to_string(),
+        checkout_exists: repo_dir.is_dir(),
+        repo_dir,
+        receipt,
+        age,
+    })
+}
+
+/// Return the exact user-facing stale-master message, if a warning applies.
+///
+/// Local checkouts are represented by callers not invoking this cache-only
+/// function. Tags, SHA pins, and non-master branches never warn.
+pub(crate) fn master_stale_warning(status: &SourceStatus) -> Option<String> {
+    if !status.is_stale_master() {
+        return None;
+    }
+
+    let days = status
+        .age
+        .map(|age| (age.as_secs() / (24 * 60 * 60)).max(1))
+        .unwrap_or(1);
+    let unit = if days == 1 { "day old" } else { "days olds" };
+    Some(format!(
+        "Your copy of FastLED master is {days} {unit}. Update with `fastled source update`."
+    ))
+}
+
+/// Populate a fresh checkout in a private staging directory and atomically
+/// publish it as `fastled-<ref>`.
+///
+/// `populate` must leave a complete FastLED checkout in the supplied staging
+/// directory. The receipt is written only after `populate` succeeds. If any
+/// pre-publish operation fails, the live checkout is untouched. If publishing
+/// the staged directory fails after the old checkout was moved aside, this
+/// function restores the old checkout before returning the failure.
+pub(crate) fn update_checkout<F>(
+    cache_base: &Path,
+    receipt: &SourceReceipt,
+    populate: F,
+) -> Result<NormalizedPath>
+where
+    F: FnOnce(&Path) -> Result<()>,
+{
+    validate_cache_ref(&receipt.requested_ref)?;
+    fs::create_dir_all(cache_base)
+        .with_context(|| format!("create source cache {}", cache_base.display()))?;
+
+    let live_dir = repo_dir(cache_base, &receipt.requested_ref)?;
+    let staging_dir = unique_sibling(cache_base, &receipt.requested_ref, "staging")?;
+    fs::create_dir(&staging_dir)
+        .with_context(|| format!("create staged source checkout {}", staging_dir.display()))?;
+
+    let staged = (|| -> Result<()> {
+        populate(&staging_dir)?;
+        if !staging_dir.join("library.json").is_file() {
+            bail!(
+                "staged FastLED checkout {} is missing library.json",
+                staging_dir.display()
+            );
+        }
+        write_receipt(&staging_dir, receipt)
+    })();
+    if let Err(error) = staged {
+        let _ = fs::remove_dir_all(&staging_dir);
+        return Err(error);
+    }
+
+    let backup_dir = unique_sibling(cache_base, &receipt.requested_ref, "backup")?;
+    let had_live_checkout = live_dir.exists();
+    if had_live_checkout {
+        fs::rename(&live_dir, &backup_dir).with_context(|| {
+            format!(
+                "stage existing FastLED checkout {} for replacement",
+                live_dir.display()
+            )
+        })?;
+    }
+
+    if let Err(error) = fs::rename(&staging_dir, &live_dir) {
+        let rollback = if had_live_checkout {
+            fs::rename(&backup_dir, &live_dir)
+                .context("restore previous FastLED checkout after failed update")
+        } else {
+            Ok(())
+        };
+        let _ = fs::remove_dir_all(&staging_dir);
+        rollback?;
+        return Err(error)
+            .with_context(|| format!("publish staged FastLED checkout {}", live_dir.display()));
+    }
+
+    if had_live_checkout {
+        fs::remove_dir_all(&backup_dir).with_context(|| {
+            format!("remove replaced FastLED checkout {}", backup_dir.display())
+        })?;
+    }
+    Ok(live_dir)
+}
+
+/// Remove a single source checkout, never the cache root.
+pub(crate) fn purge_checkout(cache_base: &Path, requested_ref: &str) -> Result<bool> {
+    let repo_dir = repo_dir(cache_base, requested_ref)?;
+    match fs::remove_dir_all(&repo_dir) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| format!("purge {}", repo_dir.display())),
+    }
+}
+
+/// Execute a user-facing `fastled source ...` command.
+pub(crate) fn run_source_action(action: SourceAction) -> Result<()> {
+    let cache_base = default_cache_base()?;
+    match action {
+        SourceAction::Status { reference } => {
+            let status = source_status(&cache_base, &reference, SystemTime::now())?;
+            println!("ref: {}", status.requested_ref);
+            println!("path: {}", status.repo_dir.display());
+            if !status.checkout_exists {
+                println!("state: not cached");
+                return Ok(());
+            }
+            println!("state: cached");
+            if let Some(receipt) = &status.receipt {
+                println!("source: {}", receipt.source_url);
+                println!("fetched at: {}", receipt.fetched_at_unix_secs);
+                if let Some(commit) = &receipt.resolved_commit {
+                    println!("commit: {commit}");
+                }
+            } else {
+                println!("fetched at: unknown (legacy cache)");
+            }
+            if let Some(warning) = master_stale_warning(&status) {
+                use std::io::IsTerminal;
+                if std::io::stderr().is_terminal() {
+                    eprintln!("{}", crossterm::style::Stylize::yellow(warning));
+                } else {
+                    eprintln!("{warning}");
+                }
+            }
+        }
+        SourceAction::Update { reference } => {
+            let path = crate::install::refresh_fastled_repo(&reference)?;
+            println!("Updated FastLED {reference} at {}", path.display());
+        }
+        SourceAction::Purge { reference } => {
+            let removed = purge_checkout(&cache_base, &reference)?;
+            crate::install::invalidate_short_fastled_copy(&reference)?;
+            if removed {
+                println!("Purged FastLED {reference}");
+            } else {
+                println!("FastLED {reference} is not cached");
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn write_receipt(repo_dir: &Path, receipt: &SourceReceipt) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(receipt).context("serialize source receipt")?;
+    fs::write(receipt_path(repo_dir), bytes)
+        .with_context(|| format!("write source receipt in {}", repo_dir.display()))
+}
+
+fn validate_cache_ref(requested_ref: &str) -> Result<()> {
+    if requested_ref.is_empty()
+        || requested_ref == "."
+        || requested_ref == ".."
+        || requested_ref.contains(['/', '\\'])
+        || requested_ref.contains("..")
+    {
+        bail!("unsafe FastLED cache ref {requested_ref:?}");
+    }
+    Ok(())
+}
+
+fn unique_sibling(cache_base: &Path, requested_ref: &str, purpose: &str) -> Result<NormalizedPath> {
+    let base = format!(".fastled-{requested_ref}.{purpose}");
+    let pid = std::process::id();
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    for counter in 0..1000_u32 {
+        let candidate = cache_base.join(format!("{base}-{pid}-{nonce}-{counter}"));
+        if !candidate.exists() {
+            return Ok(NormalizedPath::new(candidate));
+        }
+    }
+    bail!("could not allocate a unique {purpose} directory for FastLED {requested_ref}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn receipt(ref_name: &str, fetched_at: SystemTime) -> SourceReceipt {
+        SourceReceipt::new(
+            ref_name,
+            "https://github.com/FastLED/FastLED/archive/refs/heads/master.zip",
+            Some("deadbeef".to_string()),
+            fetched_at,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn master_warning_uses_exact_command_and_dynamic_days() {
+        let cache = TempDir::new().unwrap();
+        let now = UNIX_EPOCH + Duration::from_secs(5 * 24 * 60 * 60);
+        let old = receipt("master", now - Duration::from_secs(2 * 24 * 60 * 60));
+        update_checkout(cache.path(), &old, |staging| {
+            fs::write(staging.join("library.json"), "{}").context("write library")
+        })
+        .unwrap();
+
+        let status = source_status(cache.path(), "master", now).unwrap();
+        assert_eq!(
+            master_stale_warning(&status).as_deref(),
+            Some(
+                "Your copy of FastLED master is 2 days olds. Update with `fastled source update`."
+            )
+        );
+    }
+
+    #[test]
+    fn master_freshness_uses_a_strict_24_hour_boundary() {
+        let cache = TempDir::new().unwrap();
+        let now = UNIX_EPOCH + Duration::from_secs(10 * 24 * 60 * 60);
+        for (ref_name, age, warns) in [
+            ("master", Duration::from_secs(23 * 60 * 60), false),
+            ("master", Duration::from_secs(24 * 60 * 60), false),
+            ("master", Duration::from_secs(25 * 60 * 60), true),
+        ] {
+            let item = receipt(ref_name, now - age);
+            update_checkout(cache.path(), &item, |staging| {
+                fs::write(staging.join("library.json"), "{}").context("write library")
+            })
+            .unwrap();
+            let status = source_status(cache.path(), ref_name, now).unwrap();
+            assert_eq!(master_stale_warning(&status).is_some(), warns);
+        }
+    }
+
+    #[test]
+    fn master_without_receipt_is_stale() {
+        let cache = TempDir::new().unwrap();
+        let repo = repo_dir(cache.path(), "master").unwrap();
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("library.json"), "{}").unwrap();
+
+        let status = source_status(cache.path(), "master", SystemTime::now()).unwrap();
+        assert!(status.is_stale_master());
+        assert_eq!(
+            master_stale_warning(&status).as_deref(),
+            Some("Your copy of FastLED master is 1 day old. Update with `fastled source update`.")
+        );
+    }
+
+    #[test]
+    fn tags_shas_and_non_master_branches_never_warn() {
+        let cache = TempDir::new().unwrap();
+        let now = SystemTime::now();
+        for ref_name in ["3.10.0", "abcdef0", "main"] {
+            let old = receipt(ref_name, now - Duration::from_secs(7 * 24 * 60 * 60));
+            update_checkout(cache.path(), &old, |staging| {
+                fs::write(staging.join("library.json"), "{}").context("write library")
+            })
+            .unwrap();
+            let status = source_status(cache.path(), ref_name, now).unwrap();
+            assert!(master_stale_warning(&status).is_none(), "{ref_name}");
+        }
+    }
+
+    #[test]
+    fn failed_staged_update_preserves_existing_checkout() {
+        let cache = TempDir::new().unwrap();
+        let old = receipt("master", SystemTime::now());
+        let live = update_checkout(cache.path(), &old, |staging| {
+            fs::write(staging.join("library.json"), "{}").context("write library")?;
+            fs::write(staging.join("marker"), "old").context("write marker")
+        })
+        .unwrap();
+
+        let fresh = receipt("master", SystemTime::now());
+        assert!(
+            update_checkout(cache.path(), &fresh, |_staging| bail!("download failed")).is_err()
+        );
+        assert_eq!(fs::read_to_string(live.join("marker")).unwrap(), "old");
+    }
+
+    #[test]
+    fn update_replaces_checkout_and_receipt_together() {
+        let cache = TempDir::new().unwrap();
+        let old = receipt("master", UNIX_EPOCH + Duration::from_secs(1));
+        update_checkout(cache.path(), &old, |staging| {
+            fs::write(staging.join("library.json"), "{}").context("write library")?;
+            fs::write(staging.join("marker"), "old").context("write marker")
+        })
+        .unwrap();
+
+        let fresh = receipt("master", UNIX_EPOCH + Duration::from_secs(2));
+        let live = update_checkout(cache.path(), &fresh, |staging| {
+            fs::write(staging.join("library.json"), "{}").context("write library")?;
+            fs::write(staging.join("marker"), "new").context("write marker")
+        })
+        .unwrap();
+        assert_eq!(fs::read_to_string(live.join("marker")).unwrap(), "new");
+        assert_eq!(read_receipt(&live).unwrap(), Some(fresh));
+    }
+
+    #[test]
+    fn purge_is_scoped_to_one_safe_checkout() {
+        let cache = TempDir::new().unwrap();
+        let master = repo_dir(cache.path(), "master").unwrap();
+        let tag = repo_dir(cache.path(), "3.10.0").unwrap();
+        fs::create_dir_all(&master).unwrap();
+        fs::create_dir_all(&tag).unwrap();
+
+        assert!(purge_checkout(cache.path(), "master").unwrap());
+        assert!(!master.exists());
+        assert!(tag.exists());
+        assert!(repo_dir(cache.path(), "../cache").is_err());
+    }
+}

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -5,6 +5,7 @@
 //! Emscripten path resolution are owned by this Rust binary.
 
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::fs;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
@@ -15,14 +16,18 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::cli::LinkMode;
-use crate::{archive, debug_symbols, dynamic_cache, frontend, install};
+use crate::{archive, debug_symbols, dynamic_cache, frontend, install, source};
 
 /// Receives one build-output line at a time. The second argument is the
 /// originating stream: `"stdout"` or `"stderr"`. Called on the build thread.
 pub type LogSink<'a> = &'a (dyn Fn(&str, &str) + 'a);
 
 fn stdio_log(line: &str, stream: &str) {
-    if stream == "stderr" {
+    use std::io::IsTerminal;
+
+    if stream == "warning" && std::io::stderr().is_terminal() {
+        eprintln!("{}", crossterm::style::Stylize::yellow(line));
+    } else if stream == "stderr" || stream == "warning" {
         eprintln!("{line}");
     } else {
         println!("{line}");
@@ -89,6 +94,8 @@ struct ToolPaths {
     wasm_finalize: PathBuf,
     emscripten_version: String,
     python: PathBuf,
+    node: PathBuf,
+    runtime_bin: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -189,30 +196,71 @@ pub(crate) struct DwarfPathRoots {
     emsdk_root: Option<PathBuf>,
 }
 
-fn resolve_python_executable() -> PathBuf {
-    if let Some(path) = std::env::var_os("FASTLED_PYTHON_EXECUTABLE").map(PathBuf::from) {
-        if path.is_file() {
-            return path;
+/// Create a private PATH directory for child build tools.  This is deliberately
+/// inside the managed Emscripten install rather than the user's shell or the
+/// FastLED checkout.  Older FastLED revisions call bare `python`; exposing
+/// both spellings makes them use the interpreter selected by the wheel/venv.
+fn replace_runtime_alias(bin_dir: &Path, name: &str, target: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        let alias = bin_dir.join(name);
+        if alias.symlink_metadata().is_ok() {
+            if alias.is_dir() {
+                bail!("managed runtime alias {} is a directory", alias.display());
+            }
+            fs::remove_file(&alias)
+                .with_context(|| format!("remove managed runtime alias {}", alias.display()))?;
         }
+        symlink(target, &alias).with_context(|| {
+            format!(
+                "create managed runtime alias {} -> {}",
+                alias.display(),
+                target.display()
+            )
+        })?;
     }
-    if let Some(venv) = std::env::var_os("VIRTUAL_ENV").map(PathBuf::from) {
-        let candidate = if cfg!(windows) {
-            venv.join("Scripts").join("python.exe")
-        } else {
-            venv.join("bin").join("python")
-        };
-        if candidate.is_file() {
-            return candidate;
-        }
+    #[cfg(windows)]
+    {
+        // Windows resolves .cmd through PATHEXT.  A command wrapper avoids
+        // requiring symlink privileges while preserving the absolute target.
+        let alias = bin_dir.join(format!("{name}.cmd"));
+        let escaped_target = target.to_string_lossy().replace('"', "\"\"");
+        fs::write(&alias, format!("@\"{escaped_target}\" %*\r\n"))
+            .with_context(|| format!("write managed runtime alias {}", alias.display()))?;
     }
-    PathBuf::from(if cfg!(windows) {
-        "python.exe"
-    } else {
-        "python3"
-    })
+    Ok(())
 }
 
-fn resolve_tool_paths(install_dir: &Path) -> Result<ToolPaths> {
+fn prepare_runtime_bin(install_dir: &Path, python: &Path, node: &Path) -> Result<PathBuf> {
+    let bin_dir = install_dir.join(".fastled-runtime-bin");
+    fs::create_dir_all(&bin_dir)
+        .with_context(|| format!("create managed runtime directory {}", bin_dir.display()))?;
+    replace_runtime_alias(&bin_dir, "python", python)?;
+    replace_runtime_alias(&bin_dir, "python3", python)?;
+    replace_runtime_alias(&bin_dir, "node", node)?;
+    Ok(bin_dir)
+}
+
+fn runtime_path_value(
+    runtime_bin: &Path,
+    managed_project_bin: Option<&Path>,
+    caller_path: Option<&OsStr>,
+) -> Result<String> {
+    let mut entries = Vec::new();
+    if let Some(managed_project_bin) = managed_project_bin {
+        entries.push(managed_project_bin.to_path_buf());
+    }
+    entries.push(runtime_bin.to_path_buf());
+    if let Some(caller_path) = caller_path {
+        entries.extend(std::env::split_paths(caller_path));
+    }
+    let path = std::env::join_paths(entries).context("construct managed build PATH")?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+fn resolve_tool_paths(install_dir: &Path, fastled_dir: &Path) -> Result<ToolPaths> {
     let emscripten_dir = install_dir.join("emscripten");
     let emcc = emscripten_dir.join("emcc.py");
     let empp = emscripten_dir.join("em++.py");
@@ -248,6 +296,9 @@ fn resolve_tool_paths(install_dir: &Path) -> Result<ToolPaths> {
     if !clangpp.is_file() {
         bail!("missing clang++ at {}", clangpp.display());
     }
+    let python = install::resolve_fastled_python(fastled_dir)?;
+    let node = install::resolve_managed_node(Some(fastled_dir))?;
+    let runtime_bin = prepare_runtime_bin(install_dir, &python, &node)?;
     Ok(ToolPaths {
         emscripten_dir,
         emcc,
@@ -258,7 +309,9 @@ fn resolve_tool_paths(install_dir: &Path) -> Result<ToolPaths> {
         llvm_objcopy,
         wasm_finalize,
         emscripten_version,
-        python: resolve_python_executable(),
+        python,
+        node,
+        runtime_bin,
     })
 }
 
@@ -285,6 +338,19 @@ fn build_env(tools: &ToolPaths) -> Vec<(String, String)> {
         (
             "EMSDK_PYTHON".to_string(),
             tools.python.display().to_string(),
+        ),
+        (
+            "FASTLED_PYTHON_EXECUTABLE".to_string(),
+            tools.python.display().to_string(),
+        ),
+        (
+            "PATH".to_string(),
+            runtime_path_value(
+                &tools.runtime_bin,
+                tools.node.parent(),
+                std::env::var_os("PATH").as_deref(),
+            )
+            .unwrap_or_else(|_| tools.runtime_bin.display().to_string()),
         ),
         ("EMCC_SKIP_SANITY_CHECK".to_string(), "1".to_string()),
         // Build tools are Python-driven; without this their stdout is
@@ -852,6 +918,7 @@ fn toolchain_fingerprint(tools: &ToolPaths) -> Result<String> {
     let mut values = vec![
         format!("content={content}"),
         format!("python={}", tools.python.display()),
+        format!("node={}", tools.node.display()),
         format!("clang={}", clang.display()),
         format!("wasm-ld={}", wasm_ld.display()),
         format!("llvm-ar={}", llvm_ar.display()),
@@ -1955,7 +2022,11 @@ fn resolve_fastled_dir(request: &BuildRequest) -> Result<(PathBuf, Option<PathBu
         return Ok((repo, None));
     }
     let marker = short_dir.join(".fastled-source");
-    let source_key = repo.to_string_lossy().into_owned();
+    let mut source_key = repo.to_string_lossy().into_owned();
+    if let Ok(receipt) = fs::read_to_string(source::receipt_path(&repo)) {
+        source_key.push('\n');
+        source_key.push_str(&receipt);
+    }
     if short_dir.join("library.json").is_file()
         && fs::read_to_string(&marker).unwrap_or_default() == source_key
     {
@@ -1979,7 +2050,10 @@ fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
         let path = entry.path();
         let target = dst.join(entry.file_name());
         if path.is_dir() {
-            if entry.file_name().to_string_lossy() == ".git" {
+            if matches!(
+                entry.file_name().to_string_lossy().as_ref(),
+                ".git" | ".venv"
+            ) {
                 continue;
             }
             copy_dir(&path, &target)?;
@@ -2008,11 +2082,25 @@ pub fn run_build_streaming(request: &BuildRequest, log: LogSink) -> Result<Build
     }
     fs::create_dir_all(&output_dir)?;
 
-    let emscripten_install = install::ensure_emscripten_installed()?;
-    archive::write_emscripten_config(&emscripten_install, "node")?;
-    let tools = resolve_tool_paths(&emscripten_install)?;
+    if request.fastled_path.is_none() {
+        let requested_ref = crate::project::read_fastled_json_ref(&request.sketch_dir)
+            .unwrap_or_else(|| "master".to_string());
+        let is_local_ref = Path::new(&requested_ref).join("library.json").is_file();
+        if !is_local_ref && requested_ref == "master" {
+            let cache = source::default_cache_base()?;
+            let status = source::source_status(&cache, "master", std::time::SystemTime::now())?;
+            if let Some(warning) = source::master_stale_warning(&status) {
+                log(&warning, "warning");
+            }
+        }
+    }
+
     let (fastled_dir, _cleanup) = resolve_fastled_dir(request)?;
     let fastled_dir = normalize_path(&fastled_dir);
+    install::ensure_fastled_uv_environment(&fastled_dir)?;
+    let emscripten_install = install::ensure_emscripten_installed()?;
+    let tools = resolve_tool_paths(&emscripten_install, &fastled_dir)?;
+    archive::write_emscripten_config(&emscripten_install, &tools.node)?;
     let emsdk_root = Some(emscripten_install.clone());
     let (example_name, example_dir, _is_in_tree) =
         resolve_example_name(&normalize_path(&request.sketch_dir), &fastled_dir);
@@ -2291,6 +2379,60 @@ mod tests {
     }
 
     #[test]
+    fn managed_runtime_bin_exposes_python_spellings_and_node() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = temp.path().join("toolchain");
+        let tools = temp.path().join("tools");
+        fs::create_dir_all(&tools).unwrap();
+        let python = tools.join(if cfg!(windows) {
+            "python.exe"
+        } else {
+            "python"
+        });
+        let node = tools.join(if cfg!(windows) { "node.exe" } else { "node" });
+        fs::write(&python, "tool").unwrap();
+        fs::write(&node, "tool").unwrap();
+
+        let runtime_bin = prepare_runtime_bin(&install, &python, &node).unwrap();
+        #[cfg(unix)]
+        {
+            assert_eq!(fs::read_link(runtime_bin.join("python")).unwrap(), python);
+            assert_eq!(fs::read_link(runtime_bin.join("python3")).unwrap(), python);
+            assert_eq!(fs::read_link(runtime_bin.join("node")).unwrap(), node);
+        }
+        #[cfg(windows)]
+        {
+            for name in ["python", "python3", "node"] {
+                let wrapper = fs::read_to_string(runtime_bin.join(format!("{name}.cmd"))).unwrap();
+                assert!(wrapper.contains("%*"), "wrapper must forward arguments");
+            }
+        }
+    }
+
+    #[test]
+    fn managed_runtime_path_prepends_without_dropping_caller_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let runtime_bin = temp.path().join("runtime-bin");
+        let managed_bin = temp.path().join("managed-bin");
+        let caller_bin = temp.path().join("caller-bin");
+        let caller_path = std::env::join_paths([caller_bin.clone()]).unwrap();
+
+        let path = runtime_path_value(
+            &runtime_bin,
+            Some(&managed_bin),
+            Some(caller_path.as_os_str()),
+        )
+        .unwrap();
+        let entries = std::env::split_paths(OsStr::new(&path)).collect::<Vec<_>>();
+        assert_eq!(entries.first(), Some(&managed_bin));
+        assert_eq!(entries.get(1), Some(&runtime_bin));
+        assert!(
+            entries.contains(&caller_bin),
+            "caller PATH entry was dropped"
+        );
+    }
+
+    #[test]
     fn resolve_example_maps_external_to_examples_leaf() {
         let root = PathBuf::from("/tmp/FastLED");
         let sketch = PathBuf::from("/tmp/MySketch");
@@ -2404,6 +2546,8 @@ mod tests {
             wasm_finalize,
             emscripten_version: version.to_string(),
             python: PathBuf::from("python"),
+            node: PathBuf::from("node"),
+            runtime_bin: PathBuf::from("runtime-bin"),
         }
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     # emcc.py/em++.py/emar.py entry points directly.
     "meson>=1.4",
     "ninja>=1.11",
+    # The native CLI uses uv to provision FastLED's project-local Python and
+    # Node runtimes. Keeping uv in the wheel environment makes first-run WASM
+    # builds independent of Homebrew or a user-managed shell installation.
+    "uv>=0.5",
     "typeguard>=4.4.4",
     "zcmds_win32; sys_platform == 'win32'",
 ]

--- a/src/fastled/_rust_cli.py
+++ b/src/fastled/_rust_cli.py
@@ -73,11 +73,29 @@ def find_rust_fastled_cli() -> Path | None:
     return None
 
 
+def _packaged_frontend_dir() -> Path:
+    """Return the absolute frontend directory bundled with this package."""
+    return Path(__file__).resolve().parent / "frontend"
+
+
+def _managed_uv_executable() -> Path | None:
+    """Locate uv beside the interpreter installed with the FastLED wheel."""
+    scripts = Path(sys.executable).resolve().parent
+    candidate = scripts / ("uv.exe" if sys.platform == "win32" else "uv")
+    return candidate if candidate.is_file() else None
+
+
 def invoke_rust_fastled_cli(argv: list[str] | None = None) -> int:
     """Run the Rust FastLED CLI and return its exit code."""
     args = list(argv or [])
     env = os.environ.copy()
     env.setdefault("FASTLED_PYTHON_EXECUTABLE", sys.executable)
+    if uv := _managed_uv_executable():
+        env.setdefault("FASTLED_UV_EXECUTABLE", str(uv))
+    # A wheel's Rust binary must never depend on the build machine's
+    # CARGO_MANIFEST_DIR. Keep this absolute so the binary can be launched
+    # from any working directory after installation.
+    env["FASTLED_FRONTEND_DIR"] = str(_packaged_frontend_dir())
 
     cli = find_rust_fastled_cli()
     if cli is not None:

--- a/tests/unit/test_python_api.py
+++ b/tests/unit/test_python_api.py
@@ -1,8 +1,11 @@
 import importlib.util
 import re
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import fastled
+from fastled import _rust_cli
 
 
 def test_python_package_is_cli_only() -> None:
@@ -34,3 +37,21 @@ def test_python_version_matches_cargo_workspace_version() -> None:
 
 def test_native_extension_is_not_packaged() -> None:
     assert importlib.util.find_spec("fastled._native") is None
+
+
+def test_rust_launcher_exports_absolute_packaged_frontend_dir() -> None:
+    bundled_cli = Path("/tmp/fastled-wheel/bin/fastled")
+    bundled_uv = Path("/tmp/fastled-wheel/bin/uv")
+    with (
+        patch.object(_rust_cli, "find_rust_fastled_cli", return_value=bundled_cli),
+        patch.object(_rust_cli, "_managed_uv_executable", return_value=bundled_uv),
+        patch.object(_rust_cli.subprocess, "run") as run,
+    ):
+        run.return_value = subprocess.CompletedProcess([], 0)
+        assert _rust_cli.invoke_rust_fastled_cli(["--version"]) == 0
+
+    env = run.call_args.kwargs["env"]
+    frontend = Path(env["FASTLED_FRONTEND_DIR"])
+    assert frontend.is_absolute()
+    assert frontend == Path(_rust_cli.__file__).resolve().parent / "frontend"
+    assert env["FASTLED_UV_EXECUTABLE"] == str(bundled_uv)


### PR DESCRIPTION
## Summary

- provision FastLED's project-local Python, Node, Meson, and Ninja runtime through the wheel's bundled uv dependency and expose absolute runtime paths to Emscripten
- resolve frontend assets from the installed Python package instead of the build machine's embedded CARGO_MANIFEST_DIR
- add `fastled source status|update|purge`, atomic source refreshes, and the requested stale-master warning
- add a macOS ARM installed-wheel smoke test with an empty HOME and restricted PATH; it compiles a 16x16 ScreenMap sketch in the shipped viewer and requires/uploads a real PNG

## Validation

- `bash lint`
- `bash test` (234 Rust library tests, 3 binary tests, 1 doc test; 18 Python passed, 1 platform skip)
- local wheel built, installed in a clean venv, and run outside the checkout with no ambient `node` or bare `python`
- shipped viewer rendered a visually verified 1280x1280 PNG (1.1 MB)

Closes #218