### PR TITLE
fix(wasm): load remote assets into worker VFS

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -121,44 +121,48 @@ jobs:
       # rather than development fallbacks such as CARGO_MANIFEST_DIR.
       - name: Smoke test installed wheel in shipped viewer
         if: inputs.wheel-smoke
-        env:
-          FASTLED_VIEWER_LOGS: "1"
         run: |
           set -euo pipefail
           SMOKE_ROOT="$RUNNER_TEMP/fastled-wheel-smoke"
           rm -rf "$SMOKE_ROOT"
-          mkdir -p "$SMOKE_ROOT/home" "$SMOKE_ROOT/sketch" "$SMOKE_ROOT/artifacts"
+          mkdir -p "$SMOKE_ROOT/home" "$SMOKE_ROOT/sketch/data" "$SMOKE_ROOT/artifacts" "$SMOKE_ROOT/asset-origin"
           uv venv "$SMOKE_ROOT/venv" --python "$UV_PYTHON"
           uv pip install --python "$SMOKE_ROOT/venv/bin/python" dist/*.whl
           test -x "$SMOKE_ROOT/venv/bin/uv"
           BASE_PYTHON_DIR="$("$SMOKE_ROOT/venv/bin/python" -c 'from pathlib import Path; import sys; print(Path(sys.executable).resolve().parent)')"
           test ! -e "$BASE_PYTHON_DIR/uv"
-
-          cat > "$SMOKE_ROOT/sketch/wheel_smoke.ino" <<'EOF'
-          #include <FastLED.h>
-
-          #define LED_PIN 3
-          #define WIDTH 16
-          #define HEIGHT 16
-          #define NUM_LEDS (WIDTH * HEIGHT)
-
-          using namespace fl;
-
-          CRGB leds[NUM_LEDS];
-          XYMap screenMap = XYMap::constructRectangularGrid(WIDTH, HEIGHT);
-
-          void setup() {
-            FastLED.addLeds<WS2812B, LED_PIN, GRB>(leds, NUM_LEDS)
-                .setScreenMap(screenMap);
-          }
-
-          void loop() {
-            static uint8_t hue = 0;
-            fill_rainbow(leds, NUM_LEDS, hue++, 7);
-            FastLED.show();
-            delay(20);
-          }
+          cp -R "$GITHUB_WORKSPACE/tests/fixtures/wasm_vfs/." "$SMOKE_ROOT/sketch/"
+          cp "$GITHUB_WORKSPACE/tests/fixtures/wasm_vfs_origin/probe.txt" "$SMOKE_ROOT/asset-origin/probe.txt"
+          cat > "$SMOKE_ROOT/sketch/data/probe.txt.lnk" <<'EOF'
+          http://127.0.0.1:18765/probe.txt
+          sha256=2da77f7c1452125633beeeb43f366350018643c799306b4d24d8610d98f02b55
+          size_bytes=15
+          storage=vfs
           EOF
+          cat > "$SMOKE_ROOT/asset_server.py" <<'PY'
+          import http.server
+          import sys
+
+          class Handler(http.server.SimpleHTTPRequestHandler):
+              def end_headers(self):
+                  self.send_header("Access-Control-Allow-Origin", "*")
+                  self.send_header("Cross-Origin-Resource-Policy", "cross-origin")
+                  super().end_headers()
+
+              def log_message(self, *_args):
+                  pass
+
+          handler = lambda *args, **kwargs: Handler(*args, directory=sys.argv[1], **kwargs)
+          http.server.ThreadingHTTPServer(("127.0.0.1", 18765), handler).serve_forever()
+          PY
+          "$SMOKE_ROOT/venv/bin/python" "$SMOKE_ROOT/asset_server.py" "$SMOKE_ROOT/asset-origin" &
+          ASSET_SERVER_PID=$!
+          trap 'kill "$ASSET_SERVER_PID" 2>/dev/null || true' EXIT
+          for _attempt in {1..20}; do
+            if curl --fail --silent http://127.0.0.1:18765/probe.txt >/dev/null; then break; fi
+            sleep 0.25
+          done
+          curl --fail --silent http://127.0.0.1:18765/probe.txt >/dev/null
 
           # The installed launcher must supply absolute wheel-venv uv, Python,
           # and frontend paths to the Rust binary. Deliberately omit ambient
@@ -179,15 +183,15 @@ jobs:
           env -i \
             HOME="$SMOKE_ROOT/home" \
             PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-            FASTLED_VIEWER_LOGS="$FASTLED_VIEWER_LOGS" \
             "$SMOKE_ROOT/venv/bin/fastled" "$SMOKE_ROOT/sketch" \
-              --test \
+              --check \
               --test-wait-secs=2 \
               --test-timeout-secs=240 \
               --test-ready-timeout-secs=45 \
               --test-screenshot="$SMOKE_ROOT/artifacts/screenmap.png" \
-              --test-log="$SMOKE_ROOT/artifacts/viewer.log" \
-              --test-exit-on-error
+              --test-log="$SMOKE_ROOT/artifacts/viewer.log"
+          grep -F "Asset 'data/probe.txt' sha256 verified" "$SMOKE_ROOT/artifacts/viewer.log"
+          grep -F "All 1 filesystem asset(s) loaded completely before setup()." "$SMOKE_ROOT/artifacts/viewer.log"
           "$SMOKE_ROOT/venv/bin/python" - "$SMOKE_ROOT/artifacts/screenmap.png" <<'PY'
           from pathlib import Path
           import sys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "fastled-cli"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.16"
+version = "2.0.17"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/fastled-cli/src/cli.rs
+++ b/crates/fastled-cli/src/cli.rs
@@ -89,6 +89,7 @@ pub(crate) enum LinkMode {
     version,
     about = "FastLED WASM compilation CLI",
     long_about = None,
+    group(clap::ArgGroup::new("production_test").args(["test", "check"]).multiple(false)),
     // Stop Rust clap from eating flags it doesn't recognise; we want to be
     // a strict mirror, so every flag is declared explicitly.
 )]
@@ -145,11 +146,15 @@ pub(crate) struct Cli {
     #[arg(long, conflicts_with_all = ["just_compile", "no_app"], help_heading = "Production testing")]
     pub(crate) test: bool,
 
+    /// Compile and render one frame, failing on browser-side errors.
+    #[arg(long, conflicts_with_all = ["just_compile", "no_app"], help_heading = "Production testing")]
+    pub(crate) check: bool,
+
     /// Seconds to wait after the sketch is ready before the first capture.
     #[arg(
         long,
         default_value_t = 1.0,
-        requires = "test",
+        requires = "production_test",
         help_heading = "Production testing"
     )]
     pub(crate) test_wait_secs: f64,
@@ -158,20 +163,24 @@ pub(crate) struct Cli {
     #[arg(
         long,
         value_name = "PATH",
-        requires = "test",
+        requires = "production_test",
         verbatim_doc_comment,
         help_heading = "Production testing"
     )]
     pub(crate) test_screenshot: Option<PathBuf>,
 
     /// Target interval between scheduled capture starts; slow captures may delay later frames.
-    #[arg(long, requires = "test", help_heading = "Production testing")]
+    #[arg(
+        long,
+        requires = "production_test",
+        help_heading = "Production testing"
+    )]
     pub(crate) test_interval_secs: Option<f64>,
 
     /// Number of screenshots to take in interval mode.
     #[arg(
         long,
-        requires = "test",
+        requires = "production_test",
         conflicts_with = "test_duration_secs",
         help_heading = "Production testing"
     )]
@@ -180,7 +189,7 @@ pub(crate) struct Cli {
     /// Total capture window in seconds for interval mode.
     #[arg(
         long,
-        requires = "test",
+        requires = "production_test",
         conflicts_with = "test_count",
         help_heading = "Production testing"
     )]
@@ -190,20 +199,24 @@ pub(crate) struct Cli {
     #[arg(
         long,
         value_name = "PATH",
-        requires = "test",
+        requires = "production_test",
         help_heading = "Production testing"
     )]
     pub(crate) test_log: Option<PathBuf>,
 
     /// Exit with code 2 when the viewer reports a page-side error.
-    #[arg(long, requires = "test", help_heading = "Production testing")]
+    #[arg(
+        long,
+        requires = "production_test",
+        help_heading = "Production testing"
+    )]
     pub(crate) test_exit_on_error: bool,
 
     /// Hard upper bound in seconds for compile, ready wait, and capture.
     #[arg(
         long,
         default_value_t = 120.0,
-        requires = "test",
+        requires = "production_test",
         help_heading = "Production testing"
     )]
     pub(crate) test_timeout_secs: f64,
@@ -212,7 +225,7 @@ pub(crate) struct Cli {
     #[arg(
         long,
         default_value_t = 15.0,
-        requires = "test",
+        requires = "production_test",
         help_heading = "Production testing"
     )]
     pub(crate) test_ready_timeout_secs: f64,
@@ -220,7 +233,7 @@ pub(crate) struct Cli {
     /// Run a trusted host command after the first rendered frame. May be repeated.
     #[arg(
         long,
-        requires = "test",
+        requires = "production_test",
         value_name = "COMMAND",
         help_heading = "Production testing"
     )]
@@ -302,6 +315,10 @@ pub(crate) fn validate_init_ref_flags(cli: &Cli) -> Result<(), &'static str> {
 }
 
 pub(crate) fn apply_test_implications(cli: &mut Cli) {
+    if cli.check {
+        cli.test = true;
+        cli.test_exit_on_error = true;
+    }
     if cli.test {
         cli.no_interactive = true;
     }
@@ -450,6 +467,19 @@ mod tests {
         assert!(!cli.no_interactive);
         apply_test_implications(&mut cli);
         assert!(cli.no_interactive);
+    }
+
+    #[test]
+    fn check_is_a_strict_one_frame_test() {
+        let mut cli = Cli::parse_from(["fastled", "sketch", "--check", "--test-timeout-secs=30"]);
+        assert!(!cli.test);
+        assert!(!cli.test_exit_on_error);
+        apply_test_implications(&mut cli);
+        assert!(cli.test);
+        assert!(cli.test_exit_on_error);
+        assert!(cli.no_interactive);
+        assert!(cli.test_screenshot.is_none());
+        assert_eq!(cli.test_timeout_secs, 30.0);
     }
 
     #[test]

--- a/crates/fastled-cli/src/lib.rs
+++ b/crates/fastled-cli/src/lib.rs
@@ -253,6 +253,7 @@ mod tests {
             no_interactive: false,
             no_https: false,
             test: false,
+            check: false,
             test_wait_secs: 1.0,
             test_screenshot: None,
             test_interval_secs: None,

--- a/crates/fastled-cli/src/server.rs
+++ b/crates/fastled-cli/src/server.rs
@@ -469,8 +469,8 @@ async fn build_stream(State(state): State<AppState>) -> Response {
 }
 
 /// `POST /viewer-log` — receive console/error lines forwarded from the Tauri
-/// viewer's injected logging script (enabled via `FASTLED_VIEWER_LOGS`) and
-/// echo them to stderr so viewer-side failures are diagnosable.
+/// viewer's injected logging script and echo them to stderr so viewer-side
+/// failures are always diagnosable.
 fn test_request_authorized(test: &TestServerOptions, headers: &HeaderMap) -> bool {
     headers
         .get(header::AUTHORIZATION)

--- a/crates/fastled-cli/src/tauri_viewer.rs
+++ b/crates/fastled-cli/src/tauri_viewer.rs
@@ -19,9 +19,8 @@ const TEST_CAPABILITY_SCRIPT: &str = r#"
 })();
 "#;
 
-/// Injected when `FASTLED_VIEWER_LOGS` is enabled: forwards `console.*`,
-/// uncaught errors, unhandled rejections, and failed fetches to the FastLED
-/// HTTP server's `POST /viewer-log` endpoint, which echoes them to stderr.
+/// Forwards `console.*`, uncaught errors, unhandled rejections, and failed
+/// fetches to the FastLED HTTP server, which echoes them to stderr.
 const LOG_FORWARD_SCRIPT: &str = r#"
 (() => {
   const pending = window.__fastled_test_pending_logs = new Set();
@@ -317,15 +316,6 @@ const TEST_RUNTIME_SCRIPT: &str = r#"
 })();
 "#;
 
-fn env_flag_enabled(value: Option<&str>) -> bool {
-    matches!(value, Some(v) if !v.is_empty() && v != "0")
-}
-
-fn viewer_logs_enabled() -> bool {
-    let value = std::env::var("FASTLED_VIEWER_LOGS").ok();
-    env_flag_enabled(value.as_deref())
-}
-
 pub fn run(options: ViewerOptions) -> ExitCode {
     let ViewerOptions {
         url,
@@ -345,9 +335,7 @@ pub fn run(options: ViewerOptions) -> ExitCode {
             if inject_test_runtime {
                 builder = builder.initialization_script(TEST_CAPABILITY_SCRIPT);
             }
-            if viewer_logs_enabled() || inject_test_runtime {
-                builder = builder.initialization_script(LOG_FORWARD_SCRIPT);
-            }
+            builder = builder.initialization_script(LOG_FORWARD_SCRIPT);
             if inject_test_runtime {
                 builder = builder.initialization_script(TEST_RUNTIME_SCRIPT);
             }
@@ -379,15 +367,6 @@ pub fn run(options: ViewerOptions) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn viewer_logs_flag_parsing() {
-        assert!(!env_flag_enabled(None));
-        assert!(!env_flag_enabled(Some("")));
-        assert!(!env_flag_enabled(Some("0")));
-        assert!(env_flag_enabled(Some("1")));
-        assert!(env_flag_enabled(Some("true")));
-    }
 
     #[test]
     fn log_forward_script_targets_server_endpoint() {

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -1935,6 +1935,24 @@ fn copy_dynamic_output(
 fn generate_manifest(example_dir: &Path, output_dir: &Path) -> Result<()> {
     let mut files = Vec::<serde_json::Value>::new();
     collect_data_files(example_dir, example_dir, &mut files)?;
+    for file in &files {
+        let relative = file
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("generated asset manifest entry has no path"))?;
+        let source = example_dir.join(relative);
+        let target = output_dir.join(relative);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&source, &target).with_context(|| {
+            format!(
+                "copy sketch asset {} to {}",
+                source.display(),
+                target.display()
+            )
+        })?;
+    }
     let legacy = output_dir.join("files.json");
     if legacy.is_file() {
         fs::remove_file(&legacy)
@@ -2180,7 +2198,8 @@ fn collect_data_files(root: &Path, dir: &Path, out: &mut Vec<serde_json::Value>)
                 continue;
             }
             collect_data_files(root, &path, out)?;
-        } else if path != root.join("data").join("assets.json")
+        } else if path != root.join("fastled.json")
+            && path != root.join("data").join("assets.json")
             && matches!(
                 path.extension()
                     .and_then(|ext| ext.to_str())
@@ -3093,6 +3112,7 @@ link_flags = []
         fs::create_dir_all(example.join("data")).unwrap();
         fs::create_dir_all(&output).unwrap();
         fs::write(example.join("data").join("config.json"), "{}").unwrap();
+        fs::write(example.join("fastled.json"), r#"{"ref":"master"}"#).unwrap();
         fs::write(output.join("files.json"), "legacy").unwrap();
 
         generate_manifest(&example, &output).unwrap();
@@ -3100,6 +3120,12 @@ link_flags = []
         assert!(!output.join("files.json").exists());
         let manifest = fs::read_to_string(output.join("sketch_assets.json")).unwrap();
         assert!(manifest.contains("config.json"));
+        assert!(!manifest.contains("fastled.json"));
+        assert_eq!(
+            fs::read_to_string(output.join("data/config.json")).unwrap(),
+            "{}"
+        );
+        assert!(!output.join("fastled.json").exists());
     }
 
     #[test]

--- a/crates/fastled-cli/src/wasm_build.rs
+++ b/crates/fastled-cli/src/wasm_build.rs
@@ -1944,7 +1944,226 @@ fn generate_manifest(example_dir: &Path, output_dir: &Path) -> Result<()> {
         output_dir.join("sketch_assets.json"),
         serde_json::to_string_pretty(&files)?,
     )?;
+    let remote_assets = scan_remote_assets(example_dir)?;
+    fs::write(
+        output_dir.join("asset_manifest.json"),
+        format!("{}\n", serde_json::to_string_pretty(&remote_assets)?),
+    )?;
     Ok(())
+}
+
+fn remote_asset_record(
+    url: String,
+    fallback: Option<String>,
+    sha256: Option<String>,
+    size: Option<u64>,
+    storage: Option<String>,
+) -> serde_json::Value {
+    let mut record = serde_json::Map::new();
+    record.insert("url".into(), url.into());
+    record.insert(
+        "sha256".into(),
+        sha256.map_or(serde_json::Value::Null, serde_json::Value::String),
+    );
+    record.insert(
+        "fallback".into(),
+        fallback.map_or(serde_json::Value::Null, serde_json::Value::String),
+    );
+    if let Some(size) = size {
+        record.insert("size".into(), size.into());
+    }
+    if let Some(storage) = storage {
+        record.insert("storage".into(), storage.into());
+    }
+    record.into()
+}
+
+fn normalized_storage(value: Option<&serde_json::Value>) -> Option<String> {
+    let direct = value.and_then(serde_json::Value::as_str);
+    direct
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+}
+
+fn storage_from_spec(
+    spec: &serde_json::Map<String, serde_json::Value>,
+    default: Option<&str>,
+) -> Option<String> {
+    normalized_storage(spec.get("storage")).or_else(|| {
+        spec.get("dest")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|dest| normalized_storage(dest.get("target")))
+            .or_else(|| default.map(ToOwned::to_owned))
+    })
+}
+
+fn urls_from_spec(spec: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+    let value = spec.get("urls").or_else(|| spec.get("url"));
+    match value {
+        Some(serde_json::Value::Array(values)) => values
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+        Some(serde_json::Value::String(value)) if !value.trim().is_empty() => {
+            vec![value.trim().to_owned()]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn parse_json_asset(
+    spec: &serde_json::Map<String, serde_json::Value>,
+    default_storage: Option<&str>,
+) -> Option<serde_json::Value> {
+    let urls = urls_from_spec(spec);
+    let url = urls.first()?.clone();
+    let fallback = urls
+        .get(1)
+        .cloned()
+        .or_else(|| spec.get("fallback")?.as_str().map(ToOwned::to_owned));
+    let sha256 = spec
+        .get("sha256")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    let size = spec
+        .get("size_bytes")
+        .or_else(|| spec.get("size"))
+        .and_then(serde_json::Value::as_u64);
+    Some(remote_asset_record(
+        url,
+        fallback,
+        sha256,
+        size,
+        storage_from_spec(spec, default_storage),
+    ))
+}
+
+fn parse_lnk(content: &str) -> Option<serde_json::Value> {
+    let first = content
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))?;
+    if first.starts_with('{') {
+        let value: serde_json::Value = serde_json::from_str(content).ok()?;
+        return parse_json_asset(value.as_object()?, None);
+    }
+
+    let mut urls = Vec::new();
+    let mut sha256 = None;
+    let mut fallback = None;
+    let mut size = None;
+    let mut storage = None;
+    for line in content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+    {
+        if let Some((key, value)) = line.split_once('=') {
+            let value = value.trim();
+            match key.trim() {
+                "url" if !value.is_empty() => urls.push(value.to_owned()),
+                "fallback" if !value.is_empty() => fallback = Some(value.to_owned()),
+                "sha256" if !value.is_empty() => sha256 = Some(value.to_owned()),
+                "size" | "size_bytes" => size = value.parse().ok(),
+                "storage" if !value.is_empty() => storage = Some(value.to_ascii_lowercase()),
+                _ => {}
+            }
+        } else if urls.is_empty() {
+            urls.push(line.to_owned());
+        }
+    }
+    let url = urls.first()?.clone();
+    let fallback = fallback.or_else(|| urls.get(1).cloned());
+    Some(remote_asset_record(url, fallback, sha256, size, storage))
+}
+
+fn safe_manifest_name(name: &str) -> Option<String> {
+    let normalized = name.replace('\\', "/");
+    let path = Path::new(&normalized);
+    if normalized.is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|part| !matches!(part, std::path::Component::Normal(_)))
+    {
+        return None;
+    }
+    Some(normalized)
+}
+
+fn scan_remote_assets(example_dir: &Path) -> Result<BTreeMap<String, serde_json::Value>> {
+    let data_dir = example_dir.join("data");
+    let mut manifest = BTreeMap::new();
+    if !data_dir.is_dir() {
+        return Ok(manifest);
+    }
+
+    let assets_json = data_dir.join("assets.json");
+    if assets_json.is_file() {
+        let value: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(&assets_json)
+                .with_context(|| format!("read {}", assets_json.display()))?,
+        )
+        .with_context(|| format!("parse {}", assets_json.display()))?;
+        let root = value.as_object().ok_or_else(|| {
+            anyhow::anyhow!("{} must contain a JSON object", assets_json.display())
+        })?;
+        let default_storage = root
+            .get("defaults")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|defaults| storage_from_spec(defaults, None));
+        if let Some(assets) = root.get("assets").and_then(serde_json::Value::as_object) {
+            for (name, spec) in assets {
+                let Some(name) = safe_manifest_name(name) else {
+                    eprintln!(
+                        "fastled: ignoring unsafe asset path in {}: {name}",
+                        assets_json.display()
+                    );
+                    continue;
+                };
+                let Some(record) = spec
+                    .as_object()
+                    .and_then(|spec| parse_json_asset(spec, default_storage.as_deref()))
+                else {
+                    eprintln!(
+                        "fastled: ignoring asset without a URL in {}: {name}",
+                        assets_json.display()
+                    );
+                    continue;
+                };
+                manifest.insert(format!("data/{name}"), record);
+            }
+        }
+    }
+
+    let mut pending = vec![data_dir];
+    while let Some(dir) = pending.pop() {
+        for entry in fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
+            let path = entry?.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension() == Some(OsStr::new("lnk")) {
+                let content = fs::read_to_string(&path)
+                    .with_context(|| format!("read {}", path.display()))?;
+                let Some(record) = parse_lnk(&content) else {
+                    eprintln!(
+                        "fastled: ignoring asset link without a URL: {}",
+                        path.display()
+                    );
+                    continue;
+                };
+                let relative = path.strip_prefix(example_dir).unwrap_or(&path);
+                let mut name = relative.to_string_lossy().replace('\\', "/");
+                name.truncate(name.len() - ".lnk".len());
+                manifest.insert(name, record);
+            }
+        }
+    }
+    Ok(manifest)
 }
 
 fn collect_data_files(root: &Path, dir: &Path, out: &mut Vec<serde_json::Value>) -> Result<()> {
@@ -1961,13 +2180,15 @@ fn collect_data_files(root: &Path, dir: &Path, out: &mut Vec<serde_json::Value>)
                 continue;
             }
             collect_data_files(root, &path, out)?;
-        } else if matches!(
-            path.extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| ext.to_ascii_lowercase())
-                .as_deref(),
-            Some("json" | "csv" | "txt" | "cfg" | "bin" | "dat" | "mp3" | "wav")
-        ) {
+        } else if path != root.join("data").join("assets.json")
+            && matches!(
+                path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext.to_ascii_lowercase())
+                    .as_deref(),
+                Some("json" | "csv" | "txt" | "cfg" | "bin" | "dat" | "mp3" | "wav")
+            )
+        {
             let rel = path.strip_prefix(root).unwrap_or(&path).to_string_lossy();
             out.push(serde_json::json!({
                 "path": rel.replace('\\', "/"),
@@ -2879,6 +3100,87 @@ link_flags = []
         assert!(!output.join("files.json").exists());
         let manifest = fs::read_to_string(output.join("sketch_assets.json")).unwrap();
         assert!(manifest.contains("config.json"));
+    }
+
+    #[test]
+    fn generate_manifest_resolves_lnk_and_assets_json_for_the_wasm_vfs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let example = tmp.path().join("Sketch");
+        let data = example.join("data");
+        let output = example.join("fastled_js");
+        fs::create_dir_all(&data).unwrap();
+        fs::create_dir_all(&output).unwrap();
+        fs::write(
+            data.join("track.mp3.lnk"),
+            "https://cdn.example/track.mp3\nsha256=abc123\nfallback=https://mirror.example/track.mp3\nstorage=littlefs\nunknown=ignored\n",
+        )
+        .unwrap();
+        fs::write(
+            data.join("assets.json"),
+            r#"{
+              "defaults": {"storage": "vfs"},
+              "assets": {
+                "video.rgb": {
+                  "urls": ["https://cdn.example/video.rgb", "https://mirror.example/video.rgb"],
+                  "sha256": "def456",
+                  "size_bytes": 42
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        generate_manifest(&example, &output).unwrap();
+
+        let manifest: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(output.join("asset_manifest.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            manifest["data/track.mp3"]["url"],
+            "https://cdn.example/track.mp3"
+        );
+        assert_eq!(manifest["data/track.mp3"]["sha256"], "abc123");
+        assert_eq!(
+            manifest["data/track.mp3"]["fallback"],
+            "https://mirror.example/track.mp3"
+        );
+        assert_eq!(manifest["data/track.mp3"]["storage"], "littlefs");
+        assert_eq!(
+            manifest["data/video.rgb"]["url"],
+            "https://cdn.example/video.rgb"
+        );
+        assert_eq!(
+            manifest["data/video.rgb"]["fallback"],
+            "https://mirror.example/video.rgb"
+        );
+        assert_eq!(manifest["data/video.rgb"]["size"], 42);
+        assert_eq!(manifest["data/video.rgb"]["storage"], "vfs");
+
+        let local: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(output.join("sketch_assets.json")).unwrap())
+                .unwrap();
+        assert_eq!(local, serde_json::json!([]));
+    }
+
+    #[test]
+    fn lnk_parser_accepts_keyed_urls_and_json_descriptors() {
+        let keyed = parse_lnk(
+            "url=https://cdn.example/a.bin\nurl=https://mirror.example/a.bin\nsize_bytes=7\n",
+        )
+        .unwrap();
+        assert_eq!(keyed["url"], "https://cdn.example/a.bin");
+        assert_eq!(keyed["fallback"], "https://mirror.example/a.bin");
+        assert_eq!(keyed["size"], 7);
+
+        let json = parse_lnk(
+            r#"{"v":1,"url":["https://cdn.example/b.bin","https://mirror.example/b.bin"],"sha256":"abc","size":9,"storage":"VFS"}"#,
+        )
+        .unwrap();
+        assert_eq!(json["url"], "https://cdn.example/b.bin");
+        assert_eq!(json["fallback"], "https://mirror.example/b.bin");
+        assert_eq!(json["sha256"], "abc");
+        assert_eq!(json["size"], 9);
+        assert_eq!(json["storage"], "vfs");
     }
 
     #[test]

--- a/src/fastled/frontend/fastled_init.ts
+++ b/src/fastled/frontend/fastled_init.ts
@@ -21,13 +21,80 @@ import {
 } from './modules/core/fastled_debug_logger.ts';
 
 import { state, DEFAULT_FRAME_RATE_60FPS } from './state.ts';
-import {
-  jsAppendFileUint8,
-  partition,
-  getFileManifestJson,
-} from './vfs_bridge.ts';
+import { fastLEDWorkerManager } from './modules/core/fastled_worker_manager.ts';
 import { customPrintFunction } from './logging_setup.ts';
 import { toggleFastLED } from './debug_api.ts';
+
+const ASSET_FETCH_TIMEOUT_MS = 30000;
+
+async function sha256Hex(bytes) {
+  if (!globalThis.crypto || !globalThis.crypto.subtle) return '';
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function fetchAssetBytes(path, spec) {
+  const urls = [spec.url, spec.fallback].filter(Boolean);
+  for (const url of urls) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(ASSET_FETCH_TIMEOUT_MS) });
+      if (!response.ok) {
+        console.warn(`Asset '${path}': ${response.status} from ${url}`);
+        continue;
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (url !== spec.url) {
+        console.log(`Asset '${path}': primary failed, served from fallback ${url}`);
+      }
+      return bytes;
+    } catch (error) {
+      const reason = error && error.name === 'TimeoutError'
+        ? `timed out after ${ASSET_FETCH_TIMEOUT_MS}ms`
+        : String(error);
+      console.warn(`Asset '${path}' from ${url}: ${reason}`);
+    }
+  }
+  return null;
+}
+
+export async function resolveManifestAssets(manifest) {
+  const entries = Object.entries(manifest || {});
+  const resolved = await Promise.all(entries.map(async ([path, spec]) => {
+    if (!spec || !spec.url) {
+      console.error(`Asset '${path}' has no url; skipping`);
+      return null;
+    }
+    const bytes = await fetchAssetBytes(path, spec);
+    if (!bytes) {
+      console.error(`Asset '${path}' could not be fetched; the sketch will see no such file`);
+      return null;
+    }
+    if (spec.sha256) {
+      const actual = await sha256Hex(bytes);
+      if (actual && actual !== String(spec.sha256).toLowerCase()) {
+        console.error(
+          `Asset '${path}' failed integrity check: declared ${spec.sha256}, got ${actual}. Dropping it.`,
+        );
+        return null;
+      }
+      if (actual) console.log(`Asset '${path}' sha256 verified`);
+      else console.warn(`Asset '${path}': no SubtleCrypto, sha256 not verified`);
+    } else {
+      console.warn(`Asset '${path}' declares no sha256; contents are unverified`);
+    }
+    if (spec.size !== undefined && spec.size !== null && Number(spec.size) !== bytes.length) {
+      console.error(
+        `Asset '${path}' is incomplete: declared size ${spec.size} but received ${bytes.length} bytes. Dropping it.`,
+      );
+      return null;
+    }
+    console.log(`Asset '${path}' -> ${spec.url} (${bytes.length} bytes)`);
+    return { path, size: bytes.length, bytes, embedded: true };
+  }));
+  return resolved.filter(Boolean);
+}
 
 /**
  * Main setup and loop execution function for FastLED programs (Pure JavaScript Architecture)
@@ -36,7 +103,7 @@ import { toggleFastLED } from './debug_api.ts';
  * @param {number} frame_rate - Target frame rate for the animation loop
  * @returns {Promise<void>} Promise that resolves when setup is complete and loop is started
  */
-export async function FastLED_SetupAndLoop(moduleInstance, frame_rate) {
+export async function FastLED_SetupAndLoop(moduleInstance, frame_rate, beforeStart) {
   FASTLED_DEBUG_TRACE('INDEX_JS', 'FastLED_SetupAndLoop', 'ENTER', { frame_rate });
 
   try {
@@ -93,6 +160,12 @@ export async function FastLED_SetupAndLoop(moduleInstance, frame_rate) {
       maxRetries: 3
     });
     FASTLED_DEBUG_LOG('INDEX_JS', 'Web Worker mode initialized successfully');
+
+    // PROXY_TO_PTHREAD starts the C++ runtime asynchronously. Injecting files
+    // before worker initialization races its static constructors, which can
+    // reset the VFS registry after JavaScript populated it. Mount only after
+    // the worker reports ready, but still before the first extern_setup().
+    if (beforeStart) await beforeStart();
 
     // Start the async animation loop in worker mode
     await state.fastLEDController.startWithWorkerSupport();
@@ -221,97 +294,28 @@ export async function fastledLoadSetupLoop(
 ) {
   console.log('Calling setup function...');
 
-  const fileManifest = getFileManifestJson(filesJson, frame_rate);
-  moduleInstance.cwrap('fastled_declare_files', null, ['string'])(JSON.stringify(fileManifest));
-  console.log('Files JSON:', filesJson);
-
-  /**
-   * Processes a single file by streaming it to the WASM module
-   * @async
-   * @param {Object} file - File object with path and data
-   * @param {string} file.path - File path in the virtual filesystem
-   * @param {number} file.size - File size in bytes
-   */
-  const processFile = async (file) => {
-    try {
-      const response = await fetch(file.path);
-      const reader = response.body.getReader();
-
-      console.log(`File fetched: ${file.path}, size: ${file.size}`);
-
-      while (true) {
-        // deno-lint-ignore no-await-in-loop
-        const { value, done } = await reader.read();
-        if (done) break;
-        // Allocate and copy chunk data
-        jsAppendFileUint8(moduleInstance, file.path, value);
-      }
-    } catch (error) {
-      console.error(`Error processing file ${file.path}:`, error);
-    }
-  };
-
-  /**
-   * Fetches all files in parallel and calls completion callback
-   * @async
-   * @param {Array<Object>} filesJson - Array of file objects to fetch
-   * @param {Function} [onComplete] - Optional callback when all files are loaded
-   */
-  const fetchAllFiles = async (filesJson, onComplete) => {
-    const promises = filesJson.map(async (file) => {
-      await processFile(file);
-    });
-    await Promise.all(promises);
-    if (onComplete) {
-      onComplete();
-    }
-  };
-
-  // NOTE: Callback functions are now automatically registered by importing fastled_callbacks.js
-  // No need to manually bind them here - they're pure JavaScript functions
-
-  // Verify that the pure JavaScript callbacks are properly loaded
-  console.log('FastLED Pure JavaScript callbacks verified:', {
-    FastLED_onUiElementsAdded: typeof globalThis.FastLED_onUiElementsAdded,
-    FastLED_onFrame: typeof globalThis.FastLED_onFrame,
-    FastLED_onStripAdded: typeof globalThis.FastLED_onStripAdded,
-    FastLED_onStripUpdate: typeof globalThis.FastLED_onStripUpdate,
-    FastLED_processUiUpdates: typeof globalThis.FastLED_processUiUpdates,
-    FastLED_onError: typeof globalThis.FastLED_onError,
-  });
-
-  // Initialize event system integration
-  if (fastLEDEvents) {
-    console.log('FastLED Event System ready with stats:', fastLEDEvents.getEventStats());
+  const manifestFiles = await resolveManifestAssets(window.fastledAssetManifest);
+  if (manifestFiles.length > 0) {
+    console.log(`Injecting ${manifestFiles.length} manifest asset(s) into the filesystem`);
+    filesJson = (filesJson || []).concat(manifestFiles);
   }
 
-  // Come back to this later - we want to partition the files into immediate and streaming files
-  // so that large projects don't try to download ALL the large files BEFORE setup/loop is called.
-  const [immediateFiles, streamingFiles] = partition(filesJson, ['.json', '.csv', '.txt', '.cfg']);
-  console.log(
-    'The following files will be immediatly available and can be read during setup():',
-    immediateFiles,
-  );
-  console.log('The following files will be streamed in during loop():', streamingFiles);
-
-  const promiseImmediateFiles = fetchAllFiles(immediateFiles, () => {
-    if (immediateFiles.length !== 0) {
-      console.log('All immediate files downloaded to FastLED.');
-    }
-  });
-  await promiseImmediateFiles;
-  if (streamingFiles.length > 0) {
-    const streamingFilesPromise = fetchAllFiles(streamingFiles, () => {
-      console.log('All streaming files downloaded to FastLED.');
+  const loadFiles = async () => {
+    const response = await fastLEDWorkerManager.sendMessageWithResponse({
+      type: 'load_files',
+      payload: {
+        frameRate: frame_rate,
+        files: filesJson || [],
+      },
     });
-    const delay = new Promise((r) => { setTimeout(r, 250); });
-    // Wait for either the time delay or the streaming files to be processed, whichever
-    // happens first.
-    await Promise.any([delay, streamingFilesPromise]);
-  }
+    if (!response || response.success !== true) {
+      throw new Error(response && response.error ? response.error : 'worker failed to load files');
+    }
+    console.log(`All ${response.count} filesystem asset(s) loaded completely before setup().`);
+  };
 
   console.log('Starting fastled with Asyncify support');
-  await FastLED_SetupAndLoop(moduleInstance, frame_rate);
+  await FastLED_SetupAndLoop(moduleInstance, frame_rate, loadFiles);
 }
 
 /**
@@ -359,6 +363,7 @@ export function onModuleLoaded(fastLedLoader) {
   // New builds call this manifest sketch_assets.json. Keep files.json as a
   // fallback so previously generated sketches remain runnable.
   const filesJsonPromise = fetchJson('sketch_assets.json').catch(() => fetchJson('files.json'));
+  const assetManifestPromise = fetchJson('asset_manifest.json').catch(() => ({}));
   try {
     if (typeof fastLedLoader === 'function') {
       // Load the module
@@ -379,8 +384,14 @@ export function onModuleLoaded(fastLedLoader) {
         // Wait for the sketch asset manifest to load.
         let filesJson = null;
         try {
-          filesJson = await filesJsonPromise;
+          [filesJson, window.fastledAssetManifest] = await Promise.all([
+            filesJsonPromise,
+            assetManifestPromise,
+          ]);
           console.log('Files JSON:', filesJson);
+          console.log(
+            `Loaded fastledAssetManifest with ${Object.keys(window.fastledAssetManifest).length} entries`,
+          );
         } catch (error) {
           console.error('Error fetching sketch asset manifest:', error);
           filesJson = {};

--- a/src/fastled/frontend/modules/core/fastled_background_worker.ts
+++ b/src/fastled/frontend/modules/core/fastled_background_worker.ts
@@ -214,6 +214,10 @@ self.onmessage = async function(event) {
         response = await handleStart(payload);
         break;
 
+      case 'load_files':
+        response = await handleLoadFiles(payload);
+        break;
+
       case 'stop':
         response = await handleStop(payload);
         break;
@@ -478,6 +482,54 @@ async function initializeFastLEDModule() {
     workerLog('ERROR', 'BACKGROUND_WORKER', 'Failed to load FastLED WASM module', error);
     throw error;
   }
+}
+
+async function handleLoadFiles(payload) {
+  if (!workerState.initialized || !workerState.fastledModule) {
+    throw new Error('Worker WASM module is not initialized');
+  }
+  const Module = workerState.fastledModule;
+  const files = Array.isArray(payload && payload.files) ? payload.files : [];
+  const manifest = {
+    files: files.map((file) => ({ path: file.path, size: file.size })),
+    frameRate: payload && payload.frameRate,
+  };
+  Module.cwrap('fastled_declare_files', null, ['string'])(JSON.stringify(manifest));
+
+  for (const file of files) {
+    let bytes;
+    if (file.bytes) {
+      bytes = new Uint8Array(file.bytes);
+    } else {
+      const response = await fetch(file.path);
+      if (!response.ok) throw new Error(`Asset '${file.path}' returned HTTP ${response.status}`);
+      bytes = new Uint8Array(await response.arrayBuffer());
+    }
+    if (bytes.length !== Number(file.size)) {
+      throw new Error(
+        `Asset '${file.path}' is incomplete: expected ${file.size}, received ${bytes.length}`,
+      );
+    }
+    const pathLength = Module.lengthBytesUTF8(file.path) + 1;
+    const pathPtr = Module._malloc(pathLength);
+    const bytesPtr = Module._malloc(bytes.length);
+    try {
+      Module.stringToUTF8(file.path, pathPtr, pathLength);
+      Module.HEAPU8.set(bytes, bytesPtr);
+      const appended = Module.ccall(
+        'jsAppendFile',
+        'number',
+        ['number', 'number', 'number'],
+        [pathPtr, bytesPtr, bytes.length],
+      );
+      if (!appended) throw new Error(`WASM VFS rejected asset '${file.path}'`);
+    } finally {
+      Module._free(bytesPtr);
+      Module._free(pathPtr);
+    }
+    workerLog('LOG', 'BACKGROUND_WORKER', `File fetched: ${file.path}, size: ${bytes.length}`);
+  }
+  return { success: true, count: files.length };
 }
 
 /**

--- a/tests/fixtures/wasm_vfs/data/probe.txt.lnk
+++ b/tests/fixtures/wasm_vfs/data/probe.txt.lnk
@@ -1,0 +1,4 @@
+http://127.0.0.1:18765/probe.txt
+sha256=2da77f7c1452125633beeeb43f366350018643c799306b4d24d8610d98f02b55
+size_bytes=15
+storage=vfs

--- a/tests/fixtures/wasm_vfs/wasm_vfs.ino
+++ b/tests/fixtures/wasm_vfs/wasm_vfs.ino
@@ -1,0 +1,31 @@
+#include <FastLED.h>
+#include "fl/fs/embedded/embedded_fs.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define LED_PIN 3
+#define WIDTH 16
+#define HEIGHT 16
+#define NUM_LEDS (WIDTH * HEIGHT)
+
+using namespace fl;
+
+CRGB leds[NUM_LEDS];
+XYMap screenMap = XYMap::constructRectangularGrid(WIDTH, HEIGHT);
+
+void setup() {
+  FileSystem fs;
+  if (!fs.begin(getEmbeddedFs())) abort();
+  ifstream asset = fs.openRead("data/probe.txt");
+  char bytes[15] = {};
+  if (!asset.is_open() || asset.read(bytes, sizeof(bytes)).gcount() != sizeof(bytes)
+      || fl::memcmp(bytes, "fastled-vfs-ok\n", sizeof(bytes)) != 0) abort();
+  FastLED.addLeds<WS2812B, LED_PIN, GRB>(leds, NUM_LEDS)
+      .setScreenMap(screenMap);
+}
+
+void loop() {
+  fill_solid(leds, NUM_LEDS, CRGB::Green);
+  FastLED.show();
+  delay(20);
+}

--- a/tests/fixtures/wasm_vfs_origin/probe.txt
+++ b/tests/fixtures/wasm_vfs_origin/probe.txt
@@ -1,0 +1,1 @@
+fastled-vfs-ok


### PR DESCRIPTION
## Summary

- add `--check` as a strict one-frame production test and always forward browser diagnostics to stderr
- parse `.lnk` and `assets.json`, fetch fallback URLs, and validate declared size and SHA-256
- load all local and remote files into the background-worker WASM instance before `setup()`
- add a real `fl::getEmbeddedFs()` sketch fixture to the macOS ARM installed-wheel smoke test and upload its rendered PNG
- release as 2.0.17

## Root cause and falsification

The first implementation appeared successful because the frontend logged that it had injected the verified bytes. A real sketch using `fl::getEmbeddedFs()` still aborted with `File not found`: the bytes had been loaded into the foreground WASM module, while the sketch executes in a separately instantiated background-worker module. The new `load_files` worker message performs declaration and byte injection in the module that executes `extern_setup`.

The GHA fixture reads and byte-compares `data/probe.txt` during `setup()` and aborts before registering LEDs on any failure. Only a successful VFS read can produce the green PNG artifact.

## Validation

- `bash test`: 246 Rust unit tests, 2 viewer tests, cache integration, doc test; 23 Python tests passed and 1 platform-specific test skipped
- `bash lint`: formatting, clippy, cargo-dylint 6.0.3, Ruff, Black, isort, Pyright, keyboard checker
- real browser E2E against a clean archive of FastLED `origin/master`: SHA verified, worker VFS load completed before `setup()`, rendered green PNG, exit 0

Closes #213
Closes #215
Closes #216