### PR TITLE
fix(cli): preserve wheel virtualenv tools

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -127,10 +127,12 @@ jobs:
           set -euo pipefail
           SMOKE_ROOT="$RUNNER_TEMP/fastled-wheel-smoke"
           rm -rf "$SMOKE_ROOT"
-          mkdir -p "$SMOKE_ROOT/home" "$SMOKE_ROOT/bin" "$SMOKE_ROOT/sketch" "$SMOKE_ROOT/artifacts"
+          mkdir -p "$SMOKE_ROOT/home" "$SMOKE_ROOT/sketch" "$SMOKE_ROOT/artifacts"
           uv venv "$SMOKE_ROOT/venv" --python "$UV_PYTHON"
           uv pip install --python "$SMOKE_ROOT/venv/bin/python" dist/*.whl
-          ln -s "$(command -v uv)" "$SMOKE_ROOT/bin/uv"
+          test -x "$SMOKE_ROOT/venv/bin/uv"
+          BASE_PYTHON_DIR="$("$SMOKE_ROOT/venv/bin/python" -c 'from pathlib import Path; import sys; print(Path(sys.executable).resolve().parent)')"
+          test ! -e "$BASE_PYTHON_DIR/uv"
 
           cat > "$SMOKE_ROOT/sketch/wheel_smoke.ino" <<'EOF'
           #include <FastLED.h>
@@ -158,13 +160,25 @@ jobs:
           }
           EOF
 
-          # Keep uv available for the managed FastLED environment but omit
-          # ambient node and bare python. The installed launcher supplies its
-          # own absolute Python and frontend paths to the Rust binary.
+          # The installed launcher must supply absolute wheel-venv uv, Python,
+          # and frontend paths to the Rust binary. Deliberately omit ambient
+          # uv, node, and bare python so this cannot accidentally pass by
+          # resolving a developer tool from the runner image.
           cd "$SMOKE_ROOT"
           env -i \
             HOME="$SMOKE_ROOT/home" \
-            PATH="$SMOKE_ROOT/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+            /bin/bash -ceu '
+              for tool in uv node python; do
+                if command -v "$tool" >/dev/null 2>&1; then
+                  echo "unexpected ambient $tool on restricted PATH" >&2
+                  exit 1
+                fi
+              done
+            '
+          env -i \
+            HOME="$SMOKE_ROOT/home" \
+            PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
             FASTLED_VIEWER_LOGS="$FASTLED_VIEWER_LOGS" \
             "$SMOKE_ROOT/venv/bin/fastled" "$SMOKE_ROOT/sketch" \
               --test \
@@ -174,7 +188,20 @@ jobs:
               --test-screenshot="$SMOKE_ROOT/artifacts/screenmap.png" \
               --test-log="$SMOKE_ROOT/artifacts/viewer.log" \
               --test-exit-on-error
-          test -s "$SMOKE_ROOT/artifacts/screenmap.png"
+          "$SMOKE_ROOT/venv/bin/python" - "$SMOKE_ROOT/artifacts/screenmap.png" <<'PY'
+          from pathlib import Path
+          import sys
+
+          image = Path(sys.argv[1]).read_bytes()
+          if image[:8] != b"\x89PNG\r\n\x1a\n":
+              raise SystemExit("viewer screenshot is not a PNG")
+          if image[12:16] != b"IHDR" or len(image) < 24:
+              raise SystemExit("viewer screenshot is missing its IHDR header")
+          width = int.from_bytes(image[16:20], "big")
+          height = int.from_bytes(image[20:24], "big")
+          if width <= 0 or height <= 0:
+              raise SystemExit(f"viewer screenshot has invalid dimensions: {width}x{height}")
+          PY
 
       - name: Upload installed wheel viewer screenshot
         if: always() && inputs.wheel-smoke

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -53,8 +53,8 @@ jobs:
           # expensive cargo installs below (#170).
           dylint-cache: true
           dylint-toolchain: nightly-2026-03-26
-          cargo-dylint-version: "6.0.1"
-          dylint-link-version: "6.0.1"
+          cargo-dylint-version: "6.0.3"
+          dylint-link-version: "6.0.3"
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -82,10 +82,10 @@ jobs:
       - name: Install Dylint tools
         run: |
           if ! command -v cargo-dylint >/dev/null 2>&1; then
-            soldr cargo install cargo-dylint --version 6.0.1 --locked --force
+            soldr cargo install cargo-dylint --version 6.0.3 --locked --force
           fi
           if ! command -v dylint-link >/dev/null 2>&1; then
-            soldr cargo install dylint-link --version 6.0.1 --locked --force
+            soldr cargo install dylint-link --version 6.0.3 --locked --force
           fi
 
       - name: Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.14"
+version = "2.0.15"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/fastled-cli/src/install.rs
+++ b/crates/fastled-cli/src/install.rs
@@ -577,6 +577,25 @@ fn absolute_executable(candidate: &Path) -> Option<PathBuf> {
         .filter(|path| path.is_file())
 }
 
+/// Return an existing absolute executable without resolving symlinks.
+///
+/// Virtual-environment Python launchers are commonly symlinks to a base
+/// interpreter. Callers that need a sibling tool must retain the launcher
+/// path so they remain in the selected virtual environment.
+fn preserved_absolute_executable(candidate: &Path) -> Option<PathBuf> {
+    (candidate.is_absolute() && candidate.is_file()).then(|| candidate.to_path_buf())
+}
+
+/// Build the path to the `uv` launcher next to a selected Python launcher.
+///
+/// This is deliberately a path-only helper: canonicalizing `python` first
+/// would turn a virtual-environment symlink into its base interpreter and
+/// cause us to look for `uv` outside the selected environment.
+fn sibling_uv_executable(python: &Path) -> Option<PathBuf> {
+    let uv = if cfg!(windows) { "uv.exe" } else { "uv" };
+    python.parent().map(|parent| parent.join(uv))
+}
+
 /// Resolve `program` from the process PATH without ever returning a bare
 /// program name.  Child tools must receive concrete paths so their behaviour
 /// does not change when they spawn another process with a narrower PATH.
@@ -601,8 +620,7 @@ fn resolve_managed_uv() -> Result<PathBuf> {
         }
     }
     if let Ok(python) = resolve_managed_python() {
-        if let Some(parent) = python.parent() {
-            let candidate = parent.join(if cfg!(windows) { "uv.exe" } else { "uv" });
+        if let Some(candidate) = sibling_uv_executable(&python) {
             if let Some(path) = absolute_executable(&candidate) {
                 return Ok(path);
             }
@@ -618,7 +636,7 @@ fn resolve_managed_uv() -> Result<PathBuf> {
 /// an absolute path, not a shell-dependent `python` token.
 pub(crate) fn resolve_managed_python() -> Result<PathBuf> {
     if let Some(path) = std::env::var_os("FASTLED_PYTHON_EXECUTABLE").map(PathBuf::from) {
-        if let Some(path) = absolute_executable(&path) {
+        if let Some(path) = preserved_absolute_executable(&path) {
             return Ok(path);
         }
     }
@@ -628,7 +646,7 @@ pub(crate) fn resolve_managed_python() -> Result<PathBuf> {
         } else {
             venv.join("bin").join("python")
         };
-        if let Some(path) = absolute_executable(&candidate) {
+        if let Some(path) = preserved_absolute_executable(&candidate) {
             return Ok(path);
         }
     }
@@ -2196,6 +2214,28 @@ mod tests {
             resolve_fastled_python(&temp.path().join("FastLED")).unwrap(),
             venv_python
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selected_virtualenv_python_keeps_sibling_uv_path() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let base_python = temp.path().join("base/bin/python");
+        fs::create_dir_all(base_python.parent().unwrap()).unwrap();
+        fs::write(&base_python, "python").unwrap();
+
+        let venv_bin = temp.path().join("venv/bin");
+        fs::create_dir_all(&venv_bin).unwrap();
+        let venv_python = venv_bin.join("python");
+        symlink(&base_python, &venv_python).unwrap();
+        let venv_uv = venv_bin.join("uv");
+        fs::write(&venv_uv, "uv").unwrap();
+
+        let selected = preserved_absolute_executable(&venv_python).unwrap();
+        assert_eq!(selected, venv_python);
+        assert_eq!(sibling_uv_executable(&selected), Some(venv_uv));
     }
 
     #[test]

--- a/dylints/ban_std_pathbuf/Cargo.lock
+++ b/dylints/ban_std_pathbuf/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "camino"
@@ -188,21 +188,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dylint"
-version = "6.0.1"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c738fb72ea7d248df2995a31b3698beb63d0f1f9ca5a5dc0188c4b64cd0e86e4"
+checksum = "da5d2f27acc9d395eabf8b7001ca856d72e49d4c1c5c3c427c60473fb6112a08"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -218,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.1"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9796d3441d7894cbaf4992640799efffc1661978f0cc1266ec788c32254fdfb3"
+checksum = "e56d36d5cf7a909a48854ea667b94421643ae0658868b37e4a842fb3d2c6d30e"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -238,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.1"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c213635b3eaa84f43b9b497377f17d9a8d4feb413bab1d82e03ad1c73e4f6d8c"
+checksum = "561e06d4cbeeaf506d1bce9e92dc737a83f143e8121d09db825b6d4b4bf55728"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -253,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.1"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5f50ee06be9ebfb5b9538ba0d7bb08adc33e8f31c901e7d398de2a9b1ae290"
+checksum = "616d3ae583c7daa06c035fcb4e9c3f1c84e14dc1f8bfc05aefcd57fe72a1902e"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -337,15 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,17 +372,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -442,113 +419,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -634,9 +508,7 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -647,20 +519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -680,12 +538,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -731,34 +583,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -785,15 +613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -849,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -861,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -872,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustfix"
@@ -976,18 +795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,17 +803,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1098,16 +894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,24 +968,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1482,12 +1250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,83 +1257,6 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/dylints/ban_std_pathbuf/Cargo.toml
+++ b/dylints/ban_std_pathbuf/Cargo.toml
@@ -11,10 +11,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "6.0.1"
+dylint_linting = "=6.0.3"
 
 [dev-dependencies]
-dylint_testing = "6.0.1"
+dylint_testing = "=6.0.3"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/lint
+++ b/lint
@@ -20,7 +20,7 @@ DYLINT_TARGET_DIR="${FASTLED_DYLINT_TARGET_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/
 DYLINT_LIBRARY_DIR="$DYLINT_TARGET_DIR/dylint/libraries/$DYLINT_TOOLCHAIN"
 
 if ! command -v cargo-dylint &> /dev/null; then
-  echo "Error: cargo-dylint is required. Install with: soldr cargo install cargo-dylint --version 6.0.1 --locked" >&2
+  echo "Error: cargo-dylint is required. Install with: soldr cargo install cargo-dylint --version 6.0.3 --locked" >&2
   exit 1
 fi
 

--- a/src/fastled/_rust_cli.py
+++ b/src/fastled/_rust_cli.py
@@ -80,7 +80,10 @@ def _packaged_frontend_dir() -> Path:
 
 def _managed_uv_executable() -> Path | None:
     """Locate uv beside the interpreter installed with the FastLED wheel."""
-    scripts = Path(sys.executable).resolve().parent
+    # A virtualenv's interpreter is commonly a symlink to its base Python.
+    # Keep its lexical scripts directory so wheel-provided sibling tools are
+    # located inside that virtualenv, while still returning an absolute path.
+    scripts = Path(sys.executable).absolute().parent
     candidate = scripts / ("uv.exe" if sys.platform == "win32" else "uv")
     return candidate if candidate.is_file() else None
 

--- a/tests/unit/test_python_api.py
+++ b/tests/unit/test_python_api.py
@@ -1,8 +1,11 @@
 import importlib.util
 import re
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 import fastled
 from fastled import _rust_cli
@@ -37,6 +40,27 @@ def test_python_version_matches_cargo_workspace_version() -> None:
 
 def test_native_extension_is_not_packaged() -> None:
     assert importlib.util.find_spec("fastled._native") is None
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows virtual environments use copied launchers rather than symlinks",
+)
+def test_managed_uv_preserves_virtualenv_scripts_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    base_python = tmp_path / "base-python"
+    base_python.touch()
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)
+    venv_python = scripts / "python"
+    venv_python.symlink_to(base_python)
+    venv_uv = scripts / "uv"
+    venv_uv.touch()
+
+    monkeypatch.setattr(sys, "executable", str(venv_python))
+
+    assert _rust_cli._managed_uv_executable() == venv_uv.absolute()
 
 
 def test_rust_launcher_exports_absolute_packaged_frontend_dir() -> None:


### PR DESCRIPTION
## Summary

- preserve virtual-environment Python paths in both the Python launcher and Rust resolver so the wheel-provided `uv` is found without ambient tooling
- add behavior-level Python and Rust regression tests for symlinked venv interpreters
- harden the macOS ARM installed-wheel smoke test by removing ambient `uv`, asserting the failure preconditions, and validating PNG signature/IHDR dimensions
- bump the release version to 2.0.15 and pin cargo-dylint/dylint-link plus Dylint crates to 6.0.3

## RED → GREEN

Against `origin/main`, the deterministic symlink reproduction failed with:

```text
expected=/tmp/.../venv/bin/uv
actual=None
AssertionError
```

The new focused Python and Rust regression tests pass after preserving the selected venv path.

## Validation

- `PATH=/Users/zacharyvorhies/.cargo/bin:$PATH bash lint` using cargo-dylint 6.0.3
- `bash test` — 235 Rust library, 3 binary, 1 doc; 19 Python passed, 1 platform skip
- built and installed the 2.0.15 wheel into a fresh Python 3.13 venv whose base interpreter has no sibling `uv`
- restricted PATH contained no `uv`, `node`, or bare `python`; installed-wheel cold bootstrap and WASM compile succeeded
- shipped viewer rendered a visually inspected 1280×1280 PNG (1,104,678 bytes); PNG signature and IHDR dimensions validated

Closes #220
Related: #218, #219
