### PR TITLE
fix(ci): enforce cargo-dylint 6.0.3

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -81,12 +81,14 @@ jobs:
       # without a PATH-visible binary must not make the lint job fail.
       - name: Install Dylint tools
         run: |
-          if ! command -v cargo-dylint >/dev/null 2>&1; then
-            soldr cargo install cargo-dylint --version 6.0.3 --locked --force
+          DYLINT_VERSION="6.0.3"
+          if ! uv run python ci/lint_python/dylint_version_checker.py cargo-dylint "$DYLINT_VERSION"; then
+            soldr cargo install cargo-dylint --version "$DYLINT_VERSION" --locked --force
           fi
           if ! command -v dylint-link >/dev/null 2>&1; then
-            soldr cargo install dylint-link --version 6.0.3 --locked --force
+            soldr cargo install dylint-link --version "$DYLINT_VERSION" --locked --force
           fi
+          uv run python ci/lint_python/dylint_version_checker.py cargo-dylint "$DYLINT_VERSION"
 
       - name: Lint
         run: ./lint

--- a/ci/lint_python/dylint_version_checker.py
+++ b/ci/lint_python/dylint_version_checker.py
@@ -1,0 +1,52 @@
+"""Require an exact cargo-dylint version before it is used."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def check_version(tool: str, expected_version: str) -> int:
+    """Return success only when ``tool`` reports the exact expected version."""
+
+    tool_name = Path(tool).name
+    expected = f"{tool_name} {expected_version}"
+    try:
+        result = subprocess.run(
+            [tool, "dylint", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        print(f"could not query {tool_name}: {error}", file=sys.stderr)
+        return 1
+
+    actual = result.stdout.strip()
+    if result.returncode != 0:
+        detail = result.stderr.strip() or actual or f"exit status {result.returncode}"
+        print(f"could not query {tool_name}: {detail}", file=sys.stderr)
+        return 1
+    if actual != expected:
+        print(
+            f"expected {expected}, found {actual or '<empty output>'}", file=sys.stderr
+        )
+        return 1
+
+    print(actual)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tool")
+    parser.add_argument("expected_version")
+    args = parser.parse_args()
+
+    return check_version(args.tool, args.expected_version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lint
+++ b/lint
@@ -14,13 +14,18 @@ soldr cargo fmt --all --check
 echo Running cargo clippy
 soldr cargo clippy --workspace --all-targets -- -D warnings
 echo Running ban_std_pathbuf dylint
+DYLINT_VERSION="6.0.3"
 DYLINT_TOOLCHAIN="nightly-2026-03-26"
 DYLINT_DIR="$SCRIPT_DIR/dylints/ban_std_pathbuf"
 DYLINT_TARGET_DIR="${FASTLED_DYLINT_TARGET_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fastled-dylint-target}"
 DYLINT_LIBRARY_DIR="$DYLINT_TARGET_DIR/dylint/libraries/$DYLINT_TOOLCHAIN"
 
 if ! command -v cargo-dylint &> /dev/null; then
-  echo "Error: cargo-dylint is required. Install with: soldr cargo install cargo-dylint --version 6.0.3 --locked" >&2
+  echo "Error: cargo-dylint $DYLINT_VERSION is required. Install with: soldr cargo install cargo-dylint --version $DYLINT_VERSION --locked" >&2
+  exit 1
+fi
+if ! uv run python "$SCRIPT_DIR/ci/lint_python/dylint_version_checker.py" cargo-dylint "$DYLINT_VERSION"; then
+  echo "Error: cargo-dylint $DYLINT_VERSION is required. Reinstall with: soldr cargo install cargo-dylint --version $DYLINT_VERSION --locked --force" >&2
   exit 1
 fi
 

--- a/tests/unit/test_dylint_version_check.py
+++ b/tests/unit/test_dylint_version_check.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from ci.lint_python import dylint_version_checker
+
+
+def _mock_version_command(
+    monkeypatch: pytest.MonkeyPatch, output: str, exit_code: int = 0
+) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            exit_code,
+            stdout=output,
+            stderr="broken" if exit_code else "",
+        )
+
+    monkeypatch.setattr(dylint_version_checker.subprocess, "run", run)
+    return calls
+
+
+def test_accepts_exact_cargo_dylint_version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls = _mock_version_command(monkeypatch, "cargo-dylint 6.0.3\n")
+
+    result = dylint_version_checker.check_version("cargo-dylint", "6.0.3")
+
+    assert result == 0
+    assert calls == [["cargo-dylint", "dylint", "--version"]]
+    assert capsys.readouterr().out.strip() == "cargo-dylint 6.0.3"
+
+
+def test_rejects_stale_cargo_dylint_version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _mock_version_command(monkeypatch, "cargo-dylint 6.0.2\n")
+
+    result = dylint_version_checker.check_version("cargo-dylint", "6.0.3")
+
+    assert result != 0
+    error = capsys.readouterr().err
+    assert "expected cargo-dylint 6.0.3" in error
+    assert "found cargo-dylint 6.0.2" in error
+
+
+def test_rejects_unusable_cargo_dylint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _mock_version_command(monkeypatch, "", exit_code=1)
+
+    result = dylint_version_checker.check_version("cargo-dylint", "6.0.3")
+
+    assert result != 0
+    assert "could not query" in capsys.readouterr().err
+
+
+def test_lint_entrypoints_enforce_the_exact_pin() -> None:
+    lint_script = (REPO_ROOT / "lint").read_text(encoding="utf-8")
+    lint_workflow = (REPO_ROOT / ".github" / "workflows" / "_lint.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'DYLINT_VERSION="6.0.3"' in lint_script
+    invocation = r'dylint_version_checker\.py"? cargo-dylint "\$DYLINT_VERSION"'
+    assert re.search(invocation, lint_script)
+    assert 'cargo-dylint-version: "6.0.3"' in lint_workflow
+    assert 'DYLINT_VERSION="6.0.3"' in lint_workflow
+    assert len(re.findall(invocation, lint_workflow)) >= 2


### PR DESCRIPTION
## Summary

- verify the PATH-visible cargo-dylint reports exactly 6.0.3 before local lint uses it
- replace stale cached cargo-dylint binaries in GHA and verify the installed replacement
- add cross-platform regression coverage for exact, stale, and unusable binaries plus both lint entrypoints

## RED

`uv run pytest -q tests/unit/test_dylint_version_check.py`

Failed because no exact-version checker existed. A second focused RED caught the required cargo-subcommand invocation form (`cargo-dylint dylint --version`).

## GREEN

- `uv run pytest -q tests/unit/test_dylint_version_check.py` (4 passed)
- `bash test` (239 Rust tests passed; 23 Python passed, 1 platform skip)
- `PATH="$HOME/.cargo/bin:$PATH" bash lint` (passed and printed `cargo-dylint 6.0.3` before running the dylint)
